### PR TITLE
feat(ui): elevate the Mimir workbench visual design

### DIFF
--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui-mimir/src/client/ResearchPanel.module.css
+++ b/packages/ui-mimir/src/client/ResearchPanel.module.css
@@ -10,7 +10,8 @@
   position: fixed;
   inset: 0;
   z-index: -1;
-  background: rgb(15 23 42 / 24%);
+  background: rgb(10 18 38 / 42%);
+  backdrop-filter: blur(5px) saturate(0.9);
   pointer-events: none;
 }
 
@@ -22,17 +23,22 @@
   width: 96vw;
   height: 95vh;
   display: flex;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 16px;
+  border: 1px solid rgb(255 255 255 / 38%);
+  border-radius: 22px;
   background: var(--dsw-specific-menu, #fff);
   box-shadow:
     0 0 1px rgb(0 0 0 / 12%),
-    0 12px 32px rgb(0 0 0 / 10%),
-    0 32px 80px rgb(0 0 0 / 18%);
+    0 16px 40px rgb(15 23 42 / 14%),
+    0 40px 100px rgb(15 23 42 / 25%);
   pointer-events: auto;
   overflow: hidden;
   --dsh-scrollbar-thumb: var(--dsw-alias-scrollbar-bg-l2);
   --dsh-scrollbar-thumb-hover: var(--dsw-alias-scrollbar-hover-l2);
+  --mimir-accent: #4f7cff;
+  --mimir-accent-strong: #315fe9;
+  --mimir-accent-soft: rgb(79 124 255 / 12%);
+  --mimir-violet: #7758e8;
+  --mimir-card-shadow: 0 1px 2px rgb(15 23 42 / 4%), 0 10px 30px rgb(45 66 110 / 7%);
 }
 
 /* Left rail: brand head + pill nav + the project picker at the bottom.
@@ -40,19 +46,61 @@
    216px basis via the flex item's automatic minimum size. */
 .side {
   display: flex;
-  flex: 0 0 216px;
+  flex: 0 0 244px;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
   border-right: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  background: var(--dsw-specific-menu, #fff);
+  background:
+    radial-gradient(circle at 0 0, rgb(79 124 255 / 11%), transparent 34%),
+    linear-gradient(180deg, var(--dsw-specific-menu, #fff), var(--dsw-specific-menu, #fff));
 }
 
 .sideHead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 16px 14px;
+  padding: 20px 16px 18px;
+}
+
+.brand {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.brandMark {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgb(255 255 255 / 38%);
+  border-radius: 11px;
+  background: linear-gradient(145deg, var(--mimir-accent), var(--mimir-violet));
+  box-shadow: 0 7px 18px rgb(79 124 255 / 28%);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.brandCopy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.brandSubtitle {
+  overflow: hidden;
+  color: var(--dsw-alias-label-tertiary, #6b7280);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .title {
@@ -60,31 +108,24 @@
   align-items: center;
   gap: 8px;
   color: var(--dsw-alias-label-primary, #17233d);
-  font-size: 15px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 750;
   letter-spacing: 0.01em;
-}
-
-.title::before {
-  content: '';
-  width: 8px;
-  height: 8px;
-  border-radius: 3px;
-  background: var(--dsw-alias-state-business-primary, #4176e6);
-  box-shadow: 0 0 0 3px var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 15%));
 }
 
 .close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 26px;
-  padding: 0 10px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 13px;
+  border-radius: 9px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-tertiary, #5b6474);
-  font-size: 12px;
+  font-size: 18px;
+  line-height: 1;
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
@@ -131,8 +172,8 @@
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  padding: 4px 12px 12px;
+  gap: 5px;
+  padding: 4px 12px 16px;
 }
 
 .navItem {
@@ -140,10 +181,10 @@
   display: flex;
   align-items: center;
   gap: 9px;
-  height: 34px;
+  height: 40px;
   padding: 0 12px 0 14px;
   border: none;
-  border-radius: 10px;
+  border-radius: 12px;
   background: transparent;
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 13px;
@@ -194,8 +235,8 @@
 }
 
 .navItem[data-active] {
-  background: var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 12%));
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  background: linear-gradient(90deg, rgb(79 124 255 / 16%), rgb(119 88 232 / 8%));
+  color: var(--mimir-accent-strong);
   font-weight: 600;
 }
 
@@ -216,18 +257,21 @@
 .navItem[data-active]::before {
   content: '';
   position: absolute;
-  left: 4px;
-  top: 8px;
-  bottom: 8px;
+  left: 3px;
+  top: 7px;
+  bottom: 7px;
   width: 3px;
   border-radius: 2px;
-  background: var(--dsw-alias-state-business-primary, #4176e6);
+  background: linear-gradient(180deg, var(--mimir-accent), var(--mimir-violet));
+  box-shadow: 0 2px 8px rgb(79 124 255 / 35%);
 }
 
 /* Unified view header: title + subtitle on the left, actions on the right. */
 .viewHead {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  padding: 2px 2px 8px;
+  border-bottom: 1px solid var(--dsw-alias-border-l1, rgb(15 23 42 / 6%));
   justify-content: space-between;
   gap: 16px;
   width: 100%;
@@ -243,8 +287,9 @@
 .viewTitle {
   margin: 0;
   color: var(--dsw-alias-label-primary, #17233d);
-  font-size: 17px;
-  font-weight: 650;
+  font-size: 21px;
+  font-weight: 750;
+  letter-spacing: -0.02em;
   letter-spacing: 0.01em;
 }
 
@@ -301,7 +346,7 @@
 
 .btnPrimary {
   border: 1px solid transparent;
-  background: var(--dsw-alias-button-primary-fill, #4176e6);
+  background: linear-gradient(135deg, var(--mimir-accent), var(--mimir-accent-strong));
   color: var(--dsw-alias-label-primary-foreground, #fff);
   box-shadow: 0 2px 6px rgb(65 118 230 / 25%);
 }
@@ -322,24 +367,27 @@
 .statChips {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(110px, 1fr));
+  gap: 12px;
 }
 
 .statChip {
   display: inline-flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 8px 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 14px 16px;
   border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 999px;
+  border-radius: 15px;
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .statValue {
   color: var(--dsw-alias-state-business-primary, #4176e6);
-  font-size: 15px;
-  font-weight: 650;
+  font-size: 22px;
+  font-weight: 750;
   font-variant-numeric: tabular-nums;
 }
 
@@ -354,7 +402,7 @@
   overflow-y: auto;
   padding: 12px;
   border-top: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: rgb(79 124 255 / 3%);
 }
 
 /* The rail's bottom line: the keyboard-shortcut hint. */
@@ -431,9 +479,9 @@
 }
 
 .projectRow[data-selected] {
-  border-color: var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-color: rgb(79 124 255 / 24%);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: 0 6px 18px rgb(45 66 110 / 8%);
 }
 
 .projectTitle {
@@ -459,8 +507,11 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  padding: 24px 28px;
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  padding: 28px 34px;
+  background:
+    radial-gradient(circle at 92% 0, rgb(119 88 232 / 8%), transparent 28%),
+    radial-gradient(circle at 25% 0, rgb(79 124 255 / 7%), transparent 25%),
+    var(--dsw-alias-interactive-bg-hover, #f5f7fb);
 }
 
 /* Shared empty state: a centered dashed card with a glyph and copy. */
@@ -491,23 +542,23 @@
   flex-direction: column;
   gap: 16px;
   width: 100%;
-  max-width: 1080px;
+  max-width: 1180px;
   margin: 0 auto;
 }
 
 .overviewCard {
-  padding: 24px;
+  padding: 28px;
   border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  border-radius: 18px;
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%), 0 4px 16px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .overviewTitle {
   margin: 0 0 16px;
   color: var(--dsw-alias-label-primary, #17233d);
-  font-size: 17px;
-  font-weight: 650;
+  font-size: 20px;
+  font-weight: 720;
   line-height: 1.4;
 }
 
@@ -515,7 +566,7 @@
   display: flex;
   gap: 4px;
   margin: 0 0 20px;
-  padding: 4px;
+  padding: 5px;
   list-style: none;
   border-radius: 999px;
   background: var(--dsw-alias-markdown-code-block, #f1f3f5);
@@ -537,7 +588,7 @@
 }
 
 .stageStep[data-current] {
-  background: var(--dsw-alias-state-business-primary, #4176e6);
+  background: linear-gradient(135deg, var(--mimir-accent), var(--mimir-violet));
   color: var(--dsw-alias-label-primary-foreground, #fff);
   font-weight: 600;
   box-shadow: 0 2px 6px rgb(65 118 230 / 35%);
@@ -1179,15 +1230,16 @@ li.dropIndicator {
   gap: 8px;
   padding: 18px;
   border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  border-radius: 17px;
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
-  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+  box-shadow: var(--mimir-card-shadow);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
 .paperCard:hover {
   border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
+  box-shadow: 0 16px 36px rgb(45 66 110 / 12%);
+  transform: translateY(-2px);
 }
 
 .paperCardTitle {
@@ -2359,12 +2411,43 @@ li.dropIndicator {
   opacity: 0.45;
 }
 
+/* A shared elevated surface language across the data-heavy views. Kept after
+   their individual rules so every view finishes with the same visual depth. */
+.papersSearchPanel,
+.experimentTableWrap,
+.figureCard,
+.serverCard,
+.outlineRail,
+.editorPane,
+.previewPane {
+  border-radius: 17px;
+  box-shadow: var(--mimir-card-shadow);
+}
+
+.figureCard,
+.serverCard {
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.figureCard:hover,
+.figureCard:focus-within,
+.serverCard:hover {
+  box-shadow: 0 16px 36px rgb(45 66 110 / 12%);
+  transform: translateY(-2px);
+}
+
 /* Dark palette: the host theme presenter flips `body[data-ds-dark-theme]` and
    every `--dsw-*` alias above follows the dark base palette on its own — only
    the panel-private tokens (the LaTeX syntax colors) and the dimmer need a
    dark value. The editor's dark ground is the theme's bluish-900 well, so the
    syntax colors are picked for it (all ≥ 4.5:1 against it). */
 :global(body[data-ds-dark-theme]) .workbench {
+  border-color: rgb(255 255 255 / 10%);
+  --mimir-accent: #6f9cff;
+  --mimir-accent-strong: #5b86ee;
+  --mimir-accent-soft: rgb(111 156 255 / 15%);
+  --mimir-violet: #9a7cf3;
+  --mimir-card-shadow: 0 1px 2px rgb(0 0 0 / 16%), 0 14px 34px rgb(0 0 0 / 14%);
   --mimir-tok-command: #8ab0f8;
   --mimir-tok-comment: #8ba091;
   --mimir-tok-math: #b79dfa;
@@ -2412,6 +2495,10 @@ li.dropIndicator {
 }
 
 @media (max-width: 900px) {
+  .statChips {
+    grid-template-columns: repeat(2, minmax(110px, 1fr));
+  }
+
   .paperTabs {
     display: inline-flex;
   }
@@ -2442,6 +2529,16 @@ li.dropIndicator {
 
   .sideHead {
     padding: 10px 12px;
+  }
+
+  .brandSubtitle {
+    display: none;
+  }
+
+  .brandMark {
+    width: 30px;
+    height: 30px;
+    border-radius: 9px;
   }
 
   .nav {
@@ -2491,6 +2588,16 @@ li.dropIndicator {
 
   .content {
     padding: 12px 14px;
+  }
+}
+
+@media (max-width: 460px) {
+  .statChips {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .statChip {
+    padding: 10px 12px;
   }
 }
 

--- a/packages/ui-mimir/src/client/ResearchPanel.tsx
+++ b/packages/ui-mimir/src/client/ResearchPanel.tsx
@@ -239,7 +239,13 @@ export function ResearchPanel({
       <div className={css.backdrop} aria-hidden />
       <aside className={css.side}>
         <div className={css.sideHead}>
-          <span className={css.title}>{t('panel.title')}</span>
+          <div className={css.brand}>
+            <span className={css.brandMark} aria-hidden>M</span>
+            <span className={css.brandCopy}>
+              <span className={css.title}>{t('panel.title')}</span>
+              <span className={css.brandSubtitle}>{t('panel.subtitle')}</span>
+            </span>
+          </div>
           <div className={css.headActions}>
             <button
               type="button"
@@ -259,8 +265,8 @@ export function ResearchPanel({
             >
               {locale === 'zh' ? '中' : 'EN'}
             </button>
-            <button type="button" className={css.close} onClick={() => { actions.setOpen(false) }}>
-              {t('panel.close')}
+            <button type="button" className={css.close} title={t('panel.close')} aria-label={t('panel.close')} onClick={() => { actions.setOpen(false) }}>
+              ×
             </button>
           </div>
         </div>

--- a/packages/ui-mimir/src/client/locales.ts
+++ b/packages/ui-mimir/src/client/locales.ts
@@ -4,6 +4,7 @@
 export const zh = {
   'toggle': 'Mimir',
   'panel.title': 'Mimir',
+  'panel.subtitle': '智能科研工作台',
   'panel.close': '关闭',
   'panel.theme': '切换深浅色主题',
   'panel.language': '切换语言（中/EN）',
@@ -321,6 +322,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 export const en = {
   'toggle': 'Mimir',
   'panel.title': 'Mimir',
+  'panel.subtitle': 'Research intelligence',
   'panel.close': 'Close',
   'panel.theme': 'Toggle light/dark theme',
   'panel.language': 'Switch language (中/EN)',


### PR DESCRIPTION
## Summary
- introduce a distinctive Mimir brand block with bilingual research-workbench subtitle
- add a polished blue-violet accent system, layered backgrounds, backdrop blur, and deeper modal framing
- improve navigation density, active states, close control, headings, and primary actions
- turn overview statistics into responsive dashboard cards
- unify elevation, radius, and hover treatment across literature, figures, servers, experiments, and paper panes
- include dedicated dark-theme and narrow-screen adaptations
- bump only `dsh-client-ui-mimir` to `0.1.2`

## Validation
- `pnpm run build`
- `pnpm run typecheck`
- full suite: 32 files / 353 tests passed

## Visual QA note
The repository has no standalone UI fixture; live screenshot QA requires a dsh Web instance with the Mimir client and research Remote mounted. Existing light/dark/narrow screenshots were used as the baseline, and CI covers compilation plus behavior.