### PR TITLE
feat: automatically capture useful research outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ English | [中文](README.zh.md)
 
 | Tool | Purpose |
 | --- | --- |
-| `arxiv_search` / `paper_fetch` | arXiv Atom API search and single-paper fetch |
+| `arxiv_search` / `paper_fetch` | arXiv search; selected-paper fetch automatically archives and links it |
 | `wiki_note` | Read/write surface over the research wiki domain (papers, ideas, claims, experiments, projects) |
 | `latex_compile` | Compiles `main.tex` with parsed file/line diagnostics; multi-engine: `latexmk` or `tectonic` (auto-detected, or an explicit binary path) |
-| `figure_save` | Saves a generated image into a project's `figures/` directory with caption/experiment metadata and returns a LaTeX snippet |
+| `figure_save` | Saves a generated image with metadata, registers a project artifact, and returns LaTeX |
 
 **Web workbench (six views)** — a sidebar toggle opens a 96vw×95vh overlay:
 
@@ -195,8 +195,8 @@ Registers a project in the wiki, scaffolds `IDEA_REPORT.md` in the workspace, su
 
 The agent reaches the same capabilities mid-conversation:
 
-- `arxiv_search` — "search arXiv for recent whole-body mesh recovery papers" (default cap `arxiv.maxResults`).
-- `paper_fetch` — fetch one paper's metadata by arXiv id.
+- `arxiv_search` — "search arXiv for recent whole-body mesh recovery papers" (default cap `arxiv.maxResults`); search results alone do not pollute the library.
+- `paper_fetch` — fetch a useful paper by arXiv id and automatically archive its metadata, usefulness notes, and tags. It links to an explicit `project_id`, or the latest active project when omitted. Re-fetching refreshes arXiv metadata without losing existing notes, tags, links, or a downloaded PDF.
 - `wiki_note` — the wiki's read/write surface, one flat parameter set keyed by `action`: `add_paper`, `add_idea`, `fail_idea`, `add_claim`, `set_claim`, `set_project` (points a project at its paper directory), `add_experiment`, `set_experiment` (status `running`/`success`/`failed`), plus `list` and `get` over the five tables.
 - `latex_compile` — "compile the paper in `paper/`" (`project_dir` parameter); returns parsed file/line diagnostics.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,10 +24,10 @@
 
 | 工具 | 用途 |
 | --- | --- |
-| `arxiv_search` / `paper_fetch` | arXiv Atom API 检索与单篇抓取 |
+| `arxiv_search` / `paper_fetch` | arXiv 检索；单篇抓取自动归档到文献库并关联项目 |
 | `wiki_note` | 研究 wiki domain 的读写面（文献、想法、主张、实验、项目） |
 | `latex_compile` | 编译 `main.tex` 并给出解析后的文件/行号诊断；多引擎：`latexmk` 或 `tectonic`（自动探测，或显式二进制路径） |
-| `figure_save` | 把生成图片保存到项目 `figures/`，记录 caption/实验关联，并返回 LaTeX 片段 |
+| `figure_save` | 保存生成图、记录 caption/实验关联、登记项目工件并返回 LaTeX 片段 |
 
 **Web 工作台（六视图）**——侧栏开关打开 96vw×95vh 浮层：
 
@@ -195,8 +195,8 @@ dsh 会话里的典型循环：
 
 agent 在对话中途可以触达同一组能力：
 
