### PR TITLE
ci: GitHub Actions build + test pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build (ordered: mimir tsc+bundle, then ui-mimir tsc+bundle)
+        run: pnpm run build
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Build (ordered: mimir tsc+bundle, then ui-mimir tsc+bundle)
+      - name: "Build (ordered: mimir tsc+bundle, then ui-mimir tsc+bundle)"
         run: pnpm run build
 
       - name: Typecheck

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mimir
 
+[![CI](https://github.com/1692775560/Mimir/actions/workflows/ci.yml/badge.svg)](https://github.com/1692775560/Mimir/actions/workflows/ci.yml)
+
 English | [中文](README.zh.md)
 
 **Mimir is a research-lifecycle plugin suite for the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (dsh): arXiv literature search, a persistent research wiki, independent subagent review, and a closed LaTeX writing → compile → preview loop — plus a full web workbench.**

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,5 +1,7 @@
 # Mimir
 
+[![CI](https://github.com/1692775560/Mimir/actions/workflows/ci.yml/badge.svg)](https://github.com/1692775560/Mimir/actions/workflows/ci.yml)
+
 [English](README.md) | 中文
 
 **Mimir 是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（dsh）的科研生命周期插件套件：arXiv 文献检索、持久化研究 wiki、独立子代理评审，以及 LaTeX 写作 → 编译 → 预览闭环——外加一个完整的 web 工作台。**


### PR DESCRIPTION
Closes #3.

- ubuntu-latest, Node 24, pnpm 11 (pnpm/action-setup), pnpm store cached
- Steps: frozen-lockfile install → ordered build → typecheck → 256 vitest cases
- Triggers: pushes and PRs to main and dev