### PR TITLE
fix(mimir): harden arXiv PDF persistence

### DIFF
--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -294,7 +294,13 @@ function createPaperPdfHandler(
       res.writeHead(404).end('expected /research/paper-pdf/<arxiv id>')
       return
     }
-    const arxivId = decodeURIComponent(url.pathname.slice(prefix.length))
+    let arxivId: string
+    try {
+      arxivId = decodeURIComponent(url.pathname.slice(prefix.length))
+    } catch {
+      res.writeHead(400).end('invalid encoded arXiv id')
+      return
+    }
     const record = deps.domain.table('papers').get(arxivId)
     if (record === undefined) {
       res.writeHead(404).end('unknown research paper')

--- a/packages/mimir/src/service.ts
+++ b/packages/mimir/src/service.ts
@@ -14,7 +14,8 @@
  */
 
 import { execFile } from 'node:child_process'
-import { readdir, readFile, mkdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { readdir, readFile, mkdir, rename, stat, unlink, writeFile } from 'node:fs/promises'
 import { connect } from 'node:net'
 import { join, resolve, sep } from 'node:path'
 import { promisify } from 'node:util'
@@ -183,6 +184,18 @@ const PAPER_PDF_DIR = 'papers'
 const ARXIV_SEARCH_DEFAULT_MAX_RESULTS = 10
 /** Hard result cap of one panel-driven arXiv search. */
 const ARXIV_SEARCH_MAX_RESULTS = 50
+
+/** Atomically replace one binary file through a unique same-directory sibling. */
+async function writeBytesAtomic(filePath: string, bytes: Uint8Array): Promise<void> {
+  const tempPath = `${filePath}.${randomUUID()}.tmp`
+  try {
+    await writeFile(tempPath, bytes, { mode: 0o666 })
+    await rename(tempPath, filePath)
+  } catch (error) {
+    await unlink(tempPath).catch(() => {})
+    throw error
+  }
+}
 /** Timeout of the best-effort ssh `nvidia-smi` readout. */
 const GPU_PROBE_TIMEOUT_MS = 8000
 /** Connect timeout handed to the ssh client itself. */
@@ -531,7 +544,7 @@ export class ResearchService extends TypertRemoteService {
     const relPath = `${PAPER_PDF_DIR}/${paperPdfFileName(request.arxivId)}`
     const dir = join(this.workspaceDir, PAPER_PDF_DIR)
     await mkdir(dir, { recursive: true })
-    await writeFile(join(dir, paperPdfFileName(request.arxivId)), bytes)
+    await writeBytesAtomic(join(dir, paperPdfFileName(request.arxivId)), bytes)
     const next: PaperRecord = { ...existing, pdfPath: relPath }
     await table.put(request.arxivId, next)
     return success({ paper: next })

--- a/packages/mimir/src/tools/arxiv.ts
+++ b/packages/mimir/src/tools/arxiv.ts
@@ -108,17 +108,40 @@ export async function fetchArxivPdf(arxivId: string, signal: AbortSignal): Promi
   if (!response.ok) {
     throw new Error(`arXiv PDF request failed: HTTP ${response.status} for ${url}`)
   }
-  const bytes = new Uint8Array(await response.arrayBuffer())
-  if (bytes.length === 0) throw new Error(`arXiv returned an empty PDF body for ${url}`)
-  if (bytes.length > ARXIV_PDF_MAX_BYTES) {
+  const contentLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > ARXIV_PDF_MAX_BYTES) {
     throw new Error(`arXiv PDF exceeds the ${String(ARXIV_PDF_MAX_BYTES)}-byte cap for ${url}`)
+  }
+  if (response.body === null) throw new Error(`arXiv returned an empty PDF body for ${url}`)
+  const chunks: Uint8Array[] = []
+  let length = 0
+  const reader = response.body.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    length += value.length
+    if (length > ARXIV_PDF_MAX_BYTES) {
+      await reader.cancel()
+      throw new Error(`arXiv PDF exceeds the ${String(ARXIV_PDF_MAX_BYTES)}-byte cap for ${url}`)
+    }
+    chunks.push(value)
+  }
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.length
+  }
+  if (bytes.length === 0) throw new Error(`arXiv returned an empty PDF body for ${url}`)
+  if (bytes.length < 5 || String.fromCharCode(...bytes.subarray(0, 5)) !== '%PDF-') {
+    throw new Error(`arXiv returned a non-PDF body for ${url}`)
   }
   return bytes
 }
 
