### PR TITLE
docs: quickstart-driven README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ English | [中文](README.zh.md)
 | --- | --- |
 | `/research-idea <direction>` | Registers a project, scaffolds `IDEA_REPORT.md`, surveys arXiv, records the idea |
 | `/research-plan [project]` | Scaffolds `EXPERIMENT_PLAN.md`; planned claims become pending wiki claims |
-| `/research-review ...` | Independent fresh-reviewer rounds over an artifact (plan / paper), capped per project |
+| `/research-review <scope> <files...>` | Independent fresh-reviewer rounds over an artifact (plan / paper), capped per project |
 | `/paper-write [project]` | Scaffolds the `main.tex` skeleton and drives drafting to a clean compile |
 | `/paper-compile [dir]` | Direct compile report over the same engine path as the tool |
 
@@ -26,78 +26,192 @@ English | [中文](README.zh.md)
 | `wiki_note` | Read/write surface over the research wiki domain (papers, ideas, claims, experiments, projects) |
 | `latex_compile` | Compiles `main.tex` with parsed file/line diagnostics; multi-engine: `latexmk` or `tectonic` (auto-detected, or an explicit binary path) |
 
-**Web workbench (six views)** — a sidebar toggle opens a 96vw×95vh overlay: **Overview** (pipeline stage progress, stat chips, artifacts, and a data card that exports the whole wiki as one dated JSON snapshot and imports one back — merge skips existing keys, replace wipes after a red second confirm), **Paper** (collapsible clickable outline whose top-level sections drag-reorder via row grips — rewriting `main.tex`'s `\section` order under an optimistic base-outline check, auto-saving `main.tex` editor with sync line numbers and dependency-free LaTeX syntax highlighting, one-click compile with engine label, error list that jumps to source lines, inline PDF preview, and a bibliography panel over the project's `references.bib` — entry list with delete, optimistic-concurrency saves with conflict reload, and a picker that appends checked library papers; the three panes resize through drag handles with the widths persisted across sessions, and the editor/preview panes each go fullscreen on one click or exit on `Esc`), **Library** (remembered papers with editable tags, per-project links, and a tag/current-project filter bar; in-panel arXiv search with one-click import into the wiki, card delete, and one-click add-to-`references.bib` per card), **Experiments** (run records: metric-comparison bar charts over shared numeric metrics as inline SVG, per-run expandable metrics, a linked-server badge per row with an inline relink dropdown, row delete, plus `EXPERIMENT_LOG.md` rendered with the built-in restricted Markdown renderer — headings, bold/italic/inline code, code fences, lists, quotes, rules, tables, and links whose non-http(s) URLs are neutralized to plain text), **Figures** (paper-directory image grid with preview, upload, delete, and copy-LaTeX-reference card actions; image files can also be dragged onto the view — a dashed overlay shows while hovering and unsupported types are reported, not ignored), **Servers** (remembered GPU boxes: TCP reachability probe plus a best-effort SSH `nvidia-smi` readout with utilization/memory bars; tag chips on the cards and in the form, with a tag filter bar above the grid). The panel header carries a light/dark theme toggle and a 中/EN language switch (both ride the durable host preferences), and the workbench answers keyboard shortcuts: `1–6` switch views, `Esc` closes (exiting a fullscreened pane first), `⌘/Ctrl+Enter` compiles in the paper view. On narrow windows the layout degrades gracefully: below 900px the paper view collapses to a one-pane editor/preview tab bar with the outline rail hidden, and below 700px the sidebar becomes a horizontal top bar with a scrollable nav.
+**Web workbench (six views)** — a sidebar toggle opens a 96vw×95vh overlay:
 
-| Paper: narrow-width tab layout |
-| --- |
-| ![Paper: narrow-width tab layout](docs/screenshots/narrow-paper.png) |
+- **Overview** — pipeline stage progress, stat chips, artifact list, and a data card that exports/imports the whole wiki as one dated JSON snapshot (merge skips existing keys; replace arms a red second confirm).
+- **Paper** — outline rail with drag-to-reorder sections, autosaving `main.tex` editor with LaTeX syntax highlighting, one-click compile, click-to-jump error list, inline PDF preview, and a `references.bib` panel; resizable panes, fullscreen, persisted layout.
+- **Library** — remembered papers with editable tags and per-project links, a tag/current-project filter bar, in-panel arXiv search with one-click import, and add-to-`references.bib` per card.
+- **Experiments** — run records with metric-comparison bar charts (inline SVG), expandable metrics, linked-server badges with inline relink, and a rendered `EXPERIMENT_LOG.md`.
+- **Figures** — paper-directory image grid with preview, upload (button or drag-and-drop), delete, and copy-LaTeX-reference actions.
+- **Servers** — remembered GPU boxes: TCP reachability probe plus a best-effort SSH `nvidia-smi` readout with utilization/memory bars and tag filters.
 
-| Overview | Library | Library: arXiv search |
+Dark/light theme and 中/EN language toggles live in the panel header; keyboard shortcuts: `1–6` switch views, `Esc` closes, `⌘/Ctrl+Enter` compiles. Narrow windows degrade gracefully (below 900px the paper view goes single-column; below 700px the rail becomes a top strip).
+
+| Dark mode: overview | Dark mode: paper | Paper: narrow-width tab layout |
 | --- | --- | --- |
