### PR TITLE
dev → main：编辑器性能窗口化（#16）

### DIFF
--- a/packages/ui-mimir/src/client/PaperView.tsx
+++ b/packages/ui-mimir/src/client/PaperView.tsx
@@ -2,8 +2,12 @@
  * The paper view: the Overleaf-style editing surface — a clickable outline
  * rail, the `main.tex` editor with a synced line-number gutter, a dependency-
  * free LaTeX syntax-highlight overlay (transparent-text textarea over a
- * token-rendered pre, degrading to plain past HIGHLIGHT_MAX_LENGTH), the
- * autosave status pill, the compile row with the severity-colored issue list
+ * token-rendered pre, degrading to plain past HIGHLIGHT_MAX_LENGTH). The
+ * overlay and the line-number gutter are windowed: only the viewport's lines
+ * (plus an overscan) mount as DOM, the rest is fixed-height spacers, so a
+ * multi-thousand-line `main.tex` no longer rebuilds thousands of nodes per
+ * keystroke. Then the autosave status pill, the compile row with the
+ * severity-colored issue list
  * (click jumps the editor to the line), the iframe PDF preview, and the
  * bibliography panel that replaces the preview while open. The three panes
  * are resizable through drag handles (the widths persist to localStorage) and
@@ -13,13 +17,14 @@
  * @module dsh-client-ui-mimir/client/PaperView
  */
 