-- `arxiv_search`——“搜一下最近的 whole-body mesh recovery 论文”（默认上限 `arxiv.maxResults`）。
-- `paper_fetch`——按 arXiv id 抓取单篇元数据。
+- `arxiv_search`——“搜一下最近的 whole-body mesh recovery 论文”（默认上限 `arxiv.maxResults`）；搜索结果不会直接污染文献库。
+- `paper_fetch`——按 arXiv id 抓取有价值的单篇文献，同时自动保存完整元数据、用途笔记与标签，并关联显式 `project_id`（未传时关联最近活跃项目）。重复抓取会刷新 arXiv 元数据，但保留已有笔记、标签、项目关联和本地 PDF。
 - `wiki_note`——wiki 的读写面，以 `action` 为键的一套扁平参数：`add_paper`、`add_idea`、`fail_idea`、`add_claim`、`set_claim`、`set_project`（把项目指向它的论文目录）、`add_experiment`、`set_experiment`（状态 `running`/`success`/`failed`），以及对五张表的 `list` 和 `get`。
 - `latex_compile`——“编译 `paper/` 里的论文”（`project_dir` 参数）；返回解析后的文件/行号诊断。
 

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mimir/src/commands/idea.ts
+++ b/packages/mimir/src/commands/idea.ts
@@ -16,13 +16,13 @@ import type { ResearchCommandDeps } from './common.ts'
 const USAGE = 'Usage: /research-idea <research direction>'
 
 /** Build the ideation instruction handed to the model. */
