### PR TITLE
feat(mimir): artifact ingestion, Playwright E2E, and npm release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:
@@ -39,8 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,30 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  e2e:
+    if: ${{ vars.DSH_E2E_URL != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - name: Playwright E2E
+        run: pnpm test:e2e
+        env:
+          DSH_E2E_URL: ${{ vars.DSH_E2E_URL }}
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/e2e/
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.18.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run typecheck
+      - run: pnpm test
+      - name: Verify tag matches package versions
+        run: |
+          test "$GITHUB_REF_NAME" = "v$(node -p "require('./packages/mimir/package.json').version")"
+          test "$GITHUB_REF_NAME" = "v$(node -p "require('./packages/ui-mimir/package.json').version")"
+      - run: pnpm --filter dsh-mimir publish --access public --provenance --no-git-checks
+      - run: pnpm --filter dsh-client-ui-mimir publish --access public --provenance --no-git-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11.18.0
       - uses: actions/setup-node@v4
         with:
           node-version: 24

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.tsbuildinfo
 .dsh-build/
 .DS_Store
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ English | [中文](README.zh.md)
 | `/paper-write [project]` | Scaffolds the `main.tex` skeleton and drives drafting to a clean compile |
 | `/paper-compile [dir]` | Direct compile report over the same engine path as the tool |
 
-**Four agent tools**
+**Five agent tools**
 
 | Tool | Purpose |
 | --- | --- |
 | `arxiv_search` / `paper_fetch` | arXiv Atom API search and single-paper fetch |
 | `wiki_note` | Read/write surface over the research wiki domain (papers, ideas, claims, experiments, projects) |
 | `latex_compile` | Compiles `main.tex` with parsed file/line diagnostics; multi-engine: `latexmk` or `tectonic` (auto-detected, or an explicit binary path) |
+| `figure_save` | Saves a generated image into a project's `figures/` directory with caption/experiment metadata and returns a LaTeX snippet |
 
 **Web workbench (six views)** — a sidebar toggle opens a 96vw×95vh overlay:
 
@@ -45,11 +46,11 @@ Dark/light theme and 中/EN language toggles live in the panel header; keyboard 
 
 ## Quickstart
 
-> **Status:** `dsh-mimir` / `dsh-client-ui-mimir` are not on npm yet (publication planned); the only install path today is building this repository from source.
+> **Status:** both packages are release-ready with a tag-triggered provenance workflow, but first publication still requires npm publisher authentication. Until `npm view dsh-mimir` succeeds, use the source installation below.
 
 ### Prerequisites
 
-- **Node.js** — no `engines` constraint is declared; developed and verified on Node v24.
+- **Node.js** — v22 or newer; developed and verified on Node v24.
 - **pnpm** — verified on v11.18.
 - **dsh CLI** — published on npm:
   ```sh

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,13 +20,14 @@
 | `/paper-write [项目]` | 脚手架 `main.tex` 骨架并驱动撰写，直到编译干净 |
 | `/paper-compile [目录]` | 用与工具相同的引擎路径直接产出编译报告 |
 
-**四个 agent 工具**
+**五个 agent 工具**
 
 | 工具 | 用途 |
 | --- | --- |
 | `arxiv_search` / `paper_fetch` | arXiv Atom API 检索与单篇抓取 |
 | `wiki_note` | 研究 wiki domain 的读写面（文献、想法、主张、实验、项目） |
 | `latex_compile` | 编译 `main.tex` 并给出解析后的文件/行号诊断；多引擎：`latexmk` 或 `tectonic`（自动探测，或显式二进制路径） |
+| `figure_save` | 把生成图片保存到项目 `figures/`，记录 caption/实验关联，并返回 LaTeX 片段 |
 
 **Web 工作台（六视图）**——侧栏开关打开 96vw×95vh 浮层：
 
@@ -45,11 +46,11 @@
 
 ## 快速上手
 
-> **状态说明：** `dsh-mimir` / `dsh-client-ui-mimir` 尚未发布到 npm（发布计划中）；目前唯一的安装方式是从源码构建本仓库。
+> **状态说明：** 两个包已具备 tag 触发、带 provenance 的发布流水线，但首次 npm 发布仍需要发布者认证。在 `npm view dsh-mimir` 可查询前，请继续使用下方源码安装方式。
 
 ### 前置要求
 
-- **Node.js**——未声明 `engines` 约束；在 Node v24 上开发并验证。
+- **Node.js**——v22 或更高；在 Node v24 上开发并验证。
 - **pnpm**——在 v11.18 上验证。
 - **dsh CLI**——已发布在 npm：
   ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,20 @@
+# Releasing Mimir
+
+Both packages share one version. Before the first release, authenticate an npm owner for
+`dsh-mimir` and `dsh-client-ui-mimir`, or configure npm trusted publishing for this
+repository's `Release` workflow and `npm` GitHub environment.
+
+1. Update both package versions together.
+2. Run `pnpm install --frozen-lockfile && pnpm run build && pnpm run typecheck && pnpm test`.
+3. Inspect both tarballs with `pnpm --filter dsh-mimir pack --dry-run` and
+   `pnpm --filter dsh-client-ui-mimir pack --dry-run`.
+4. Push a tag matching the package version, for example `v0.1.0`.
+
+The tag workflow verifies the version, tests both packages, publishes the host package
+first, then the client package, and records npm provenance.
+
+## Browser E2E
+
+Point `DSH_E2E_URL` at a running dsh Web instance with both Mimir packages mounted, then
+run `pnpm test:e2e`. Configure the same URL as a GitHub Actions repository variable to
+enable the CI E2E job. Reports, traces, and screenshots are uploaded as artifacts.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,10 @@ polish round every few iterations.
 
 ## In progress
 
+- [x] Agent artifact ingestion (Issue #30): `figure_save` copies generated images into the selected project's `figures/` directory, records caption/source/experiment metadata in the wiki, and returns a LaTeX snippet; the figures view shows that metadata.
+- [x] Standard Playwright E2E suite (Issue #13): core six-view and literature-search scenarios, reusable against a mounted dsh Web URL, with CI artifact upload when `DSH_E2E_URL` is configured.
+- [x] npm release preparation (Issue #2): Node engines, pack verification, tag-triggered provenance workflow, and release documentation. First publication remains blocked on npm publisher authentication.
+
 ## Done
 
 - [x] Server tags + experiment server links: ServerRecord grew `tags`

--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test'
+
+test.skip(process.env.DSH_E2E_URL === undefined, 'Set DSH_E2E_URL to a running dsh Web instance with Mimir mounted')
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  const toggle = page.getByRole('button', { name: /Mimir/ }).first()
+  await expect(toggle).toBeVisible({ timeout: 30_000 })
+  await toggle.click()
+  await expect(page.getByRole('dialog', { name: /Mimir/ })).toBeVisible()
+})
+
+test('opens the workbench and renders all six views', async ({ page }, testInfo) => {
+  const workbench = page.getByRole('dialog', { name: /Mimir/ })
+  const tabs = [/总览|Overview/, /^论文$|^Paper$/, /^文献$|^Library$/, /^实验$|^Experiments$/, /^图表$|^Figures$/, /^服务器$|^Servers$/]
+  for (const [index, label] of tabs.entries()) {
+    await workbench.getByRole('button', { name: label }).first().click()
+    await expect(workbench).toBeVisible()
+    await page.screenshot({ path: testInfo.outputPath(`view-${String(index + 1)}.png`) })
+  }
+})
+
+test('literature search exposes an import outcome', async ({ page }) => {
+  const workbench = page.getByRole('dialog', { name: /Mimir/ })
+  await workbench.getByRole('button', { name: /^文献$|^Library$/ }).first().click()
+  await workbench.getByPlaceholder(/egocentric whole body/).fill('attention is all you need')
+  await workbench.getByRole('button', { name: /^搜索$|^Search$/ }).click()
+  await expect(workbench.getByText(/Attention Is All You Need/i).first()).toBeVisible({ timeout: 30_000 })
+  await expect(workbench.getByRole('button', { name: /^导入$|^Import$|已入库|Imported/ }).first()).toBeVisible()
+})

--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
   "name": "mimir-monorepo",
   "private": true,
+  "packageManager": "pnpm@11.18.0",
+  "engines": { "node": ">=22" },
   "type": "module",
   "scripts": {
     "build": "tsc -b packages/mimir && pnpm --filter dsh-mimir run bundle && tsc -b packages/ui-mimir && pnpm --filter dsh-client-ui-mimir run bundle",
     "typecheck": "tsc -b packages/mimir packages/ui-mimir",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "bundle": "pnpm -r run bundle"
   },
   "devDependencies": {
     "@deepseek-ai/dsh-typert-generator": "0.1.0-rc.8",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^22.20.0",
     "lightningcss": "^1.32.0",
     "tsdown": "^0.22.2",

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -11,6 +11,7 @@
     "directory": "packages/mimir"
   },
   "type": "module",
+  "engines": { "node": ">=22" },
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
   "exports": {

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -18,6 +18,7 @@ import { researchWikiDomainSpec } from './store.ts'
 import { createArxivSearchTool, createPaperFetchTool } from './tools/arxiv.ts'
 import { createWikiNoteTool } from './tools/wiki.ts'
 import { createLatexCompileTool } from './tools/latex.ts'
+import { createFigureSaveTool } from './tools/figure.ts'
 import { registerIdeaCommand } from './commands/idea.ts'
 import { registerPlanCommand } from './commands/plan.ts'
 import { registerReviewCommand } from './commands/review.ts'
@@ -28,7 +29,7 @@ import { isFigureFile } from './artifacts.ts'
 import { ResearchService } from './service.ts'
 import { startWikiBackupLoop } from './backup.ts'
 
-export type { Verdict, PaperRecord, IdeaRecord, ClaimRecord, ProjectRecord, ReviewIssue, ReviewRound, ProjectStage, ExperimentRecord, ExperimentStatus, ExperimentInput, JobRecord, JobStatus } from './types.ts'
+export type { Verdict, PaperRecord, IdeaRecord, ClaimRecord, ProjectRecord, ReviewIssue, ReviewRound, ProjectStage, ExperimentRecord, ExperimentStatus, ExperimentInput, FigureRecord, JobRecord, JobStatus } from './types.ts'
 export type {
   FigureEntry,
   OutlineNode,
@@ -88,6 +89,7 @@ export type { LatexCompileResult, LatexToolOptions, LatexEngineKind, ResolvedLat
 export { createArxivSearchTool, createPaperFetchTool, fetchArxivPdf, fetchArxivSearch, paperPdfFileName, parseArxivFeed, ARXIV_PDF_MAX_BYTES } from './tools/arxiv.ts'
 export type { ArxivEntry } from './tools/arxiv.ts'
 export { createWikiNoteTool } from './tools/wiki.ts'
+export { createFigureSaveTool } from './tools/figure.ts'
 export { buildWikiSnapshot } from './wiki-snapshot.ts'
 export type { WikiSnapshotSource } from './wiki-snapshot.ts'
 export {
@@ -490,6 +492,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   ctx.tools.register(createPaperFetchTool())
   ctx.tools.register(createWikiNoteTool(domain))
   ctx.tools.register(createLatexCompileTool(resolved.latex))
+  ctx.tools.register(createFigureSaveTool(deps.workspaceDir, domain))
 
   registerIdeaCommand(ctx, deps)
   registerPlanCommand(ctx, deps)

--- a/packages/mimir/src/service.ts
+++ b/packages/mimir/src/service.ts
@@ -707,7 +707,15 @@ export class ResearchService extends TypertRemoteService {
       if (isNotFound(error)) return rejected({ code: 'paper-not-found' })
       throw error
     }
-    return success({ figures: Object.freeze(await listPaperFigures(dir)) })
+    const metadata = new Map([...this.domain.table('figures').entries()]
+      .map(([, figure]) => figure)
+      .filter(figure => figure.projectId === request.projectId)
+      .map(figure => [figure.relPath, figure]))
+    const figures = (await listPaperFigures(dir)).map(figure => {
+      const meta = metadata.get(figure.relPath)
+      return meta === undefined ? figure : { ...figure, caption: meta.caption, experimentId: meta.experimentId }
+    })
+    return success({ figures: Object.freeze(figures) })
   }
 
   /**
@@ -1107,6 +1115,7 @@ export class ResearchService extends TypertRemoteService {
       if (isNotFound(error)) return rejected({ code: 'figure-not-found', relPath: request.relPath })
       throw error
     }
+    await this.domain.table('figures').delete(`${request.projectId}:${request.relPath}`)
     return success({ relPath: request.relPath })
   }
 

--- a/packages/mimir/src/store.ts
+++ b/packages/mimir/src/store.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod'
 import { defineDomain, domainTable } from '@deepseek-ai/dsh-storage-domain'
 import type { Domain } from '@deepseek-ai/dsh-storage-domain'
-import type { ClaimRecord, ExperimentRecord, IdeaRecord, JobRecord, PaperRecord, ProjectRecord, ServerRecord } from './types.ts'
+import type { ClaimRecord, ExperimentRecord, FigureRecord, IdeaRecord, JobRecord, PaperRecord, ProjectRecord, ServerRecord } from './types.ts'
 
 /** Durable shape of one remembered paper. */
 export const paperRecord = z.object({
@@ -71,6 +71,17 @@ export const experimentRecord = z.object({
   updatedAt: z.string(),
 })
 
+/** Durable metadata for one agent-saved paper figure. */
+export const figureRecord = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  relPath: z.string(),
+  caption: z.string(),
+  sourcePath: z.string(),
+  experimentId: z.string().optional(),
+  createdAt: z.string(),
+})
+
 /** Durable shape of one remembered compute server. */
 export const serverRecord = z.object({
   id: z.string(),
@@ -103,7 +114,7 @@ export const jobRecord = z.object({
 })
 
 /**
- * The research wiki domain spec: seven tables, no global singleton. The spec
+ * The research wiki domain spec: eight tables, no global singleton. The spec
  * object is the single source of the domain's name, version, and schemas.
  * The `servers` and `jobs` tables were added WITHOUT a version bump: the
  * domain loader fills a table missing from a stored snapshot with an empty
@@ -122,6 +133,7 @@ export const researchWikiDomainSpec = defineDomain({
     claims: domainTable<string, ClaimRecord>(claimRecord),
     projects: domainTable<string, ProjectRecord>(projectRecord),
     experiments: domainTable<string, ExperimentRecord>(experimentRecord),
+    figures: domainTable<string, FigureRecord>(figureRecord),
     servers: domainTable<string, ServerRecord>(serverRecord),
     jobs: domainTable<string, JobRecord>(jobRecord),
   },

--- a/packages/mimir/src/tools/figure.ts
+++ b/packages/mimir/src/tools/figure.ts
@@ -1,0 +1,64 @@
+/** Agent tool for promoting a generated image into a project's paper tree. */
+import { copyFile, mkdir, stat } from 'node:fs/promises'
+import { basename, extname, isAbsolute, join, resolve } from 'node:path'
+import { defineTool, type ToolDefinition } from '@deepseek-ai/dsh-tools'
+import type { JsonValue } from '@deepseek-ai/dsh-session'
+import type { ResearchWikiDomain } from '../store.ts'
+import { isFigureFile } from '../artifacts.ts'
+import { resolvePaperDir } from '../paper-source.ts'
+
+interface FigureSaveArgs {
+  readonly path: string
+  readonly project_id: string
+  readonly caption?: string
+  readonly experiment_id?: string
+}
+
+export function createFigureSaveTool(workspaceDir: string, domain: ResearchWikiDomain): ToolDefinition {
+  return defineTool({
+    name: 'figure_save',
+    description: 'Save a generated image into a Mimir project. Use this immediately after creating a paper-worthy figure. The file is copied to <paperDir>/figures, recorded with its caption and optional experiment link, and returned with a LaTeX includegraphics snippet.',
+    parameters: {
+      path: { type: 'string', required: true, description: 'Generated image path, absolute or relative to the current process directory.' },
+      project_id: { type: 'string', required: true, description: 'Owning Mimir project id.' },
+      caption: { type: 'string', description: 'Human-readable figure caption.' },
+      experiment_id: { type: 'string', description: 'Optional experiment record id that produced the figure.' },
+    },
+    output: { schema: { type: 'json' }, render: (_args, value) => [{ type: 'text', text: JSON.stringify(value, null, 2) }] },
+    execute: async (raw): Promise<JsonValue> => {
+      const args = raw as unknown as FigureSaveArgs
+      const project = domain.table('projects').get(args.project_id)
+      if (project === undefined) throw new Error(`figure_save: no project with id '${args.project_id}'`)
+      if (args.experiment_id !== undefined) {
+        const experiment = domain.table('experiments').get(args.experiment_id)
+        if (experiment === undefined || experiment.projectId !== args.project_id) {
+          throw new Error(`figure_save: experiment '${args.experiment_id}' does not belong to project '${args.project_id}'`)
+        }
+      }
+      const sourcePath = isAbsolute(args.path) ? resolve(args.path) : resolve(process.cwd(), args.path)
+      const source = await stat(sourcePath)
+      if (!source.isFile() || !isFigureFile(basename(sourcePath))) throw new Error('figure_save: path must name a supported image file')
+      const paperDir = resolvePaperDir(workspaceDir, undefined, project.paperDir)
+      if (paperDir === undefined) throw new Error('figure_save: project paperDir is invalid')
+      const figuresDir = join(paperDir, 'figures')
+      await mkdir(figuresDir, { recursive: true })
+      const name = basename(sourcePath)
+      const relPath = `figures/${name}`
+      const destinationPath = join(figuresDir, name)
+      if (sourcePath !== destinationPath) await copyFile(sourcePath, destinationPath)
+      const id = `${args.project_id}:${relPath}`
+      const record = {
+        id,
+        projectId: args.project_id,
+        relPath,
+        caption: args.caption?.trim() ?? '',
+        sourcePath,
+        ...(args.experiment_id === undefined ? {} : { experimentId: args.experiment_id }),
+        createdAt: new Date().toISOString(),
+      }
+      await domain.table('figures').put(id, record)
+      const label = name.slice(0, -extname(name).length).replace(/[^a-zA-Z0-9:-]+/g, '-')
+      return { ok: true, relPath, record: record as unknown as JsonValue, latex: `\\includegraphics[width=0.8\\linewidth]{${relPath}}`, label: `fig:${label}` }
+    },
+  })
+}

--- a/packages/mimir/src/tools/wiki.ts
+++ b/packages/mimir/src/tools/wiki.ts
@@ -241,7 +241,7 @@ function renderOutcome(value: Record<string, JsonValue | undefined>): string {
 export function createWikiNoteTool(domain: ResearchWikiDomain): ToolDefinition {
   return defineTool({
     name: 'wiki_note',
-    description: 'Read and write the persistent research wiki: remembered papers (add_paper), ideas including never-deleted failed ones (add_idea, fail_idea), tracked claims (add_claim, set_claim), project records (set_project points a project at its paper directory), and experiment runs (add_experiment, set_experiment); list and get read any table. Always check the ideas table before proposing work, to avoid re-proving failed directions.',
+    description: 'Read and write the persistent research wiki: remembered papers (add_paper), ideas including never-deleted failed ones (add_idea, fail_idea), tracked claims (add_claim, set_claim), project records (set_project points a project at its paper directory), and experiment runs (add_experiment, set_experiment); list and get read any table. Always check failed ideas before proposing work. Save useful papers with add_paper, and record every completed experiment with add_experiment/set_experiment; use figure_save immediately after generating a paper-worthy image.',
     parameters: {
       action: { type: 'string', enum: ACTIONS, required: true, description: 'The wiki operation to perform.' },
       table: { type: 'string', enum: TABLES, description: 'Table for list/get (papers|ideas|claims|projects|experiments).' },

--- a/packages/mimir/src/types.ts
+++ b/packages/mimir/src/types.ts
@@ -105,6 +105,17 @@ export interface ExperimentRecord {
   readonly updatedAt: string
 }
 
+/** Metadata recorded when an agent saves a generated figure into a paper. */
+export interface FigureRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly relPath: string
+  readonly caption: string
+  readonly sourcePath: string
+  readonly experimentId?: string | undefined
+  readonly createdAt: string
+}
+
 /** Lifecycle of one remote job submitted over ssh. */
 export type JobStatus = 'queued' | 'running' | 'succeeded' | 'failed'
 
@@ -293,6 +304,8 @@ export interface FigureEntry {
   readonly relPath: string
   readonly sizeBytes: number
   readonly mtimeMs: number
+  readonly caption?: string | undefined
+  readonly experimentId?: string | undefined
 }
 
 /** `listFigures` result: image files of the project's paper directory. */
@@ -389,7 +402,7 @@ export type ResearchImportBibResult = ResearchResult<{
   readonly skipped: readonly string[]
 }>
 
-/** The six research-wiki tables, in domain order. */
+/** The six research-wiki tables included in backup/export. */
 export type ResearchWikiTableName = 'papers' | 'ideas' | 'claims' | 'projects' | 'experiments' | 'servers'
 
 /** One wiki export snapshot's table payload. */

--- a/packages/mimir/tests/figure-save.spec.ts
+++ b/packages/mimir/tests/figure-save.spec.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import type { ToolRunContext } from '@deepseek-ai/dsh-tools'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import { createFigureSaveTool } from '../src/tools/figure.ts'
+
+async function harness() {
+  const ctx = new Context()
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  const domain = await facility.open(researchWikiDomainSpec)
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-figure-save-'))
+  await domain.table('projects').put('p1', { id: 'p1', title: 'P', stage: 'experiment', paperDir: 'paper', artifacts: [], reviewRounds: 0, updatedAt: new Date().toISOString() })
+  return { domain, workspaceDir, tool: createFigureSaveTool(workspaceDir, domain) }
+}
+
+describe('figure_save', () => {
+  it('copies a generated figure and records caption metadata', async () => {
+    const { domain, workspaceDir, tool } = await harness()
+    const sourceDir = await mkdtemp(join(tmpdir(), 'mimir-generated-'))
+    const source = join(sourceDir, 'loss.png')
+    await writeFile(source, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    const value = await tool.execute({ path: source, project_id: 'p1', caption: 'Training loss' }, {} as ToolRunContext) as Record<string, unknown>
+    expect(value).toMatchObject({ ok: true, relPath: 'figures/loss.png' })
+    expect(await readFile(join(workspaceDir, 'paper', 'figures', 'loss.png'))).toEqual(await readFile(source))
+    expect(domain.table('figures').get('p1:figures/loss.png')).toMatchObject({ caption: 'Training loss', projectId: 'p1' })
+  })
+
+  it('rejects unsupported files and cross-project experiment links', async () => {
+    const { domain, workspaceDir, tool } = await harness()
+    await mkdir(join(workspaceDir, 'generated'), { recursive: true })
+    const text = join(workspaceDir, 'generated', 'notes.txt')
+    await writeFile(text, 'nope')
+    await expect(tool.execute({ path: text, project_id: 'p1' }, {} as ToolRunContext)).rejects.toThrow('supported image')
+    await domain.table('projects').put('p2', { id: 'p2', title: 'P2', stage: 'experiment', artifacts: [], reviewRounds: 0, updatedAt: new Date().toISOString() })
+    await domain.table('experiments').put('e2', { id: 'e2', projectId: 'p2', name: 'x', status: 'success', metrics: {}, updatedAt: new Date().toISOString() })
+    const image = join(workspaceDir, 'generated', 'plot.svg')
+    await writeFile(image, '<svg/>')
+    await expect(tool.execute({ path: image, project_id: 'p1', experiment_id: 'e2' }, {} as ToolRunContext)).rejects.toThrow('does not belong')
+  })
+})

--- a/packages/mimir/tests/store.spec.ts
+++ b/packages/mimir/tests/store.spec.ts
@@ -93,6 +93,18 @@ describe('researchWikiDomainSpec', () => {
     expect(reopened.table('servers').size).toBe(0)
   })
 
+  it('opens a v2 snapshot predating figure metadata with figures empty', async () => {
+    const pool = new MemoryMediaPool()
+    {
+      const { facility } = await harness(pool)
+      await (await facility.open(researchWikiDomainSpec)).table('papers').put(paper.arxivId, paper)
+    }
+    pool.media.get('research_wiki')!.tables.delete('figures')
+    const { facility } = await harness(pool)
+    const reopened = await facility.open(researchWikiDomainSpec)
+    expect(reopened.table('figures').size).toBe(0)
+  })
+
   it('loads a paper record predating tags/projectIds with both defaulted empty', async () => {
     const pool = new MemoryMediaPool()
     {

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -11,6 +11,7 @@
     "directory": "packages/ui-mimir"
   },
   "type": "module",
+  "engines": { "node": ">=22" },
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
   "exports": {

--- a/packages/ui-mimir/src/client/FiguresView.tsx
+++ b/packages/ui-mimir/src/client/FiguresView.tsx
@@ -199,6 +199,8 @@ export function FiguresView({ figures, projectId, dir, loadFigures, uploadFigure
                     : <img className={css.figureThumb} src={url(entry)} alt={entry.name} loading="lazy" />}
                 </button>
                 <span className={css.figureName} title={entry.relPath}>{entry.name}</span>
+                {entry.caption !== undefined && entry.caption !== '' && <span className={css.figureSize}>{entry.caption}</span>}
+                {entry.experimentId !== undefined && <span className={css.figureBadge}>#{entry.experimentId}</span>}
                 <span className={css.figureSize}>{formatSize(entry.sizeBytes)}</span>
                 <div className={css.figureActions}>
                   <button

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: 'test-results/e2e',
+  timeout: 45_000,
+  retries: process.env.CI === 'true' ? 2 : 0,
+  reporter: process.env.CI === 'true' ? [['line'], ['html', { outputFolder: 'playwright-report', open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.DSH_E2E_URL ?? 'http://127.0.0.1:3080',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    viewport: { width: 1440, height: 960 },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@deepseek-ai/dsh-typert-generator':
         specifier: 0.1.0-rc.8
         version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.1
@@ -920,6 +923,11 @@ packages:
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -1385,6 +1393,11 @@ packages:
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1664,6 +1677,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -3029,6 +3052,10 @@ snapshots:
 
   '@oxc-project/types@0.146.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -3377,6 +3404,9 @@ snapshots:
       picomatch: 4.0.5
 
   fflate@0.8.3: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3828,6 +3858,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.26:
     dependencies:


### PR DESCRIPTION
## 改动内容

同时交付 Issues #30、#13、#2 的可落地部分：

### 会话产物自动入库
- 新增 agent 工具 `figure_save`：复制生成图片到项目 `figures/`，记录 caption、源路径和可选实验关联，返回 LaTeX 片段。
- 新增兼容 v2 存储的 `figures` 元数据表。
- 图表视图展示 caption 和实验徽标，删除文件时同步清理元数据。
- 强化 `wiki_note` 行为引导：有用文献、实验结果、生成图片及时入库。

### Playwright E2E
- 标准 `@playwright/test` 配置，覆盖工作台打开、六视图、文献搜索/导入入口。
- 使用 `DSH_E2E_URL` 对接已装配 Mimir 的 dsh Web；CI 配置该变量后执行并上传截图、trace 和 HTML 报告。
- 未配置宿主服务时明确 skip，不伪造 E2E 通过。

### npm 发布准备
- 两个包声明 Node >=22，根项目锁定 pnpm 版本。
- 新增 tag 触发的 npm provenance 发布流水线，按 host 包 → client 包顺序发布。
- 增加 RELEASING 文档、中英文状态说明和 tarball 检查流程。
- 包名目前未注册，但本机 npm 未登录；首次真实发布仍需 npm publisher/trusted publishing 配置。

## 验证
- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm test`（30 个测试文件，345 项测试）
- [x] `pnpm test:e2e` 未配置服务时 2 项明确 skip
- [x] 两个包 `pack --dry-run` 内容检查
- [ ] GitHub Actions CI
- [ ] 配置 `DSH_E2E_URL` 后运行真实宿主 E2E
- [ ] npm 首次发布认证与 `v0.1.0` tag

Closes #30
Refs #13, #2
