### PR TITLE
chore: release v0.2.0

### DIFF
--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Bump dsh-mimir 0.1.1 → 0.2.0 与 dsh-client-ui-mimir 0.1.2 → 0.2.0。

自上次发版以来的主要变化：
- feat(mimir): figure_save 图表保存工具 + figures 元数据表（#44，经 #45 合入）
- feat(ui): 工作台体验美化——论文栏布局/项目名两行/卡片徽章自适应/指标条折行/总览最近动态/图表网格加密（#46）

合并后打 v0.2.0 tag 触发 release.yml 同时发布两个包。