-function ideaInstruction(deps: ResearchCommandDeps, direction: string): string {
+function ideaInstruction(deps: ResearchCommandDeps, direction: string, projectId: string): string {
   return [
     `You are starting a research ideation task. Direction: ${direction}`,
     `Workspace root: ${deps.workspaceDir} — all artifacts live under it.`,
     'Do these steps in order:',
     "1. Check the wiki's idea memory first: wiki_note with action=list, table=ideas. If a FAILED idea already covers this direction, do not resurrect it unchanged; state the overlap in your report and pivot to what is actually new.",
-    '2. Survey the literature with arxiv_search using 2-4 focused queries. Record every paper that matters with wiki_note action=add_paper.',
+    `2. Survey the literature with arxiv_search using 2-4 focused queries. For every result that materially informs the project, call paper_fetch with project_id=${projectId}, its arXiv id, concise usefulness notes, and tags. paper_fetch automatically archives and links it; do not rely on search output alone.`,
     `3. Write the idea report to ${join(deps.workspaceDir, 'IDEA_REPORT.md')}, filling every section of the skeleton already written there. Ground Related Work in the recorded papers (cite arXiv ids) and fill "Failed Ideas Considered" from step 1.`,
     '4. Record the idea with wiki_note action=add_idea (it starts active).',
     '5. Finish with a short summary for the user: the hypothesis, the closest prior work, and why this is not a repeat of a failed idea.',
@@ -45,7 +45,7 @@ export function registerIdeaCommand(ctx: Context, deps: ResearchCommandDeps): vo
       await ensureWorkspace(deps)
       await writeIfAbsent(join(deps.workspaceDir, 'IDEA_REPORT.md'), IDEA_REPORT_MD)
       const project = await createProject(deps.domain, direction, ['IDEA_REPORT.md'])
-      followupInstruction(invocation.agent, ideaInstruction(deps, direction))
+      followupInstruction(invocation.agent, ideaInstruction(deps, direction, project.id))
       return {
         kind: 'success',
         text: `Research ideation started for "${direction}" (project ${project.id}). The agent is surveying the literature now; its report lands in ${join(deps.workspaceDir, 'IDEA_REPORT.md')}.`,

--- a/packages/mimir/src/commands/paper.ts
+++ b/packages/mimir/src/commands/paper.ts
@@ -24,8 +24,9 @@ function writeInstruction(deps: ResearchCommandDeps, paperDir: string, projectTi
     `1. Read ${join(deps.workspaceDir, 'IDEA_REPORT.md')} and ${join(deps.workspaceDir, 'EXPERIMENT_PLAN.md')}, and list the wiki's claims (wiki_note action=list, table=claims) and papers (table=papers).`,
     `2. Fill ${join(paperDir, 'main.tex')}: replace every <placeholder> with real content grounded in those sources. Keep the article-class skeleton; do not introduce packages beyond what it already loads.`,
     `3. Put real references into ${join(paperDir, 'references.bib')} from the wiki's papers, and cite them from the text.`,
-    `4. Run latex_compile with project_dir=${paperDir} and fix every error it reports until success is true. Fix undefined-citation warnings too; other warnings may be reported to the user instead.`,
-    '5. Finish with a short summary: title, section list, and compile status.',
+    '4. Whenever you create or discover a paper-worthy image, immediately call figure_save with its path, the project id, a useful caption, and the producing experiment id when applicable. The tool archives the file and registers it as a project artifact.',
+    `5. Run latex_compile with project_dir=${paperDir} and fix every error it reports until success is true. Fix undefined-citation warnings too; other warnings may be reported to the user instead.`,
+    '6. Finish with a short summary: title, section list, compile status, and the papers/figures archived during this pass.',
   ].join('\n')
 }
 

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -495,7 +495,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   }
 
   ctx.tools.register(createArxivSearchTool(resolved.arxiv.maxResults))
-  ctx.tools.register(createPaperFetchTool())
+  ctx.tools.register(createPaperFetchTool(domain))
   ctx.tools.register(createWikiNoteTool(domain))
   ctx.tools.register(createLatexCompileTool(resolved.latex))
   ctx.tools.register(createFigureSaveTool(deps.workspaceDir, domain))

--- a/packages/mimir/src/tools/arxiv.ts
+++ b/packages/mimir/src/tools/arxiv.ts
@@ -9,6 +9,8 @@
 
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
+import type { ResearchWikiDomain } from '../store.ts'
+import type { PaperRecord, ProjectRecord } from '../types.ts'
 
 /** One parsed arXiv entry, shared by both tools' output. */
 export interface ArxivEntry {
@@ -162,6 +164,54 @@ function renderEntries(entries: readonly ArxivEntry[]): string {
   ).join('\n')
 }
 
+/** Most recently touched project, used when a fetch omits an explicit id. */
+function latestProject(domain: ResearchWikiDomain): ProjectRecord | undefined {
+  let latest: ProjectRecord | undefined
+  for (const [, project] of domain.table('projects').entries()) {
+    if (latest === undefined || project.updatedAt > latest.updatedAt) latest = project
+  }
+  return latest
+}
+
+/**
+ * Persist a deliberately fetched paper and associate it with the active
+ * project. Re-fetching refreshes arXiv metadata while preserving the user's
+ * organization, downloaded PDF, first-save timestamp, and prior notes.
+ */
+export async function rememberFetchedPaper(
+  domain: ResearchWikiDomain,
+  entry: ArxivEntry,
+  options: { readonly projectId?: string; readonly notes?: string; readonly tags?: readonly string[] } = {},
+): Promise<PaperRecord> {
+  const explicitProject = options.projectId === undefined ? undefined : domain.table('projects').get(options.projectId)
+  if (options.projectId !== undefined && explicitProject === undefined) {
+    throw new Error(`paper_fetch: no project with id '${options.projectId}'`)
+  }
+  const project = explicitProject ?? latestProject(domain)
+  const table = domain.table('papers')
+  const existing = table.get(entry.id)
+  const incomingNotes = options.notes?.trim() ?? ''
+  const notes = incomingNotes === '' || incomingNotes === existing?.notes
+    ? (existing?.notes ?? '')
+    : existing?.notes === '' || existing?.notes === undefined
+      ? incomingNotes
+      : `${existing.notes}\n\n${incomingNotes}`
+  const record: PaperRecord = {
+    arxivId: entry.id,
+    title: entry.title,
+    authors: [...entry.authors],
+    summary: entry.summary,
+    url: entry.url === '' ? `https://arxiv.org/abs/${entry.id}` : entry.url,
+    notes,
+    tags: [...new Set([...(existing?.tags ?? []), ...(options.tags ?? []).map(tag => tag.trim()).filter(Boolean)])],
+    projectIds: [...new Set([...(existing?.projectIds ?? []), ...(project === undefined ? [] : [project.id])])],
+    ...(existing?.pdfPath === undefined ? {} : { pdfPath: existing.pdfPath }),
+    addedAt: existing?.addedAt ?? new Date().toISOString(),
+  }
+  await table.put(entry.id, record)
+  return record
+}
+
 /**
  * Build the `arxiv_search` tool.
  * @param defaultMaxResults - Deployment default for the result cap.
@@ -203,12 +253,15 @@ export function createArxivSearchTool(defaultMaxResults: number): ToolDefinition
  * Build the `paper_fetch` tool.
  * @returns the registry-ready tool definition.
  */
-export function createPaperFetchTool(): ToolDefinition {
+export function createPaperFetchTool(domain: ResearchWikiDomain): ToolDefinition {
   return defineTool({
     name: 'paper_fetch',
-    description: 'Fetch one arXiv paper\'s full metadata record by its arXiv id (e.g. 2103.00020 or 2103.00020v2).',
+    description: 'Fetch one useful arXiv paper by id and automatically save it to the Mimir literature library. It is linked to project_id when supplied, otherwise to the most recently active project.',
     parameters: {
       arxiv_id: { type: 'string', required: true, description: 'Bare arXiv id, with or without a version suffix.' },
+      project_id: { type: 'string', description: 'Project to associate with the saved paper; defaults to the most recently updated project.' },
+      notes: { type: 'string', description: 'Why this paper is useful; appended without erasing existing notes.' },
+      tags: { type: 'array', items: { type: 'string' }, description: 'Organization tags merged into the saved paper.' },
     },
     output: {
       schema: { type: 'object', additionalProperties: false, properties: ENTRY_PROPERTIES },
@@ -220,6 +273,11 @@ export function createPaperFetchTool(): ToolDefinition {
       const url = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(id)}&max_results=1`
       const [entry] = parseArxivFeed(await fetchArxiv(url, exec.signal))
       if (entry === undefined) throw new Error(`arXiv holds no record for id '${id}'`)
+      await rememberFetchedPaper(domain, entry, {
+        ...(args.project_id === undefined ? {} : { projectId: args.project_id }),
+        ...(args.notes === undefined ? {} : { notes: args.notes }),
+        ...(args.tags === undefined ? {} : { tags: args.tags }),
+      })
       return entry
     },
   })

--- a/packages/mimir/src/tools/figure.ts
+++ b/packages/mimir/src/tools/figure.ts
@@ -57,6 +57,12 @@ export function createFigureSaveTool(workspaceDir: string, domain: ResearchWikiD
         createdAt: new Date().toISOString(),
       }
       await domain.table('figures').put(id, record)
+      const artifactPath = `${project.paperDir ?? 'paper'}/${relPath}`
+      await domain.table('projects').update(project.id, current => ({
+        ...current,
+        artifacts: [...new Set([...current.artifacts, artifactPath])],
+        updatedAt: new Date().toISOString(),
+      }))
       const label = name.slice(0, -extname(name).length).replace(/[^a-zA-Z0-9:-]+/g, '-')
       return { ok: true, relPath, record: record as unknown as JsonValue, latex: `\\includegraphics[width=0.8\\linewidth]{${relPath}}`, label: `fig:${label}` }
     },

--- a/packages/mimir/tests/figure-save.spec.ts
+++ b/packages/mimir/tests/figure-save.spec.ts
@@ -34,6 +34,7 @@ describe('figure_save', () => {
     expect(value).toMatchObject({ ok: true, relPath: 'figures/loss.png' })
     expect(await readFile(join(workspaceDir, 'paper', 'figures', 'loss.png'))).toEqual(await readFile(source))
     expect(domain.table('figures').get('p1:figures/loss.png')).toMatchObject({ caption: 'Training loss', projectId: 'p1' })
+    expect(domain.table('projects').get('p1')?.artifacts).toContain('paper/figures/loss.png')
   })
 
   it('rejects unsupported files and cross-project experiment links', async () => {

--- a/packages/mimir/tests/paper-capture.spec.ts
+++ b/packages/mimir/tests/paper-capture.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import type { ToolRunContext } from '@deepseek-ai/dsh-tools'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import { createPaperFetchTool, rememberFetchedPaper, type ArxivEntry } from '../src/tools/arxiv.ts'
+
+const ENTRY: ArxivEntry = {
+  id: '2401.01234v2',
+  title: 'Useful Paper',
+  authors: ['Ada Researcher'],
+  summary: 'A useful result.',
+  published: '2024-01-03T00:00:00Z',
+  url: 'https://arxiv.org/abs/2401.01234v2',
+}
+
+async function domainHarness() {
+  const ctx = new Context()
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  return facility.open(researchWikiDomainSpec)
+}
+
+describe('automatic paper capture', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('archives through the paper_fetch tool, not only the storage helper', async () => {
+    const domain = await domainHarness()
+    await domain.table('projects').put('p1', { id: 'p1', title: 'P1', stage: 'idea', artifacts: [], reviewRounds: 0, updatedAt: new Date().toISOString() })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(`
+      <feed><entry>
+        <id>https://arxiv.org/abs/${ENTRY.id}</id><title>${ENTRY.title}</title>
+        <author><name>${ENTRY.authors[0]}</name></author><summary>${ENTRY.summary}</summary>
+        <published>${ENTRY.published}</published>
+      </entry></feed>
+    `, { status: 200 })))
+
+    const tool = createPaperFetchTool(domain)
+    await tool.execute({ arxiv_id: ENTRY.id, project_id: 'p1', notes: 'Use in related work', tags: ['useful'] }, { signal: AbortSignal.timeout(1_000) } as ToolRunContext)
+
+    expect(domain.table('papers').get(ENTRY.id)).toMatchObject({
+      notes: 'Use in related work',
+      tags: ['useful'],
+      projectIds: ['p1'],
+    })
+  })
+
+  it('links a fetched paper to the latest project and records context', async () => {
+    const domain = await domainHarness()
+    await domain.table('projects').put('older', { id: 'older', title: 'Old', stage: 'idea', artifacts: [], reviewRounds: 0, updatedAt: '2024-01-01T00:00:00Z' })
+    await domain.table('projects').put('active', { id: 'active', title: 'Active', stage: 'idea', artifacts: [], reviewRounds: 0, updatedAt: '2024-01-02T00:00:00Z' })
+
+    const saved = await rememberFetchedPaper(domain, ENTRY, { notes: 'Closest baseline', tags: ['retrieval'] })
+
+    expect(saved).toMatchObject({ notes: 'Closest baseline', tags: ['retrieval'], projectIds: ['active'] })
+    expect(domain.table('papers').get(ENTRY.id)).toEqual(saved)
+  })
+
+  it('refreshes metadata without losing prior curation', async () => {
+    const domain = await domainHarness()
+    await domain.table('projects').put('p1', { id: 'p1', title: 'P1', stage: 'idea', artifacts: [], reviewRounds: 0, updatedAt: new Date().toISOString() })
+    const first = await rememberFetchedPaper(domain, ENTRY, { projectId: 'p1', notes: 'First note', tags: ['baseline'] })
+    await domain.table('papers').update(ENTRY.id, current => ({ ...current, pdfPath: 'papers/saved.pdf' }))
+
+    const refreshed = await rememberFetchedPaper(domain, { ...ENTRY, title: 'Updated title' }, { projectId: 'p1', notes: 'Second note', tags: ['strong'] })
+
+    expect(refreshed.title).toBe('Updated title')
+    expect(refreshed.notes).toBe('First note\n\nSecond note')
+    expect(refreshed.tags).toEqual(['baseline', 'strong'])
+    expect(refreshed.projectIds).toEqual(['p1'])
+    expect(refreshed.pdfPath).toBe('papers/saved.pdf')
+    expect(refreshed.addedAt).toBe(first.addedAt)
+  })
+
+  it('rejects an explicit unknown project instead of silently mislinking', async () => {
+    const domain = await domainHarness()
+    await expect(rememberFetchedPaper(domain, ENTRY, { projectId: 'missing' })).rejects.toThrow("no project with id 'missing'")
+  })
+})


### PR DESCRIPTION
## Summary
- make `paper_fetch` automatically archive selected arXiv papers in the Mimir library
- associate fetched papers with an explicit project, or the latest active project by default
- preserve existing notes, tags, project links, downloaded PDFs, and first-added timestamps on refresh
- register `figure_save` outputs in the owning project's artifact list
- strengthen research/paper command instructions so agents consistently use the capture path
- bump only `dsh-mimir` to `0.1.1`

## Validation
- full suite: 32 test files / 352 tests passed
- focused integration suite: 2 files / 6 tests passed
- `pnpm run build`
- `pnpm run typecheck`