### PR TITLE
chore: release dsh-client-ui-mimir v0.2.1

### DIFF
--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
UI 包 0.2.0 → 0.2.1：
- 深色原生控件适配 + 键盘导航/ARIA 无障碍（#48）
- 论文编辑器高亮层/gutter 窗口化，大文件性能提升（#50）

dsh-mimir 宿主包无改动，不发新版。合并后打 dsh-client-ui-mimir-v0.2.1 tag。