-import { useEffect, useMemo, useRef, useState, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import type { BibEntry, OutlineNode, SectionMove, SectionOutlineTitles, SubsectionMove } from 'dsh-mimir/types'
 import type {
   ResearchBibView, ResearchCompileView, ResearchFailureView, ResearchImportCounts,
   ResearchOutlineView, ResearchPapersView, ResearchSourceView,
 } from './controller.ts'
 import { wrapIndex } from './focus.ts'
+import { EDITOR_LINE_HEIGHT_PX, splitTokensByLine, visibleLineRange, widestLine } from './highlight-window.ts'
 import { HIGHLIGHT_MAX_LENGTH, tokenizeLatex } from './latex-highlight.ts'
 import {
   editorShareFromDrag, loadPaperLayout, PAPER_LAYOUT_DEFAULT, PAPER_LAYOUT_STORAGE_KEY,
@@ -32,8 +37,8 @@ import type { ResearchT, SubsectionDrag } from './view-common.ts'
 import { BibPanel } from './BibPanel.tsx'
 import css from './ResearchPanel.module.css'
 
-/** Editor line height in px; keep in sync with `.editor` in the module CSS. */
-const EDITOR_LINE_HEIGHT = 19
+/** Editor line height in px (re-exported name kept local to the jump math). */
+const EDITOR_LINE_HEIGHT = EDITOR_LINE_HEIGHT_PX
 
 /** How long the jumped-to gutter row stays flashed. */
 const GUTTER_FLASH_MS = 1200
@@ -332,6 +337,10 @@ export function PaperView({
   const [bibOpen, setBibOpen] = useState(false)
   // The last rejected section reorder, surfaced in the rail.
   const [reorderError, setReorderError] = useState<ResearchFailureView | null>(null)
+  // The textarea's viewport in lines/px: drives the windowed gutter and
+  // highlight overlay. Coarsened to whole lines so mid-line scrolls don't
+  // re-render.
+  const [viewport, setViewport] = useState({ firstLine: 0, height: 0 })
   // Pane widths; restored from localStorage, written back on every settle.
   const [layout, setLayout] = useState<PaperLayout>(() => loadPaperLayout(key => localStorage.getItem(key)))
   // Which drag handle is mid-gesture (drives the container's data-dragging).
@@ -421,7 +430,23 @@ export function PaperView({
       highlightRef.current.scrollTop = editor.scrollTop
       highlightRef.current.scrollLeft = editor.scrollLeft
     }
+    // Feed the windowed gutter/overlay; state only moves when the first
+    // visible line or the viewport height changes.
+    const firstLine = Math.floor(editor.scrollTop / EDITOR_LINE_HEIGHT)
+    const height = editor.clientHeight
+    setViewport(prev => (prev.firstLine === firstLine && prev.height === height ? prev : { firstLine, height }))
   }
+
+  // Pane drags and fullscreen flips resize the textarea without firing a
+  // scroll event; the window must still follow the new viewport height.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (editor === null || typeof ResizeObserver === 'undefined') return undefined
+    const observer = new ResizeObserver(() => { syncEditorScroll() })
+    observer.observe(editor)
+    return () => { observer.disconnect() }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   /**
    * Keyboard twin of the rail-handle drag: ArrowLeft/ArrowRight resize the
@@ -515,12 +540,28 @@ export function PaperView({
     ? `/research/pdf/${encodeURIComponent(projectId)}?v=${compileView.pdfUpdatedAt}`
       + (dir === undefined ? '' : `&dir=${encodeURIComponent(dir)}`)
     : null
-  const lineCount = currentSource === null ? 1 : currentSource.content.split('\n').length
+  // Logical lines of the draft; everything line-based derives from this one
+  // split so the gutter, the overlay, and the window never disagree.
+  const sourceLines = useMemo(() => (currentSource?.content ?? '').split('\n'), [currentSource?.content])
+  const lineCount = sourceLines.length
   // The highlight overlay's tokens; oversized sources degrade to plain text.
   const highlightTokens = useMemo(() => {
     const content = currentSource?.content ?? ''
     return content.length > 0 && content.length <= HIGHLIGHT_MAX_LENGTH ? tokenizeLatex(content) : null
   }, [currentSource?.content])
+  // Per-line tokens for the windowed overlay (the split consumes newlines).
+  const lineTokens = useMemo(
+    () => (highlightTokens === null ? null : splitTokensByLine(highlightTokens)),
+    [highlightTokens],
+  )
+  // Only the viewport ± overscan mounts as DOM; spacers keep the scrollable
+  // geometry identical to the full render.
+  const lineWindow = visibleLineRange(
+    viewport.firstLine * EDITOR_LINE_HEIGHT, viewport.height, lineCount,
+  )
+  // Hidden sizer keeping the overlay's horizontal scroll extent in step with
+  // the textarea even when the widest line is outside the window.
+  const sizerLine = useMemo(() => widestLine(sourceLines), [sourceLines])
 
   // The overlay remounts when highlighting toggles; re-sync its scroll after
   // every token recompute so it never lags the textarea.
@@ -727,25 +768,38 @@ export function PaperView({
         )}
         <div className={css.editorWrap}>
           <div ref={gutterRef} className={css.gutter} aria-hidden>
-            {Array.from({ length: lineCount }, (_, index) => (
-              <div key={index} data-flash={index + 1 === flashLine || undefined}>{index + 1}</div>
-            ))}
+            {/* Windowed like the overlay: spacers above/below the mounted
+                rows keep the gutter's scrollable height at lineCount lines. */}
+            <div className={css.gutterSpacer} style={{ height: lineWindow.start * EDITOR_LINE_HEIGHT }} />
+            {Array.from({ length: lineWindow.end - lineWindow.start }, (_, offset) => {
+              const line = lineWindow.start + offset + 1
+              return <div key={line} data-flash={line === flashLine || undefined}>{line}</div>
+            })}
+            <div className={css.gutterSpacer} style={{ height: (lineCount - lineWindow.end) * EDITOR_LINE_HEIGHT }} />
           </div>
           <div className={css.editorStack}>
-            {highlightTokens !== null && (
+            {lineTokens !== null && (
               <pre ref={highlightRef} className={css.editorHighlight} aria-hidden>
-                {highlightTokens.map((token, index) => token.type === 'plain'
-                  ? token.text
-                  : <span key={index} data-tok={token.type}>{token.text}</span>)}
-                {/* A trailing newline keeps the pre as tall as the textarea
-                    when the source ends with one. */}
-                {'\n'}
+                <div style={{ height: lineWindow.start * EDITOR_LINE_HEIGHT }} />
+                {lineTokens.slice(lineWindow.start, lineWindow.end).map((tokens, offset) => (
+                  <div key={lineWindow.start + offset} className={css.editorHighlightLine}>
+                    {tokens.map((token, index) => token.type === 'plain'
+                      ? <Fragment key={index}>{token.text}</Fragment>
+                      : <span key={index} data-tok={token.type}>{token.text}</span>)}
+                  </div>
+                ))}
+                <div style={{ height: (lineCount - lineWindow.end) * EDITOR_LINE_HEIGHT }} />
+                {/* Zero-height sizer: the doc's widest line keeps the pre's
+                    scrollable width in step with the textarea's while only a
+                    window of lines is mounted. Per-line divs already give the
+                    pre the textarea's exact height, trailing newline included. */}
+                <div className={css.editorHighlightSizer}>{sizerLine}</div>
               </pre>
             )}
             <textarea
               ref={editorRef}
               className={css.editor}
-              data-highlighted={highlightTokens !== null || undefined}
+              data-highlighted={lineTokens !== null || undefined}
               spellCheck={false}
               value={currentSource?.content ?? ''}
               disabled={projectId === null || currentSource === null

--- a/packages/ui-mimir/src/client/ResearchPanel.module.css
+++ b/packages/ui-mimir/src/client/ResearchPanel.module.css
@@ -1128,6 +1128,21 @@ li.dropIndicator {
   user-select: none;
 }
 
+/* One mounted line of the windowed overlay; the fixed height keeps empty
+   lines pixel-aligned with the textarea (a contentless div would collapse). */
+.editorHighlightLine {
+  height: 19px;
+}
+
+/* Zero-height widest-line sizer: holds the pre's scrollable width in step
+   with the textarea's while only a window of lines is mounted. */
+.editorHighlightSizer {
+  height: 0;
+  width: max-content;
+  overflow: hidden;
+  visibility: hidden;
+}
+
 .editorHighlight [data-tok='command'] {
   color: var(--mimir-tok-command, #1d4ed8);
 }
@@ -1291,6 +1306,11 @@ li.dropIndicator {
 .gutter div {
   border-radius: 4px;
   transition: background-color 0.3s ease;
+}
+
+/* Window spacer: carries the height of the unmounted rows, nothing else. */
+.gutterSpacer {
+  pointer-events: none;
 }
 
 .gutter div[data-flash] {

--- a/packages/ui-mimir/src/client/highlight-window.ts
+++ b/packages/ui-mimir/src/client/highlight-window.ts
@@ -1,0 +1,131 @@
+/**
+ * Windowing helpers for the paper editor's highlight overlay and gutter.
+ * Rendering every token span and gutter row of a multi-thousand-line
+ * `main.tex` on each keystroke is the editor's dominant cost, so the overlay
+ * mounts only the lines around the textarea's viewport and pads the rest
+ * with fixed-height spacers (the editor forbids soft wrap, so every logical
+ * line is exactly {@link EDITOR_LINE_HEIGHT_PX} tall). All functions here are
+ * pure; the component owns the scroll state.
+ * @module dsh-client-ui-mimir/client/highlight-window
+ */
+
+import type { LatexToken } from './latex-highlight.ts'
+
+/** Editor line height in px; keep in sync with `.editor` in the module CSS. */
+export const EDITOR_LINE_HEIGHT_PX = 19
+
+/** Extra lines mounted above/below the viewport so small scrolls reuse the DOM. */
+export const HIGHLIGHT_OVERSCAN_LINES = 20
+
+/** A half-open line window: `start` inclusive, `end` exclusive, both 0-based. */
+export interface LineRange {
+  readonly start: number
+  readonly end: number
+}
+
+/**
+ * Convert a scroll position into the line window to mount, clamped to
+ * `[0, lineCount]` and widened by the overscan on both sides.
+ * @param scrollTop - the textarea's vertical scroll offset in px.
+ * @param viewportHeight - the textarea's visible height in px (0 when hidden).
+ * @param lineCount - total logical lines of the source.
+ * @param lineHeight - the fixed editor line height in px.
+ * @param overscan - extra lines mounted on each side of the viewport.
+ * @returns the clamped half-open line window.
+ */
+export function visibleLineRange(
+  scrollTop: number,
+  viewportHeight: number,
+  lineCount: number,
+  lineHeight: number = EDITOR_LINE_HEIGHT_PX,
+  overscan: number = HIGHLIGHT_OVERSCAN_LINES,
+): LineRange {
+  const firstVisible = Math.floor(Math.max(0, scrollTop) / lineHeight)
+  const lastVisibleExclusive = Math.ceil(Math.max(0, scrollTop + viewportHeight) / lineHeight)
+  return {
+    start: Math.max(0, Math.min(lineCount, firstVisible - overscan)),
+    end: Math.max(0, Math.min(lineCount, lastVisibleExclusive + overscan)),
+  }
+}
+
+/**
+ * Split a flat token list into one token list per logical line. Newlines are
+ * consumed by the split, so the concatenation of `lines[i]` equals
+ * `content.split('\n')[i]`; a token spanning lines (only `$$...$$` math and
+ * `plain` runs can) is divided at the line boundary with its type preserved.
+ * @param tokens - the full-document tokens from `tokenizeLatex`.
+ * @returns per-line token lists; `lines.length` is the source's line count.
+ */
+export function splitTokensByLine(tokens: readonly LatexToken[]): LatexToken[][] {
+  const lines: LatexToken[][] = [[]]
+  for (const token of tokens) {
+    let segmentStart = 0
+    for (let i = 0; i <= token.text.length; i += 1) {
+      if (i === token.text.length || token.text[i] === '\n') {
+        if (i > segmentStart) {
+          lines[lines.length - 1]?.push({ type: token.type, text: token.text.slice(segmentStart, i) })
+        }
+        if (i < token.text.length) lines.push([])
+        segmentStart = i + 1
+      }
+    }
+  }
+  return lines
+}
+
+/**
+ * Display width of one line in monospace columns: a tab advances to the next
+ * multiple of `tabSize`, East-Asian wide code points count double, everything
+ * else counts one. Heuristic by design — it only picks the sizer line that
+ * keeps the overlay's scrollable width in step with the textarea's.
+ * @param line - one logical source line (no trailing newline).
+ * @param tabSize - the editor's tab stop (CSS `tab-size`).
+ * @returns the line's width in `ch` columns.
+ */
+export function displayColumns(line: string, tabSize: number = 8): number {
+  let columns = 0
+  for (const ch of line) {
+    if (ch === '\t') {
+      columns += tabSize - (columns % tabSize)
+      continue
+    }
+    const code = ch.codePointAt(0) ?? 0
+    columns += (code >= 0x1100 && code <= 0x115f)
+      || (code >= 0x2e80 && code <= 0xa4cf)
+      || (code >= 0xac00 && code <= 0xd7a3)
+      || (code >= 0xf900 && code <= 0xfaff)
+      || (code >= 0xfe30 && code <= 0xfe4f)
+      || (code >= 0xff00 && code <= 0xff60)
+      || (code >= 0xffe0 && code <= 0xffe6)
+      || (code >= 0x20000 && code <= 0x3fffd)
+      ? 2
+      : 1
+  }
+  return columns
+}
+
+/**
+ * Pick the widest line by {@link displayColumns}. The overlay renders it in a
+ * zero-height hidden sizer so its scrollable width matches the textarea's
+ * even though only a window of lines is mounted (the browser measures the
+ * glyphs itself, so tabs and wide chars expand exactly as in the textarea).
+ * @param lines - the source split into logical lines.
+ * @param tabSize - the editor's tab stop (CSS `tab-size`).
+ * @returns the widest line's text, or `''` for an empty source.
+ */
+export function widestLine(lines: readonly string[], tabSize: number = 8): string {
+  let widest = ''
+  let widestColumns = -1
+  for (const line of lines) {
+    // Cheap upper bound first: no code point exceeds `tabSize` columns (a tab
+    // at column 0), so a short enough line can never dethrone the champion.
+    // 1-column ASCII lines dominate real sources, so this skips most measuring.
+    if (line.length * tabSize <= widestColumns) continue
+    const columns = displayColumns(line, tabSize)
+    if (columns > widestColumns) {
+      widestColumns = columns
+      widest = line
+    }
+  }
+  return widest
+}

--- a/packages/ui-mimir/tests/highlight-window.spec.ts
+++ b/packages/ui-mimir/tests/highlight-window.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Behavior tests for the highlight overlay's windowing helpers: the scroll→
+ * line-window clamping, the token→line split's round-trip invariant, the
+ * display-width heuristic behind the horizontal sizer, and the window's core
+ * performance guarantee — its size stays bounded no matter how large the
+ * document grows.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  displayColumns, EDITOR_LINE_HEIGHT_PX, HIGHLIGHT_OVERSCAN_LINES,
+  splitTokensByLine, visibleLineRange, widestLine,
+} from '../src/client/highlight-window.ts'
+import { tokenizeLatex } from '../src/client/latex-highlight.ts'
+
+/** Join per-line token lists back into lines. */
+function linesOf(lines: readonly { readonly text: string }[][]): string[] {
+  return lines.map(tokens => tokens.map(token => token.text).join(''))
+}
+
+describe('visibleLineRange', () => {
+  const viewportLines = 40
+
+  it('mounts the viewport plus the overscan on both sides', () => {
+    const range = visibleLineRange(100 * EDITOR_LINE_HEIGHT_PX, viewportLines * EDITOR_LINE_HEIGHT_PX, 1000)
+    expect(range).toEqual({ start: 100 - HIGHLIGHT_OVERSCAN_LINES, end: 140 + HIGHLIGHT_OVERSCAN_LINES })
+  })
+
+  it('clamps to the document at both ends', () => {
+    expect(visibleLineRange(0, 500, 1000).start).toBe(0)
+    const tail = visibleLineRange(995 * EDITOR_LINE_HEIGHT_PX, 500, 1000)
+    expect(tail.end).toBe(1000)
+  })
+
+  it('never produces a negative or inverted range for tiny documents', () => {
+    const range = visibleLineRange(0, 800, 5)
+    expect(range).toEqual({ start: 0, end: 5 })
+  })
+
+  it('treats a zero-height viewport (hidden editor) as overscan only', () => {
+    const range = visibleLineRange(50 * EDITOR_LINE_HEIGHT_PX, 0, 1000)
+    expect(range).toEqual({ start: 50 - HIGHLIGHT_OVERSCAN_LINES, end: 50 + HIGHLIGHT_OVERSCAN_LINES })
+  })
+
+  it('keeps the window bounded as the document grows (the perf invariant)', () => {
+    for (const lineCount of [100, 1_000, 10_000, 100_000]) {
+      const range = visibleLineRange(lineCount * EDITOR_LINE_HEIGHT_PX / 2, 800, lineCount)
+      expect(range.end - range.start).toBeLessThanOrEqual(Math.ceil(800 / EDITOR_LINE_HEIGHT_PX) + 2 * HIGHLIGHT_OVERSCAN_LINES)
+    }
+  })
+
+  it('clamps a scroll position past the end of the document', () => {
+    const range = visibleLineRange(999_999, 500, 200)
+    expect(range.start).toBeGreaterThanOrEqual(0)
+    expect(range.end).toBe(200)
+  })
+})
+
+describe('splitTokensByLine', () => {
+  it('reproduces the source line for line (the overlay alignment invariant)', () => {
+    const source = '\\section{Intro} % TODO\nbody $x^2$ more\n\n\\begin{itemize}\n\\end{itemize}\n'
+    expect(linesOf(splitTokensByLine(tokenizeLatex(source)))).toEqual(source.split('\n'))
+  })
+
+  it('splits a multi-line $$ math token at the boundary, preserving its type', () => {
+    const source = 'before $$\na+b\n$$ after'
+    const lines = splitTokensByLine(tokenizeLatex(source))
+    expect(linesOf(lines)).toEqual(source.split('\n'))
+    expect(lines[0]?.at(-1)).toEqual({ type: 'math', text: '$$' })
+    expect(lines[1]).toEqual([{ type: 'math', text: 'a+b' }])
+    expect(lines[2]?.[0]).toEqual({ type: 'math', text: '$$' })
+  })
+
+  it('returns one empty line for empty input and preserves trailing empties', () => {
+    expect(splitTokensByLine([])).toEqual([[]])
+    expect(linesOf(splitTokensByLine(tokenizeLatex('a\n\n')))).toEqual(['a', '', ''])
+  })
+
+  it('handles a 3000-line document without dropping a character', () => {
+    const source = Array.from(
+      { length: 3_200 },
+      (_, i) => `\\subsection{Setup ${i}} % step ${i}\nBody $x_${i}$ with \\textbf{bold} and [opts].`,
+    ).join('\n')
+    expect(linesOf(splitTokensByLine(tokenizeLatex(source)))).toEqual(source.split('\n'))
+  })
+})
+
+describe('displayColumns', () => {
+  it('counts ASCII one column per char', () => {
+    expect(displayColumns('hello world')).toBe(11)
+  })
+
+  it('advances tabs to the next multiple of the tab size', () => {
+    expect(displayColumns('\t', 8)).toBe(8)
+    expect(displayColumns('ab\t', 8)).toBe(8)
+    expect(displayColumns('ab\t', 4)).toBe(4)
+  })
+
+  it('counts East-Asian wide code points double', () => {
+    expect(displayColumns('公式')).toBe(4)
+    expect(displayColumns('a公')).toBe(3)
+  })
+})
+
+describe('widestLine', () => {
+  it('picks the widest line by display columns, not code units', () => {
+    expect(widestLine(['short', 'a much longer ascii line', '中文宽字符'])).toBe('a much longer ascii line')
+    expect(widestLine(['xxxxxxxxxx', '中文字符宽度'])).toBe('中文字符宽度')
+  })
+
+  it('expands tabs like the editor does', () => {
+    expect(widestLine(['aaaaaaa', '\tx'])).toBe('\tx')
+  })
+
+  it("returns '' for an empty source", () => {
+    expect(widestLine([])).toBe('')
+    expect(widestLine([''])).toBe('')
+  })
+})


### PR DESCRIPTION
包含：
- perf(ui): 论文编辑器高亮层与行号 gutter 窗口化渲染（Issue #16, PR #50）——高亮节点 10938→293，按键→高亮中位 25ms→8ms

合并后关闭 #14/#15/#16 并发 v0.2.1。