-| ![Overview](docs/screenshots/tab-overview.png) | ![Library](docs/screenshots/tab-papers.png) | ![Library: arXiv search](docs/screenshots/tab-papers-search.png) |
+| ![Dark mode: overview](docs/screenshots/dark-overview.png) | ![Dark mode: paper](docs/screenshots/dark-paper.png) | ![Paper: narrow-width tab layout](docs/screenshots/narrow-paper.png) |
+
+## Quickstart
+
+> **Status:** `dsh-mimir` / `dsh-client-ui-mimir` are not on npm yet (publication planned); the only install path today is building this repository from source.
+
+### Prerequisites
+
+- **Node.js** — no `engines` constraint is declared; developed and verified on Node v24.
+- **pnpm** — verified on v11.18.
+- **dsh CLI** — published on npm:
+  ```sh
+  npm install -g @deepseek-ai/dsh
+  ```
+- **`DEEPSEEK_API_KEY`** — required for agent sessions (export it, or put it in dsh's `.env`).
+- **A LaTeX engine** — only for paper compilation: `latexmk` or `tectonic` on PATH. Tectonic is a single binary and the easiest to install:
+  ```sh
+  brew install tectonic        # macOS; see https://tectonic-typesetting.github.io for others
+  ```
+- **arXiv access** — literature search calls `export.arxiv.org`; behind a proxy, export `HTTPS_PROXY` before starting dsh.
+
+### 1. Clone and build
+
+```sh
+git clone https://github.com/1692775560/Mimir.git
+cd Mimir
+pnpm install
+pnpm run build
+pnpm test          # optional sanity check: vitest, both packages
+```
+
+### 2. Install the plugin into the web profile
+
+dsh resolves patch plugin names from the profile directory (`~/.dsh/profiles/web`), **not** from the current directory — so link the built package into the profile (the profile directory is created on dsh's first run):
+
+```sh
+dsh plugin --profile web add "$PWD/packages/mimir"
+```
+
+### 3. Start the example
+
+```sh
+dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
+```
+
+Then open http://127.0.0.1:3080. The wiki persists at `~/.dsh/storages/research_wiki.json`; research artifacts land in the workspace directory (default `./.research` under the directory you started dsh from).
+
+### 4. First session
+
+In a dsh session (web UI or TUI with the same patch):
+
+```
+/research-idea efficient long-context retrieval for code agents
+/research-plan
+/research-review plan EXPERIMENT_PLAN.md
+/paper-write
+/paper-compile
+```
+
+### 5. The web workbench
+
+The six-view workbench ships as `dsh-client-ui-mimir` (`packages/ui-mimir`). One honest caveat: **the published dsh web composition predates Mimir** — it neither loads the client plugin nor mounts the `research` Remote namespace, so a cordis patch alone does not put the Mimir button in the sidebar. Mounting the panel today requires a dsh source checkout with the client plugin registered and the Remote assembly one-liner from [Known limitations](#known-limitations) applied. Everything agent-side — the slash commands, tools, wiki, reviewer loop, and the `/research/*` routes — works through the patch alone.
+
+## Usage guide
+
+### Overview
+
+The landing view: the selected project's five-stage pipeline progress, stat chips (papers / experiments / figures / servers), the artifact list, and timestamps. The **data card** exports the entire wiki as one dated JSON snapshot (`mimir-wiki-<date>.json`) for backup or migration, and imports one back: pick a file, review the per-table row counts, then choose merge (existing keys are skipped, never overwritten) or replace (wipes all six tables — a red second confirm guards it). A successful import refreshes every loaded view.
+
+| Overview | Overview: wiki export/import |
+| --- | --- |
+| ![Overview](docs/screenshots/tab-overview.png) | ![Overview: wiki export/import](docs/screenshots/tab-overview-data.png) |
+
+### Paper
+
+An Overleaf-style editor for the project's paper directory: a collapsible outline whose top-level sections drag-reorder via row grips (rewriting `main.tex`'s `\section` order), an autosaving `main.tex` editor (~800 ms debounce, optimistic concurrency — a displaced draft freezes and offers reload) with LaTeX syntax highlighting and synced line numbers, one-click compile with the engine labeled, an error list whose entries jump the editor to the source line, an inline PDF preview, and a bibliography panel over `references.bib` (delete entries, conflict-safe saves, append checked library papers). Saving an untouched draft auto-compiles after ~1.5 s. Drag handles resize the three panes (widths persist); editor and preview go fullscreen on one click. `⌘/Ctrl+Enter` compiles.
 
 | Paper: syntax highlighting | Paper: compile issues | Paper: click-to-jump |
 | --- | --- | --- |
 | ![Paper: syntax highlighting](docs/screenshots/tab-paper-highlight.png) | ![Paper: compile issues](docs/screenshots/tab-paper-issues.png) | ![Paper: click-to-jump](docs/screenshots/tab-paper-issue-jump.png) |
 
-| Dark mode: overview | Dark mode: paper (syntax colors re-tinted) |
-| --- | --- |
-| ![Dark mode: overview](docs/screenshots/dark-overview.png) | ![Dark mode: paper](docs/screenshots/dark-paper.png) |
-
 | Paper: bibliography panel | Paper: editor fullscreen |
 | --- | --- |
 | ![Paper: bibliography panel](docs/screenshots/tab-paper-bib.png) | ![Paper: editor fullscreen](docs/screenshots/tab-paper-fullscreen.png) |
 
-| Experiments | Figures | Servers |
+### Library
+
+Every remembered paper as a card grid (summaries collapse to three lines): editable tags, per-project links, a tag/current-project filter bar, and in-panel arXiv search — one click imports a result into the wiki, another appends it to the project's `references.bib`.
+
+| Library | Library: tags | Library: arXiv search |
 | --- | --- | --- |
-| ![Experiments](docs/screenshots/tab-experiments.png) | ![Figures](docs/screenshots/tab-figures.png) | ![Servers](docs/screenshots/tab-servers.png) |
+| ![Library](docs/screenshots/tab-papers.png) | ![Library: tags](docs/screenshots/tab-papers-tags.png) | ![Library: arXiv search](docs/screenshots/tab-papers-search.png) |
 
-| Figures: drag-and-drop upload |
+### Experiments
+
+Run records from the wiki: a status pill per row, metric-comparison bar charts for numeric metrics shared by ≥2 runs, per-run expandable metrics, a linked-server badge with an inline relink dropdown, and row delete. Below the table, `EXPERIMENT_LOG.md` renders with the built-in restricted Markdown renderer (headings, emphasis, code, fences, lists, quotes, rules, tables, links — non-http(s) URLs are neutralized to plain text).
+
+| Experiments |
 | --- |
-| ![Figures: drag-and-drop upload](docs/screenshots/tab-figures-drop.png) |
+| ![Experiments](docs/screenshots/tab-experiments.png) |
 
-| Overview: wiki export/import |
+### Figures
+
+The paper directory's images as a grid: click to zoom, copy a ready-made LaTeX `\includegraphics` snippet, upload via the toolbar button — or just drop image files anywhere on the view (a dashed overlay shows while hovering; unsupported types are named, not silently ignored) — and delete what you no longer need. Refresh forces a rescan.
+
+| Figures | Figures: drag-and-drop upload |
+| --- | --- |
+| ![Figures](docs/screenshots/tab-figures.png) | ![Figures: drag-and-drop upload](docs/screenshots/tab-figures-drop.png) |
+
+### Servers
+
+Remembered GPU boxes: add/edit/delete, one-click TCP reachability probe, and a best-effort SSH `nvidia-smi` readout with per-GPU utilization and memory bars. Tag chips on the cards and a filter bar above the grid keep large fleets navigable.
+
+| Servers |
 | --- |
-| ![Overview: wiki export/import](docs/screenshots/tab-overview-data.png) |
+| ![Servers](docs/screenshots/tab-servers.png) |
 
-## Packages
+### Slash commands in practice
 
-- **`dsh-mimir`** (`packages/mimir`) — the host plugin: commands, tools, wiki domain, reviewer loop, LaTeX compile, BibTeX management, and the `research` Remote namespace (27 methods) + `/research/pdf` / `/research/figure` / `/research/figure-upload` routes backing the panel.
-- **`dsh-client-ui-mimir`** (`packages/ui-mimir`) — the browser workbench: sidebar toggle + overlay panel.
+A typical loop inside a dsh session:
 
-## Install
-
-Both packages are dsh (Cordis) plugins. In your dsh checkout, apply the example overlay:
-
-```sh
-dsh web --patch "$PWD/cordis.yml"
+```
+/research-idea efficient long-context retrieval for code agents
 ```
 
-with `cordis.yml` (see [examples/mimir-agent/cordis.yml](examples/mimir-agent/cordis.yml)):
+Registers a project in the wiki, scaffolds `IDEA_REPORT.md` in the workspace, surveys arXiv for the direction, and records the idea — failed ideas are never deleted, so retreading a dead end is flagged instead of repeated.
 
-```yaml
-- insert:
-    - id: mimir
-      name: 'dsh-mimir'
-      config:
-        workspaceDir: .research
-        reviewer: { provider: spawn, maxRounds: 3 }
-        latex: { engine: auto, timeoutMs: 120000 }
-        arxiv: { maxResults: 10 }
+```
+/research-plan
+/research-review plan EXPERIMENT_PLAN.md
 ```
 
-The web profile already mounts storage, so the wiki persists under the profile's storage root. Paper compilation needs `latexmk` **or** `tectonic` on PATH (`engine: auto` probes latexmk first), or an absolute binary path in `latex.engine`.
+`research-plan` scaffolds `EXPERIMENT_PLAN.md` and registers the planned claims as pending wiki claims. `research-review` starts a **fresh reviewer subagent** that receives only the listed file paths — never the executor's summary — and returns a schema-validated PASS/WARN/FAIL verdict; WARN/FAIL is handed back to the agent as a revision follow-up, capped at `reviewer.maxRounds` rounds per project (default 3).
 
-## Configuration
+```
+/paper-write
+/paper-compile
+```
+
+`paper-write` scaffolds the `main.tex` skeleton and drafts to a clean compile; `paper-compile` runs one compile and reports parsed errors/warnings directly.
+
+### Agent tools in practice
+
+The agent reaches the same capabilities mid-conversation:
+
+- `arxiv_search` — "search arXiv for recent whole-body mesh recovery papers" (default cap `arxiv.maxResults`).
+- `paper_fetch` — fetch one paper's metadata by arXiv id.
+- `wiki_note` — the wiki's read/write surface, one flat parameter set keyed by `action`: `add_paper`, `add_idea`, `fail_idea`, `add_claim`, `set_claim`, `set_project` (points a project at its paper directory), `add_experiment`, `set_experiment` (status `running`/`success`/`failed`), plus `list` and `get` over the five tables.
+- `latex_compile` — "compile the paper in `paper/`" (`project_dir` parameter); returns parsed file/line diagnostics.
+
+## Configuration reference
+
+All keys are optional; these are the defaults from `packages/mimir/src/index.ts`:
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `workspaceDir` | `.research` | Research workspace root, resolved against the process cwd |
+| `workspaceDir` | `.research` | Research workspace root, resolved against the process cwd; must be a non-empty path |
 | `reviewer.provider` | `spawn` | Subagent provider route for review rounds |
-| `reviewer.maxRounds` | `3` | Per-project review-round budget |
+| `reviewer.maxRounds` | `3` | Per-project review-round budget (positive integer) |
 | `latex.engine` | `auto` | `auto` (probe `latexmk` then `tectonic` on PATH), an engine name, or an absolute binary path (basename picks the dialect) |
-| `latex.timeoutMs` | `120000` | Compile kill timeout; raise it for tectonic's first network fetch |
+| `latex.timeoutMs` | `120000` | Compile kill timeout (ms); raise it for tectonic's first network fetch |
 | `arxiv.maxResults` | `10` | Default `arxiv_search` result cap |
+
+Full example with comments: [examples/mimir-agent/cordis.yml](examples/mimir-agent/cordis.yml).
+
+## Troubleshooting
+
+- **`dsh: plugin tree failed to load … Cannot find package 'dsh-mimir'`** — the patch resolves plugin names from the profile directory, not your cwd. Run the [install step](#2-install-the-plugin-into-the-web-profile): `dsh plugin --profile web add <repo>/packages/mimir`.
+- **`pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS`** — pnpm ≥ 11.18 requires explicit build-script approval; this repository's `pnpm-workspace.yaml` already pins `allowBuilds` for `esbuild`, so a fresh checkout is fine. If you add dependencies that ship build scripts (e.g. the dsh CLI as a dev dependency), approve them in the same `allowBuilds` map.
+- **LaTeX engine not found** — install tectonic (single binary): `brew install tectonic` on macOS, or see <https://tectonic-typesetting.github.io>. Alternatively point `latex.engine` at an absolute binary path. `engine: auto` probes `latexmk` first, then `tectonic`.
+- **Compile errors** — `/paper-compile` prints parsed file/line diagnostics; in the workbench's Paper view, clicking an error jumps the editor to that source line. First tectonic runs download packages over the network — raise `latex.timeoutMs` if the initial compile times out.
+- **arXiv search fails** — the tools call `export.arxiv.org`; check connectivity, and export `HTTPS_PROXY`/`HTTP_PROXY` before starting dsh when you are behind a proxy.
+- **Where is my data / how do I back it up** — the wiki lives at `~/.dsh/storages/research_wiki.json`, research artifacts under `workspaceDir` (default `./.research`). Use the Overview view's data card to export the whole wiki as one JSON snapshot (and import it back later — merge is non-destructive).
 
 ## Known limitations
 
@@ -109,7 +223,7 @@ The web profile already mounts storage, so the wiki persists under the profile's
   disposers.push(await ctx.remote.$mount(researchRemote))
   ```
 
-  This is a dsh-side design constraint (the assembly is an explicit allowlist), not a Mimir defect.
+  The client plugin (`dsh-client-ui-mimir`) must likewise be registered in the web composition. This is a dsh-side design constraint (the assembly is an explicit allowlist), not a Mimir defect — see [Quickstart §5](#5-the-web-workbench).
 - **Compile status is host process memory** — a host restart forgets the last result; the panel shows `idle` until the next compile even if a previously built `main.pdf` is still on disk.
 - **No live push** — the panel neither polls nor subscribes; compiles started elsewhere (`/paper-compile` or the tool) become visible on the next selection or compile.
 
@@ -124,9 +238,18 @@ pnpm run typecheck   # tsc -b both packages; assumes a prior build (ui-mimir
                      # imports the generated dsh-mimir/remote declarations)
 ```
 
+Layout:
+
+- `packages/mimir` — the host plugin (`dsh-mimir`): commands, tools, wiki domain, reviewer loop, LaTeX compile, BibTeX management, the `research` Remote namespace (27 methods), and the `/research/pdf` / `/research/figure` / `/research/figure-upload` routes.
+- `packages/ui-mimir` — the browser workbench (`dsh-client-ui-mimir`): sidebar toggle + overlay panel.
+- `packages/typert-protocol` — vendored, never-published source copy of the Typert protocol (see below).
+- `examples/mimir-agent` — the cordis patch used in the Quickstart.
+
 Build artifacts: `packages/mimir/lib/{index.js, invariant.js, typert.host.js, typert.remote-client.js, types/}` and `packages/ui-mimir/lib/{index.js, invariant.js, client.js, types/}`.
 
 `packages/ui-mimir/scripts/screenshot.ts` is a QA harness (not part of the test suite): against a running `dsh web` instance with the plugin mounted, it captures one PNG per workbench tab into `/tmp/research-ui/`. It requires a local Playwright installation; adjust the import/`CHROMIUM` path at the top of the file.
+
+Contributing: branch off `main` (`feature/<name>` or `fix/<name>`), keep `pnpm run build && pnpm test && pnpm run typecheck` green, and open a PR.
 
 ### Repository notes
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,9 +2,9 @@
 
 [English](README.md) | 中文
 
-**Mimir 是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（dsh）的科研全周期插件套件：arXiv 文献调研、持久化研究 wiki、独立子代理评审，以及 LaTeX 写作 → 编译 → 预览闭环——外加完整的 Web 工作台。**
+**Mimir 是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（dsh）的科研生命周期插件套件：arXiv 文献检索、持久化研究 wiki、独立子代理评审，以及 LaTeX 写作 → 编译 → 预览闭环——外加一个完整的 web 工作台。**
 
-![论文工作台：大纲、源码编辑器、编译后 PDF 预览](docs/screenshots/tab-paper-compiled.png)
+![论文工作台：大纲、源码编辑器、编译产物 PDF 预览](docs/screenshots/tab-paper-compiled.png)
 
 ## 功能
 
@@ -13,132 +13,255 @@
 | 命令 | 作用 |
 | --- | --- |
 | `/research-idea <方向>` | 注册项目、脚手架 `IDEA_REPORT.md`、调研 arXiv、记录想法 |
-| `/research-plan [项目]` | 脚手架 `EXPERIMENT_PLAN.md`；计划论断进入 pending wiki claim |
-| `/research-review ...` | 对工件（方案/论文）做独立 fresh-reviewer 评审轮次，按项目限轮 |
-| `/paper-write [项目]` | 脚手架 `main.tex` 骨架并驱动写作直到编译干净 |
-| `/paper-compile [目录]` | 直接输出编译报告（与工具同一引擎路径） |
+| `/research-plan [项目]` | 脚手架 `EXPERIMENT_PLAN.md`；计划中的主张登记为待定 wiki 主张 |
+| `/research-review <范围> <文件...>` | 对工件（方案/论文）进行独立的新 reviewer 评审轮次，按项目封顶 |
+| `/paper-write [项目]` | 脚手架 `main.tex` 骨架并驱动撰写，直到编译干净 |
+| `/paper-compile [目录]` | 用与工具相同的引擎路径直接产出编译报告 |
 
 **四个 agent 工具**
 
 | 工具 | 用途 |
 | --- | --- |
 | `arxiv_search` / `paper_fetch` | arXiv Atom API 检索与单篇抓取 |
-| `wiki_note` | 研究 wiki domain 的读写面（文献、想法、论断、实验、项目） |
-| `latex_compile` | 编译 `main.tex` 并解析出带文件/行号的诊断；多引擎：`latexmk` 或 `tectonic`（自动探测或显式二进制路径） |
+| `wiki_note` | 研究 wiki domain 的读写面（文献、想法、主张、实验、项目） |
+| `latex_compile` | 编译 `main.tex` 并给出解析后的文件/行号诊断；多引擎：`latexmk` 或 `tectonic`（自动探测，或显式二进制路径） |
 
-**Web 工作台（六视图）**——侧栏开关打开 96vw×95vh 浮层：**总览**（流水线阶段进度、统计芯片、工件清单，以及数据卡片——一键导出整个 wiki 为带日期的 JSON 快照并可导入回放：合并跳过已存在主键，替换需红字二次确认后先清空再写入）、**论文**（可折叠可跳行的大纲栏——顶层章节可从行首手柄拖拽重排，在乐观大纲校验下重写 `main.tex` 的 `\section` 顺序、自动保存的 `main.tex` 编辑器（同步行号 + 零依赖 LaTeX 语法高亮）、一键编译（状态行标注引擎）、点击跳源码行的错误列表、内嵌 PDF 预览，以及覆盖项目 `references.bib` 的参考文献面板——条目列表可删除、乐观并发保存带冲突重载、勾选股库论文一键追加；三栏可用拖拽手柄调宽且布局跨会话持久化，编辑器/预览栏可一键全屏、`Esc` 退出）、**文献**（已收录论文：可编辑标签、按项目关联、标签/当前项目筛选栏；面板内 arXiv 搜索 + 一键导入 wiki，卡片可删除、可一键加入 `references.bib`）、**实验**（运行记录：共享数值指标的内联 SVG 对比条形图、逐 run 可展开指标、每行的服务器关联 badge 与内联下拉换绑、行删除，以及 `EXPERIMENT_LOG.md`——由内置的受限 Markdown 渲染器渲染：标题、粗体/斜体/行内代码、代码块、列表、引用、分隔线、表格、链接，非 http(s) 的链接协议一律中性化为纯文本）、**图表**（论文目录图片网格：放大预览、上传、删除、复制 LaTeX 引用；也可直接把图片文件拖进视图——悬停时显示虚线高亮框，不支持的类型会点名提示而不是静默忽略）、**服务器**（登记的 GPU 机器：TCP 连通性探测 + 尽力而为的 SSH `nvidia-smi` 读取，含利用率/显存条；卡片与表单支持标签 chips，网格上方有标签筛选条）。面板头部带深色/浅色主题切换和中/EN 语言切换（两者都落在宿主持久化偏好上），并支持快捷键：`1–6` 切换视图、`Esc` 关闭（有全屏栏时先退全屏）、论文视图内 `⌘/Ctrl+Enter` 编译。窄窗口下布局自动降级：宽度不足 900px 时论文视图收起大纲栏、编辑器/预览改为单栏 tab 切换；不足 700px 时侧栏变为顶部水平条，导航可横向滚动。
+**Web 工作台（六视图）**——侧栏开关打开 96vw×95vh 浮层：
 
-| 论文：窄屏 tab 布局 |
-| --- |
-| ![论文：窄屏 tab 布局](docs/screenshots/narrow-paper.png) |
+- **总览**——流水线阶段进度、统计芯片、工件清单，以及数据卡片：把整个 wiki 导出/导入为一份带日期的 JSON 快照（合并跳过已存在主键；替换会先清空，有红字二次确认）。
+- **论文**——大纲栏顶层章节可拖拽重排、`main.tex` 自动保存编辑器带 LaTeX 语法高亮、一键编译、点击跳源码行的错误列表、内嵌 PDF 预览、`references.bib` 面板；分栏可调宽、可全屏、布局持久化。
+- **文献**——已收录论文：可编辑标签、按项目关联、标签/当前项目筛选栏、面板内 arXiv 搜索一键导入、逐卡片加入 `references.bib`。
+- **实验**——运行记录：指标对比条形图（内联 SVG）、可展开指标、服务器关联 badge 内联换绑，以及渲染后的 `EXPERIMENT_LOG.md`。
+- **图表**——论文目录图片网格：预览、上传（按钮或拖拽）、删除、复制 LaTeX 引用。
+- **服务器**——登记的 GPU 机器：TCP 连通性探测 + 尽力而为的 SSH `nvidia-smi` 读取（利用率/显存条、标签筛选）。
 
-| 总览 | 文献 | 文献：arXiv 搜索 |
+面板头部带深色/浅色主题切换和中/EN 语言切换；快捷键：`1–6` 切换视图、`Esc` 关闭、`⌘/Ctrl+Enter` 编译。窄窗口自动降级（不足 900px 时论文视图变单栏；不足 700px 时侧栏变为顶部水平条）。
+
+| 深色模式：总览 | 深色模式：论文 | 论文：窄屏 tab 布局 |
 | --- | --- | --- |
-| ![总览](docs/screenshots/tab-overview.png) | ![文献](docs/screenshots/tab-papers.png) | ![文献：arXiv 搜索](docs/screenshots/tab-papers-search.png) |
+| ![深色模式：总览](docs/screenshots/dark-overview.png) | ![深色模式：论文](docs/screenshots/dark-paper.png) | ![论文：窄屏 tab 布局](docs/screenshots/narrow-paper.png) |
+
+## 快速上手
+
+> **状态说明：** `dsh-mimir` / `dsh-client-ui-mimir` 尚未发布到 npm（发布计划中）；目前唯一的安装方式是从源码构建本仓库。
+
+### 前置要求
+
+- **Node.js**——未声明 `engines` 约束；在 Node v24 上开发并验证。
+- **pnpm**——在 v11.18 上验证。
+- **dsh CLI**——已发布在 npm：
+  ```sh
+  npm install -g @deepseek-ai/dsh
+  ```
+- **`DEEPSEEK_API_KEY`**——agent 会话必需（导出环境变量，或写入 dsh 的 `.env`）。
+- **LaTeX 引擎**——仅论文编译需要：PATH 上的 `latexmk` 或 `tectonic`。tectonic 是单二进制，最好装：
+  ```sh
+  brew install tectonic        # macOS；其他平台见 https://tectonic-typesetting.github.io
+  ```
+- **arXiv 访问**——文献检索请求 `export.arxiv.org`；在代理环境下，启动 dsh 前导出 `HTTPS_PROXY`。
+
+### 1. 克隆并构建
+
+```sh
+git clone https://github.com/1692775560/Mimir.git
+cd Mimir
+pnpm install
+pnpm run build
+pnpm test          # 可选自检：vitest，覆盖两个包
+```
+
+### 2. 把插件装进 web profile
+
+dsh 从 profile 目录（`~/.dsh/profiles/web`）解析 patch 里的插件名，**而不是**从当前目录——因此要把构建好的包 link 进 profile（profile 目录在 dsh 首次运行时创建）：
+
+```sh
+dsh plugin --profile web add "$PWD/packages/mimir"
+```
+
+### 3. 启动示例
+
+```sh
+dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
+```
+
+然后打开 http://127.0.0.1:3080。wiki 持久化在 `~/.dsh/storages/research_wiki.json`；科研工件落在工作区目录（默认 `./.research`，相对启动 dsh 时的目录）。
+
+### 4. 第一个会话
+
+在 dsh 会话中（web UI 或挂了同一 patch 的 TUI）：
+
+```
+/research-idea efficient long-context retrieval for code agents
+/research-plan
+/research-review plan EXPERIMENT_PLAN.md
+/paper-write
+/paper-compile
+```
+
+### 5. Web 工作台
+
+六视图工作台以 `dsh-client-ui-mimir`（`packages/ui-mimir`）发布。有一个需要如实说明的限制：**已发布的 dsh web 组合早于 Mimir**——它既不加载这个客户端插件，也不挂载 `research` Remote 命名空间，因此仅靠 cordis patch 不会在侧栏出现 Mimir 按钮。今天要挂上面板，需要在 dsh 源码检出中注册客户端插件，并应用 [已知限制](#已知限制) 里的 Remote 装配一行。agent 侧的一切——斜杠命令、工具、wiki、评审循环、`/research/*` 路由——仅靠 patch 即可工作。
+
+## 使用指南
+
+### 总览
+
+落地视图：所选项目的五阶段流水线进度、统计芯片（文献/实验/图表/服务器）、工件清单与时间戳。**数据卡片**可以把整个 wiki 导出为一份带日期的 JSON 快照（`mimir-wiki-<日期>.json`）用于备份或迁移，也可以导入回放：选择文件、确认逐表行数摘要，然后选合并（已存在主键跳过、绝不覆盖）或替换（先清空六张表——有红字二次确认）。导入成功后会刷新所有已加载的视图。
+
+| 总览 | 总览：wiki 导出/导入 |
+| --- | --- |
+| ![总览](docs/screenshots/tab-overview.png) | ![总览：wiki 导出/导入](docs/screenshots/tab-overview-data.png) |
+
+### 论文
+
+项目论文目录的 Overleaf 式编辑器：可折叠大纲栏（顶层章节从行首手柄拖拽重排，重写 `main.tex` 的 `\section` 顺序）、自动保存的 `main.tex` 编辑器（约 800 ms 防抖、乐观并发——被顶掉的草稿会冻结并提供重载）带 LaTeX 语法高亮与同步行号、一键编译（标注引擎）、点击跳源码行的错误列表、内嵌 PDF 预览，以及覆盖 `references.bib` 的参考文献面板（删除条目、冲突安全保存、勾选股库论文追加）。未再改动的草稿保存成功约 1.5 s 后自动编译。拖拽手柄调整三栏宽度（布局持久化）；编辑器/预览可一键全屏。`⌘/Ctrl+Enter` 编译。
 
 | 论文：语法高亮 | 论文：编译问题 | 论文：点击跳源码行 |
 | --- | --- | --- |
 | ![论文：语法高亮](docs/screenshots/tab-paper-highlight.png) | ![论文：编译问题](docs/screenshots/tab-paper-issues.png) | ![论文：点击跳源码行](docs/screenshots/tab-paper-issue-jump.png) |
 
-| 深色模式：总览 | 深色模式：论文（语法配色重调） |
-| --- | --- |
-| ![深色模式：总览](docs/screenshots/dark-overview.png) | ![深色模式：论文](docs/screenshots/dark-paper.png) |
-
 | 论文：参考文献面板 | 论文：编辑器全屏 |
 | --- | --- |
 | ![论文：参考文献面板](docs/screenshots/tab-paper-bib.png) | ![论文：编辑器全屏](docs/screenshots/tab-paper-fullscreen.png) |
 
-| 实验 | 图表 | 服务器 |
+### 文献
+
+每一篇收录论文都是一张卡片（摘要默认三行折叠）：可编辑标签、按项目关联、标签/当前项目筛选栏，以及面板内 arXiv 搜索——一键把结果导入 wiki，再一键追加到项目的 `references.bib`。
+
+| 文献 | 文献：标签 | 文献：arXiv 搜索 |
 | --- | --- | --- |
-| ![实验](docs/screenshots/tab-experiments.png) | ![图表](docs/screenshots/tab-figures.png) | ![服务器](docs/screenshots/tab-servers.png) |
+| ![文献](docs/screenshots/tab-papers.png) | ![文献：标签](docs/screenshots/tab-papers-tags.png) | ![文献：arXiv 搜索](docs/screenshots/tab-papers-search.png) |
 
-| 图表：拖拽上传 |
+### 实验
+
+wiki 中的运行记录：每行状态徽标、≥2 个 run 共享的数值指标对比条形图、逐 run 可展开指标、服务器关联 badge 内联下拉换绑、行删除。表格下方是用内置受限 Markdown 渲染器渲染的 `EXPERIMENT_LOG.md`（标题、强调、代码、代码块、列表、引用、分隔线、表格、链接——非 http(s) 的链接一律中性化为纯文本）。
+
+| 实验 |
 | --- |
-| ![图表：拖拽上传](docs/screenshots/tab-figures-drop.png) |
+| ![实验](docs/screenshots/tab-experiments.png) |
 
-| 总览：wiki 导出/导入 |
+### 图表
+
+论文目录的图片网格：点击放大、复制现成的 LaTeX `\includegraphics` 片段、工具栏按钮上传——或直接把图片文件拖进视图（悬停时显示虚线高亮框；不支持的类型会点名提示而非静默忽略）——以及删除不再需要的文件。刷新按钮强制重扫。
+
+| 图表 | 图表：拖拽上传 |
+| --- | --- |
+| ![图表](docs/screenshots/tab-figures.png) | ![图表：拖拽上传](docs/screenshots/tab-figures-drop.png) |
+
+### 服务器
+
+登记的 GPU 机器：增删改、一键 TCP 连通性探测，以及尽力而为的 SSH `nvidia-smi` 读取（每块 GPU 的利用率与显存条）。卡片上的标签 chips 与网格上方的筛选条让大量机器也好找。
+
+| 服务器 |
 | --- |
-| ![总览：wiki 导出/导入](docs/screenshots/tab-overview-data.png) |
+| ![服务器](docs/screenshots/tab-servers.png) |
 
-## 包
+### 斜杠命令实战
 
-- **`dsh-mimir`**（`packages/mimir`）——宿主插件：命令、工具、wiki domain、评审循环、LaTeX 编译、BibTeX 管理，以及支撑面板的 `research` Remote 命名空间（27 个方法）+ `/research/pdf` / `/research/figure` / `/research/figure-upload` 路由。
-- **`dsh-client-ui-mimir`**（`packages/ui-mimir`）——浏览器工作台：侧栏开关 + 浮层面板。
+dsh 会话里的典型循环：
 
-## 安装
-
-两个包都是 dsh（Cordis）插件。在你的 dsh 检出中应用示例 overlay：
-
-```sh
-dsh web --patch "$PWD/cordis.yml"
+```
+/research-idea efficient long-context retrieval for code agents
 ```
 
-`cordis.yml` 内容（见 [examples/mimir-agent/cordis.yml](examples/mimir-agent/cordis.yml)）：
+在 wiki 里注册项目、在工作区脚手架 `IDEA_REPORT.md`、调研该方向的 arXiv 文献并记录想法——失败的想法永不删除，因此重蹈死路会被标记而不是重复。
 
-```yaml
-- insert:
-    - id: mimir
-      name: 'dsh-mimir'
-      config:
-        workspaceDir: .research
-        reviewer: { provider: spawn, maxRounds: 3 }
-        latex: { engine: auto, timeoutMs: 120000 }
-        arxiv: { maxResults: 10 }
+```
+/research-plan
+/research-review plan EXPERIMENT_PLAN.md
 ```
 
-web profile 已挂载 storage，wiki 持久化在 profile 的 storage 根下。论文编译需要 PATH 上有 `latexmk` **或** `tectonic`（`engine: auto` 优先探测 latexmk），或在 `latex.engine` 配置二进制绝对路径。
+`research-plan` 脚手架 `EXPERIMENT_PLAN.md`，并把计划中的主张登记为待定 wiki 主张。`research-review` 启动一个**全新的 reviewer 子代理**——它只收到列出的文件路径，永远看不到执行者的摘要——返回 schema 校验过的 PASS/WARN/FAIL 结论；WARN/FAIL 会作为修订任务交回给 agent，每个项目最多 `reviewer.maxRounds` 轮（默认 3）。
 
-## 配置项
+```
+/paper-write
+/paper-compile
+```
+
+`paper-write` 脚手架 `main.tex` 骨架并撰写到编译干净；`paper-compile` 跑一次编译并直接报告解析后的错误/警告。
+
+### Agent 工具实战
+
+agent 在对话中途可以触达同一组能力：
+
+- `arxiv_search`——“搜一下最近的 whole-body mesh recovery 论文”（默认上限 `arxiv.maxResults`）。
+- `paper_fetch`——按 arXiv id 抓取单篇元数据。
+- `wiki_note`——wiki 的读写面，以 `action` 为键的一套扁平参数：`add_paper`、`add_idea`、`fail_idea`、`add_claim`、`set_claim`、`set_project`（把项目指向它的论文目录）、`add_experiment`、`set_experiment`（状态 `running`/`success`/`failed`），以及对五张表的 `list` 和 `get`。
+- `latex_compile`——“编译 `paper/` 里的论文”（`project_dir` 参数）；返回解析后的文件/行号诊断。
+
+## 配置参考
+
+所有键都可缺省；以下默认值来自 `packages/mimir/src/index.ts`：
 
 | 键 | 默认值 | 含义 |
 | --- | --- | --- |
-| `workspaceDir` | `.research` | 研究工作区根目录（相对进程 cwd 解析） |
-| `reviewer.provider` | `spawn` | 评审子代理的 provider 路由 |
-| `reviewer.maxRounds` | `3` | 每项目评审轮次预算 |
-| `latex.engine` | `auto` | `auto`（依次探测 PATH 上的 `latexmk`、`tectonic`）、引擎名，或二进制绝对路径（按 basename 判断命令行） |
-| `latex.timeoutMs` | `120000` | 编译超时；tectonic 首次联网下载宏包时调大 |
-| `arxiv.maxResults` | `10` | `arxiv_search` 默认结果上限 |
+| `workspaceDir` | `.research` | 科研工作区根目录，相对进程 cwd 解析；必须是非空路径 |
+| `reviewer.provider` | `spawn` | 评审轮次的子代理 provider 路由 |
+| `reviewer.maxRounds` | `3` | 每个项目的评审轮次预算（正整数） |
+| `latex.engine` | `auto` | `auto`（依次探测 PATH 上的 `latexmk`、`tectonic`）、引擎名，或绝对二进制路径（按 basename 选择方言） |
+| `latex.timeoutMs` | `120000` | 编译杀进程超时（毫秒）；tectonic 首次联网拉包时可调大 |
+| `arxiv.maxResults` | `10` | `arxiv_search` 的默认结果上限 |
+
+带注释的完整示例见 [examples/mimir-agent/cordis.yml](examples/mimir-agent/cordis.yml)。
+
+## 故障排查
+
+- **`dsh: plugin tree failed to load … Cannot find package 'dsh-mimir'`**——patch 从 profile 目录取插件名，而不是你的当前目录。执行[安装步骤](#2-把插件装进-web-profile)：`dsh plugin --profile web add <仓库>/packages/mimir`。
+- **`pnpm install` 报 `ERR_PNPM_IGNORED_BUILDS`**——pnpm ≥ 11.18 要求显式批准构建脚本；本仓库的 `pnpm-workspace.yaml` 已为 `esbuild` 固定好 `allowBuilds`，全新检出即可通过。如果你自行添加了带构建脚本的依赖（比如把 dsh CLI 装成 dev dependency），在同一个 `allowBuilds` 映射里批准即可。
+- **找不到 LaTeX 引擎**——装 tectonic（单二进制）：macOS 用 `brew install tectonic`，其他平台见 <https://tectonic-typesetting.github.io>。也可以把 `latex.engine` 指到绝对二进制路径。`engine: auto` 先探测 `latexmk`，再探测 `tectonic`。
+- **编译报错**——`/paper-compile` 打印解析后的文件/行号诊断；在工作台论文视图里点击错误会跳到对应源码行。tectonic 首次运行要联网下载宏包——初次编译超时就把 `latex.timeoutMs` 调大。
+- **arXiv 搜索失败**——工具请求 `export.arxiv.org`；检查连通性，代理环境下在启动 dsh 前导出 `HTTPS_PROXY`/`HTTP_PROXY`。
+- **数据在哪 / 怎么备份**——wiki 在 `~/.dsh/storages/research_wiki.json`，科研工件在 `workspaceDir`（默认 `./.research`）下。用总览视图的数据卡片把整个 wiki 导出为一份 JSON 快照（之后可导入回放——合并是非破坏性的）。
 
 ## 已知限制
 
-- **工作台的 Remote 命名空间需要由 client 的 Remote 装配显式挂载。** dsh 已发布的 `@deepseek-ai/dsh-api-remotes` 早于 Mimir，不挂载 `research` 命名空间；请在你的装配中加一行 Mimir 的生成贡献：
+- **工作台的 Remote 命名空间需要由客户端 Remote 装配挂载。** dsh 已发布的 `@deepseek-ai/dsh-api-remotes` 早于 Mimir，没有挂载 `research` 命名空间；把 Mimir 生成的贡献加进你的装配（一行）：
 
   ```ts
   import researchRemote from 'dsh-mimir/remote'
-  // 装配的 apply() 内，与其他贡献并列：
+  // 在装配的 apply() 里，与其他贡献并列：
   disposers.push(await ctx.remote.$mount(researchRemote))
   ```
 
-  这是 dsh 侧的设计约束（装配是显式白名单），不是 Mimir 的缺陷。
-- **编译状态是宿主进程内存**——宿主重启后上次结果丢失；即使磁盘上还留着 `main.pdf`，面板也显示 `idle` 直到下一次编译。
-- **无实时推送**——面板不轮询不订阅；别处启动的编译（`/paper-compile` 或工具）要到下一次选择或编译时才可见。
+  客户端插件（`dsh-client-ui-mimir`）同样要在 web 组合里注册。这是 dsh 侧的设计约束（装配是显式白名单），不是 Mimir 的缺陷——见[快速上手第 5 步](#5-web-工作台)。
+- **编译状态是宿主进程内存**——宿主重启会忘掉上次结果；即使磁盘上还留着之前构建的 `main.pdf`，面板也会显示 `idle` 直到下一次编译。
+- **无实时推送**——面板不轮询也不订阅；在别处启动的编译（`/paper-compile` 或工具）要到下一次选择或编译时才可见。
 
 ## 开发
 
 ```sh
 pnpm install
-pnpm run build       # 有序流水线：mimir typecheck → mimir bundle（产出 ui-mimir
-                     # typecheck 依赖的 typert 产物）→ ui-mimir
-pnpm test            # vitest，两个包
-pnpm run typecheck   # tsc -b 两个包；需先构建过（ui-mimir 引用生成的
+pnpm run build       # 有序流水线：mimir 类型检查 → mimir 打包（产出
+                     # ui-mimir 类型检查所依赖的 typert 工件）→ ui-mimir
+pnpm test            # vitest，覆盖两个包
+pnpm run typecheck   # tsc -b 两个包；需先构建（ui-mimir 引用生成的
                      # dsh-mimir/remote 声明）
 ```
 
+目录结构：
+
+- `packages/mimir`——宿主插件（`dsh-mimir`）：命令、工具、wiki domain、评审循环、LaTeX 编译、BibTeX 管理、`research` Remote 命名空间（27 个方法），以及 `/research/pdf` / `/research/figure` / `/research/figure-upload` 路由。
+- `packages/ui-mimir`——浏览器工作台（`dsh-client-ui-mimir`）：侧栏开关 + 浮层面板。
+- `packages/typert-protocol`——Typert 协议的 vendored 源码副本，从不发布（见下）。
+- `examples/mimir-agent`——快速上手使用的 cordis patch。
+
 构建产物：`packages/mimir/lib/{index.js, invariant.js, typert.host.js, typert.remote-client.js, types/}` 与 `packages/ui-mimir/lib/{index.js, invariant.js, client.js, types/}`。
 
-`packages/ui-mimir/scripts/screenshot.ts` 是 QA 工具（不属于测试套件）：对着挂载了插件的 `dsh web` 实例把每个工作台 tab 截一张 PNG 到 `/tmp/research-ui/`。需要本机有 Playwright；按文件顶部的 import/`CHROMIUM` 路径调整。
+`packages/ui-mimir/scripts/screenshot.ts` 是 QA 工具（不属于测试套件）：对着一个挂载了插件的运行中 `dsh web` 实例，把工作台每个 tab 截一张 PNG 到 `/tmp/research-ui/`。需要本地安装 Playwright；按机器调整文件顶部的 import/`CHROMIUM` 路径。
+
+贡献方式：从 `main` 拉分支（`feature/<名字>` 或 `fix/<名字>`），保持 `pnpm run build && pnpm test && pnpm run typecheck` 全绿，然后开 PR。
 
 ### 仓库说明
 
-- `packages/typert-protocol` 是 `@deepseek-ai/dsh-typert-protocol@0.1.0-rc.8` 的**内 vendored、永不发布**的源码副本：Typert 生成器只识别 workspace 注册包内声明的 `Remote` 元数据，因此协议包必须在仓库内编译。运行时消费方仍解析 npm 发布版。
-- Typert 生成走**按贡献者过滤的 workspace 模式**（`packages/mimir/tsdown.config.ts` 里 `mode: 'workspace'`）：只有暴露 `./typert`/`./remote` 入口的包——即 dsh-mimir——会被建模。默认 package 模式会连 vendored 协议包一起分析，进而在被 npm 发布版增强的 Typert 映射接口上失败（session/agent 特意保持 npm 外部依赖，其类型永不展开）。
-- `build/client-preset/` vendored 了 dsh 的 client bundle tsdown 预设（闭包工厂式浏览器产物 + lightningcss 流水线），裁剪到本仓库所需。
+- `packages/typert-protocol` 是 `@deepseek-ai/dsh-typert-protocol@0.1.0-rc.8` 的 **vendored、从不发布**的源码副本：Typert 生成器只识别 workspace 注册包内声明的 `Remote` 元数据，因此协议必须在仓内编译。运行时消费者仍然解析 npm 发布版。
+- Typert 生成运行在**按贡献者过滤的 workspace 模式**（`packages/mimir/tsdown.config.ts` 里 `mode: 'workspace'`）：只有暴露 `./typert`/`./remote` 入口的包——仅 dsh-mimir——会被建模。默认的包模式会连带分析 vendored 协议，而后者在被 npm 发布版增强的 Typert map 接口上会失败（session/agent 有意保持为 npm 外部依赖，正是为了让它们的类型永不展开）。
+- `build/client-preset/` vendored 了 dsh 客户端打包的 tsdown 预设（闭包工厂浏览器产物 + lightningcss 流水线），裁剪到本仓库所需的范围。
 
 ## 致谢
 
-- 工作流灵感来自 [ARIS / Auto-claude-code-research-in-sleep](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)
-- 构建于 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 插件平台（Cordis、Typert、client 模块系统）。
+- 工作流灵感：[ARIS / Auto-claude-code-research-in-sleep](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)
+- 构建于 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 插件平台（Cordis、Typert、客户端模块系统）之上。
 
-## 许可证
+## License
 
 [MIT](LICENSE)

--- a/examples/mimir-agent/README.md
+++ b/examples/mimir-agent/README.md
@@ -8,11 +8,14 @@ This overlay opts one `dsh` profile into the research-assistant suite (`dsh-mimi
 
 Requires `DEEPSEEK_API_KEY` (root `.env` or environment) and, for paper compilation, `latexmk` or `tectonic` on PATH (or an absolute binary path in `latex.engine`; `auto` probes latexmk first).
 
+Build this repository first (`pnpm install && pnpm run build`), then link the plugin into the web profile — dsh resolves patch plugin names from the profile directory (`~/.dsh/profiles/web`), not the current directory:
+
 ```sh
+dsh plugin --profile web add "$PWD/packages/mimir"
 dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
 ```
 
-Then, in a session:
+The web UI listens on http://127.0.0.1:3080 by default. Then, in a session:
 
 ```
 /research-idea efficient long-context retrieval for code agents
@@ -22,8 +25,8 @@ Then, in a session:
 /paper-compile
 ```
 
-The workspace root defaults to `./.research` under the invoking directory: `IDEA_REPORT.md`, `EXPERIMENT_PLAN.md`, and `paper/` land there, and the wiki's JSON store lives in `./.research/store`, surviving restarts. Failed ideas stay in the wiki forever, so a later `/research-idea` on an explored dead end is flagged instead of repeated.
+The workspace root defaults to `./.research` under the invoking directory: `IDEA_REPORT.md`, `EXPERIMENT_PLAN.md`, and `paper/` land there, and the wiki's JSON store lives at `~/.dsh/storages/research_wiki.json`, surviving restarts. Failed ideas stay in the wiki forever, so a later `/research-idea` on an explored dead end is flagged instead of repeated.
 
 `/research-review` starts a fresh reviewer subagent that receives only the listed absolute file paths — never the executor's summary — and returns a schema-validated PASS/WARN/FAIL verdict. WARN/FAIL is handed back to the agent as a revision follow-up; a project is limited to `reviewer.maxRounds` rounds (default 3).
 
-See the package README at [packages/research/mimir](../../packages/research/mimir/README.md) for the full tool/command surface and config keys.
+See the package README at [packages/mimir](../../packages/mimir/README.md) for the full tool/command surface and config keys.

--- a/examples/mimir-agent/README.zh.md
+++ b/examples/mimir-agent/README.zh.md
@@ -8,11 +8,14 @@
 
 需要 `DEEPSEEK_API_KEY`（根目录 `.env` 或环境变量）；论文编译还需要 PATH 上有 `latexmk` 或 `tectonic`（或在 `latex.engine` 配置二进制绝对路径；`auto` 优先探测 latexmk）。
 
+先构建本仓库（`pnpm install && pnpm run build`），再把插件 link 进 web profile——dsh 从 profile 目录（`~/.dsh/profiles/web`）解析 patch 里的插件名，而不是当前目录：
+
 ```sh
+dsh plugin --profile web add "$PWD/packages/mimir"
 dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
 ```
 
-然后在会话中：
+web UI 默认监听 http://127.0.0.1:3080。然后在会话中：
 
 ```
 /research-idea efficient long-context retrieval for code agents
@@ -22,8 +25,8 @@ dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
 /paper-compile
 ```
 
-workspace 根目录默认是调用目录下的 `./.research`：`IDEA_REPORT.md`、`EXPERIMENT_PLAN.md` 和 `paper/` 都落在那里，wiki 的 JSON 存储在 `./.research/store`，重启后仍在。失败想法永远留在 wiki 里，因此对已探索过的死胡同再次运行 `/research-idea` 会被标记而不是重复。
+workspace 根目录默认是调用目录下的 `./.research`：`IDEA_REPORT.md`、`EXPERIMENT_PLAN.md` 和 `paper/` 都落在那里，wiki 的 JSON 存储在 `~/.dsh/storages/research_wiki.json`，重启后仍在。失败想法永远留在 wiki 里，因此对已探索过的死胡同再次运行 `/research-idea` 会被标记而不是重复。
 
 `/research-review` 启动一个全新的 reviewer subagent，它只收到列出的绝对文件路径——永远拿不到执行者的总结——返回 schema 校验过的 PASS/WARN/FAIL 结论。WARN/FAIL 会作为修订后续交还给 agent；每个项目最多 `reviewer.maxRounds` 轮（默认 3）。
 
-完整的工具/命令面与配置项见 [packages/research/mimir](../../packages/research/mimir/README.md) 的包 README。
+完整的工具/命令面与配置项见 [packages/mimir](../../packages/mimir/README.md) 的包 README。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
   - packages/*
   - examples/*
+allowBuilds:
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
- Rebuild both READMEs around a verified Quickstart (every command run against a fresh clone): prerequisites, build, `dsh plugin --profile web add`, launching the example, per-view usage guide, config reference, troubleshooting
- Fix `pnpm install` on pnpm 11.18 (allowBuilds for esbuild)
- Correct example README: plugin-install step, real wiki path, fixed package links
- Document honestly: packages are not on npm yet; the workbench toggle needs the dsh-side client registration (known limitation)