### PR TITLE
fix(ui-mimir): raise sectionTitle contrast in light mode

### DIFF
--- a/packages/ui-mimir/src/client/ResearchPanel.module.css
+++ b/packages/ui-mimir/src/client/ResearchPanel.module.css
@@ -457,7 +457,7 @@
 
 .sectionTitle {
   margin: 0 0 10px;
-  color: var(--dsw-alias-label-tertiary, #5b6474);
+  color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.06em;


### PR DESCRIPTION
## 问题
浅色模式下 `.sectionTitle`（如服务器页「远程任务」标题）使用三级标签色，落在面板灰色背景上几乎不可见。

## 修复
`label-tertiary` → `label-secondary`（与文件内其他 28 处用法一致），深色模式不变。

## 验证
playwright 截图目检：修复前 computed color rgb(129,133,140) 几乎隐形，修复后 rgb(97,102,107) 清晰可读。