### PR TITLE
docs: feature Mimir cover on homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ English | [中文](README.zh.md)
 
 **Mimir is a research-lifecycle plugin suite for the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (dsh): arXiv literature search, a persistent research wiki, independent subagent review, and a closed LaTeX writing → compile → preview loop — plus a full web workbench.**
 
+![Mimir — open-source AI research workspace](docs/media/mimir-cover.png)
+
 ## Video demo
 
 [![Watch the Mimir product demo](docs/media/mimir-demo-preview.gif)](https://raw.githubusercontent.com/1692775560/Mimir/main/docs/media/mimir-demo.mp4)

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,6 +6,8 @@
 
 **Mimir 是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（dsh）的科研生命周期插件套件：arXiv 文献检索、持久化研究 wiki、独立子代理评审，以及 LaTeX 写作 → 编译 → 预览闭环——外加一个完整的 web 工作台。**
 
+![Mimir——开源 AI 科研工作台](docs/media/mimir-cover.png)
+
 ## 视频演示
 
 [![观看 Mimir 产品演示](docs/media/mimir-demo-preview.gif)](https://raw.githubusercontent.com/1692775560/Mimir/main/docs/media/mimir-demo.mp4)


### PR DESCRIPTION
## Summary

- display the existing Mimir promotional cover near the top of the English README
- display the same cover near the top of the Chinese README
- reuse the existing media asset without uploading a duplicate

## Validation

- source image and repository image have identical SHA-256 hashes
- `git diff --check` passes