-/** File name (no directory) of one arXiv id's stored PDF; old-style slashes flatten. */
+/** File name (no directory) of one arXiv id's stored PDF; percent encoding keeps old-style slashes collision-free. */
 export function paperPdfFileName(arxivId: string): string {
-  return `${arxivId.replace(/[^a-zA-Z0-9._-]/g, '_')}.pdf`
+  return `${encodeURIComponent(arxivId)}.pdf`
 }
 
 /** JSON-schema properties of one {@link ArxivEntry} in tool output. */

--- a/packages/mimir/tests/service.spec.ts
+++ b/packages/mimir/tests/service.spec.ts
@@ -21,7 +21,7 @@ import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
 import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
 import { researchWikiDomainSpec } from '../src/store.ts'
 import { ResearchService } from '../src/service.ts'
-import { parseArxivFeed } from '../src/tools/arxiv.ts'
+import { ARXIV_PDF_MAX_BYTES, paperPdfFileName, parseArxivFeed } from '../src/tools/arxiv.ts'
 import type { ProjectRecord } from '../src/types.ts'
 
 /** Boot a service over a memory-backed domain and a fresh temp workspace. */
@@ -407,6 +407,21 @@ describe('ResearchService.fetchPaperPdf', () => {
     expect(domain.table('papers').get(ARXIV_ENTRY.id)?.pdfPath).toBeUndefined()
   })
 
+  it('rejects non-PDF and declared over-cap bodies without touching the record', async () => {
+    const { domain, service } = await harness()
+    await service.importPaper({ entry: ARXIV_ENTRY })
+    vi.stubGlobal('fetch', async () => new Response('<html>rate limited</html>', { status: 200 }))
+    await expect(service.fetchPaperPdf({ arxivId: ARXIV_ENTRY.id }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'operation-failed', message: expect.stringContaining('non-PDF') } })
+    vi.stubGlobal('fetch', async () => new Response(PDF_BYTES, {
+      status: 200,
+      headers: { 'content-length': String(ARXIV_PDF_MAX_BYTES + 1) },
+    }))
+    await expect(service.fetchPaperPdf({ arxivId: ARXIV_ENTRY.id }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'operation-failed', message: expect.stringContaining('exceeds') } })
+    expect(domain.table('papers').get(ARXIV_ENTRY.id)?.pdfPath).toBeUndefined()
+  })
+
   it('rejects an unconvertible arXiv id before any request', async () => {
     let fetches = 0
     vi.stubGlobal('fetch', async () => {
@@ -428,6 +443,14 @@ describe('ResearchService.fetchPaperPdf', () => {
     await expect(service.fetchPaperPdf({ arxivId: 'bad id' }))
       .resolves.toMatchObject({ ok: false, error: { code: 'operation-failed', message: expect.stringContaining('invalid arXiv id') } })
     expect(fetches).toBe(0)
+  })
+})
+
+describe('paperPdfFileName', () => {
+  it('keeps old-style slash ids distinct from ids containing underscores', () => {
+    expect(paperPdfFileName('hep-th/9901001')).toBe('hep-th%2F9901001.pdf')
+    expect(paperPdfFileName('hep-th_9901001')).toBe('hep-th_9901001.pdf')
+    expect(paperPdfFileName('hep-th/9901001')).not.toBe(paperPdfFileName('hep-th_9901001'))
   })
 })
 


### PR DESCRIPTION
## 改动内容

<!-- 简述做了什么、为什么。关联 Issue：Closes #xx -->

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿
- [ ] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（本仓库 `pnpm run build` 会处理）
- [ ] README.md / README.zh.md 保持逐节对齐（如涉及功能描述）
- [ ] ROADMAP.md 已更新（如涉及队列条目）

## 截图

<!-- UI 改动必填 -->
