### PR TITLE
ci: support independent npm package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags:
+      - 'v*'
+      - 'dsh-mimir-v*'
+      - 'dsh-client-ui-mimir-v*'
 
 permissions:
   contents: read
@@ -24,9 +27,33 @@ jobs:
       - run: pnpm run build
       - run: pnpm run typecheck
       - run: pnpm test
-      - name: Verify tag matches package versions
+      - name: Select package and verify tag version
+        id: release
         run: |
-          test "$GITHUB_REF_NAME" = "v$(node -p "require('./packages/mimir/package.json').version")"
-          test "$GITHUB_REF_NAME" = "v$(node -p "require('./packages/ui-mimir/package.json').version")"
-      - run: pnpm --filter dsh-mimir publish --access public --provenance --no-git-checks
-      - run: pnpm --filter dsh-client-ui-mimir publish --access public --provenance --no-git-checks
+          host_version=$(node -p "require('./packages/mimir/package.json').version")
+          ui_version=$(node -p "require('./packages/ui-mimir/package.json').version")
+          case "$GITHUB_REF_NAME" in
+            "v$host_version")
+              test "$host_version" = "$ui_version"
+              echo "publish_host=true" >> "$GITHUB_OUTPUT"
+              echo "publish_ui=true" >> "$GITHUB_OUTPUT"
+              ;;
+            "dsh-mimir-v$host_version")
+              echo "publish_host=true" >> "$GITHUB_OUTPUT"
+              echo "publish_ui=false" >> "$GITHUB_OUTPUT"
+              ;;
+            "dsh-client-ui-mimir-v$ui_version")
+              echo "publish_host=false" >> "$GITHUB_OUTPUT"
+              echo "publish_ui=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Tag $GITHUB_REF_NAME does not match a package version" >&2
+              exit 1
+              ;;
+          esac
+      - name: Publish dsh-mimir
+        if: steps.release.outputs.publish_host == 'true'
+        run: pnpm --filter dsh-mimir publish --access public --provenance --no-git-checks
+      - name: Publish dsh-client-ui-mimir
+        if: steps.release.outputs.publish_ui == 'true'
+        run: pnpm --filter dsh-client-ui-mimir publish --access public --provenance --no-git-checks

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,22 @@
 # Releasing Mimir
 
-Both packages share one version. Before the first release, authenticate an npm owner for
-`dsh-mimir` and `dsh-client-ui-mimir`, or configure npm trusted publishing for this
-repository's `Release` workflow and `npm` GitHub environment.
+The host and UI packages can be released independently. Configure npm trusted publishing
+for this repository's `Release` workflow and `npm` GitHub environment before pushing a
+release tag.
 
-1. Update both package versions together.
+1. Update the version of every package that changed.
 2. Run `pnpm install --frozen-lockfile && pnpm run build && pnpm run typecheck && pnpm test`.
-3. Inspect both tarballs with `pnpm --filter dsh-mimir pack --dry-run` and
-   `pnpm --filter dsh-client-ui-mimir pack --dry-run`.
-4. Push a tag matching the package version, for example `v0.1.0`.
+3. Inspect each changed tarball with `pnpm --filter <package> pack --dry-run`.
+4. Push the tag for the package being released:
 
-The tag workflow verifies the version, tests both packages, publishes the host package
-first, then the client package, and records npm provenance.
+   - `dsh-mimir-vX.Y.Z` publishes only `dsh-mimir`.
+   - `dsh-client-ui-mimir-vX.Y.Z` publishes only `dsh-client-ui-mimir`.
+   - `vX.Y.Z` remains available for a coordinated release when both packages have the
+     same version.
+
+The tag workflow verifies the selected package version, runs the full repository checks,
+publishes only the selected package (or both for a coordinated tag), and records npm
+provenance.
 
 ## Browser E2E
 


### PR DESCRIPTION
## Summary
- add package-specific release tags for `dsh-mimir` and `dsh-client-ui-mimir`
- retain `vX.Y.Z` for coordinated same-version releases
- publish only the package selected by the tag
- document the independent release process

## Validation
- verified `dsh-client-ui-mimir-v0.1.1` selects only the UI package
- inspected the `dsh-client-ui-mimir@0.1.1` tarball with `pnpm pack --dry-run`
- full repository checks run in CI