### PR TITLE
feat(mimir): guard experiment status write-back against stale job settles

### DIFF
--- a/packages/mimir/src/services/server.ts
+++ b/packages/mimir/src/services/server.ts
@@ -294,7 +294,8 @@ export async function checkServer(
  * TCP-only record cannot run jobs). A given `experimentId` must name an
  * experiment record (`experiment-not-found`): a linked experiment flips
  * to `running` with the server link on submit, then to
- * `success`/`failed` when the job settles.
+ * `success`/`failed` when the job settles — unless a newer job linked to
+ * the same experiment supersedes the settle.
  * @param deps - open wiki domain.
  * @param state - the service's mutable job counter (incremented here).
  * @param request - the target server, the command line, and the optional
@@ -462,6 +463,12 @@ async function runJob(deps: ServerDeps, id: string): Promise<void> {
  * trailing log excerpt) as the record's `lastJob`, and append one line to
  * the workspace's `EXPERIMENT_LOG.md`. An unlinked or deleted experiment
  * is skipped; the log append is best-effort and never fails the settle.
+ *
+ * Stale-settle guard: when a NEWER job is linked to the same experiment
+ * (submitted after this one, in any status), that job owns the
+ * experiment's state, so this late settle leaves the record untouched and
+ * only lands in the log — otherwise an old job finishing last would flip
+ * the status back over the newer job's write-back.
  * @param deps - open wiki domain plus workspace root.
  * @param job - the settled job record.
  */
@@ -483,6 +490,10 @@ async function writeBackExperiment(deps: ServerDeps, job: JobRecord): Promise<vo
     finishedAt,
     summary: jobSummaryOf(job),
   }
+  if (hasNewerLinkedJob(deps, job)) {
+    await appendExperimentLog(deps, existing.name, outcome).catch(() => {})
+    return
+  }
   await table.put(existing.id, {
     ...existing,
     status: outcome.status === 'succeeded' ? 'success' : 'failed',
@@ -491,6 +502,34 @@ async function writeBackExperiment(deps: ServerDeps, job: JobRecord): Promise<vo
   })
   // Best-effort: a read-only workspace must not break the settle.
   await appendExperimentLog(deps, existing.name, outcome).catch(() => {})
+}
+
+/**
+ * Whether another job linked to the same experiment was submitted after
+ * `job` (compared on `createdAt`, then on the id's sequence suffix —
+ * submits within the same millisecond share a `createdAt`). A deleted
+ * newer record is invisible here; its documented contract is already
+ * "the outcome is written nowhere".
+ * @param deps - open wiki domain.
+ * @param job - the settled job record.
+ * @returns true when a newer linked job supersedes this settle.
+ */
+function hasNewerLinkedJob(deps: ServerDeps, job: JobRecord): boolean {
+  for (const [, other] of deps.domain.table('jobs').entries()) {
+    if (other.id === job.id || other.experimentId !== job.experimentId) continue
+    if (other.createdAt !== job.createdAt) {
+      if (other.createdAt > job.createdAt) return true
+    } else if (jobSeqOf(other.id) > jobSeqOf(job.id)) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Numeric sequence suffix of one job id (`job-<ms>-<seq>`); 0 when absent. */
+function jobSeqOf(id: string): number {
+  const match = /-(\d+)$/.exec(id)
+  return match === null ? 0 : Number(match[1])
 }
 
 /** Non-empty lines kept of one settled job's log summary written back to the experiment. */

--- a/packages/mimir/tests/ssh-jobs.spec.ts
+++ b/packages/mimir/tests/ssh-jobs.spec.ts
@@ -52,8 +52,9 @@ const EXPERIMENT: ExperimentRecord = {
 
 /**
  * Shim a fake `ssh` onto PATH: it echoes the remote command (its last
- * argument) to stdout, writes one stderr line, and exits 3 when the command
- * contains `mimir-fail`.
+ * argument) to stdout, writes one stderr line, sleeps a moment when the
+ * command contains `mimir-slow`, and exits 3 when the command contains
+ * `mimir-fail`.
  * @returns the harness cleanup; PATH restores via `vi.unstubAllEnvs`.
  */
 async function stubFakeSsh(): Promise<void> {
@@ -64,6 +65,7 @@ async function stubFakeSsh(): Promise<void> {
     'echo "fake-ssh stdout: $1"',
     'echo "fake-ssh stderr line" >&2',
     'case "$1" in *mimir-fail*) exit 3 ;; esac',
+    'case "$1" in *mimir-slow*) sleep 0.5 ;; esac',
     'exit 0',
     '',
   ].join('\n')
@@ -198,6 +200,75 @@ describe('ResearchService job lifecycle', () => {
     expect(settled.status).toBe('failed')
     expect(settled.stderrTail).toBeTruthy()
   }, 20_000)
+})
+
+describe('ResearchService linked-experiment stale-settle guard', () => {
+  /** Boot the harness with one server and one linked experiment. */
+  async function linkedHarness() {
+    const { ctx, domain, workspaceDir, service } = await harness()
+    await stubFakeSsh()
+    const created = await service.saveServer({ server: SERVER_INPUT })
+    if (!created.ok) throw new Error('create failed')
+    await domain.table('experiments').put(EXPERIMENT.id, EXPERIMENT)
+    const serverId = created.value.server.id
+    const submit = async (command: string): Promise<JobRecord> => {
+      const submitted = await service.submitJob({ serverId, command, experimentId: EXPERIMENT.id })
+      if (!submitted.ok) throw new Error('submit rejected')
+      return submitted.value.job
+    }
+    return { ctx, domain, workspaceDir, service, submit }
+  }
+
+  it('does not let an old job settling last overwrite the newer job’s write-back', async () => {
+    const { domain, service, workspaceDir, submit } = await linkedHarness()
+    const older = await submit('mimir-slow python train.py --epochs 20')
+    const newer = await submit('python train.py --epochs 1')
+
+    // The newer job settles first and owns the experiment's state.
+    const settledNewer = await settleJob(service, newer.id)
+    expect(settledNewer.status).toBe('succeeded')
+    expect(domain.table('experiments').get(EXPERIMENT.id)).toMatchObject({
+      status: 'success',
+      lastJob: { jobId: newer.id, status: 'succeeded' },
+    })
+
+    // The older job settles late: its outcome lands only in the log, the
+    // record keeps the newer job's status and `lastJob`.
+    const settledOlder = await settleJob(service, older.id)
+    expect(settledOlder.status).toBe('succeeded')
+    // Give the (skipped) write-back a beat to prove it stays skipped.
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(domain.table('experiments').get(EXPERIMENT.id)).toMatchObject({
+      status: 'success',
+      lastJob: { jobId: newer.id, status: 'succeeded' },
+    })
+    const log = await readFile(join(workspaceDir, 'EXPERIMENT_LOG.md'), 'utf8')
+    expect(log).toContain(`job ${newer.id} succeeded`)
+    expect(log).toContain(`job ${older.id} succeeded`)
+  })
+
+  it('does not let an old job settling first flip the status while the newer job still runs', async () => {
+    const { domain, service, submit } = await linkedHarness()
+    const older = await submit('echo mimir-fail')
+    const newer = await submit('mimir-slow python train.py --epochs 20')
+
+    // The older job fails fast; the newer job still runs and owns the
+    // experiment, so the failed settle leaves the record `running`.
+    const settledOlder = await settleJob(service, older.id)
+    expect(settledOlder.status).toBe('failed')
+    await new Promise(resolve => setTimeout(resolve, 100))
+    const midway = domain.table('experiments').get(EXPERIMENT.id)
+    expect(midway?.status).toBe('running')
+    expect(midway?.lastJob).toBeUndefined()
+
+    // The newer job's settle then writes back normally.
+    const settledNewer = await settleJob(service, newer.id)
+    expect(settledNewer.status).toBe('succeeded')
+    expect(domain.table('experiments').get(EXPERIMENT.id)).toMatchObject({
+      status: 'success',
+      lastJob: { jobId: newer.id, status: 'succeeded' },
+    })
+  })
 })
 
 describe('ResearchService.listJobs / deleteJob', () => {


### PR DESCRIPTION
## Motivation

Submitting a remote job with an `experimentId` already flips the linked experiment to `running`, and the settle writes the outcome back (`succeeded` → `success`, otherwise `failed`, plus the `lastJob` outcome record). What was missing: the write-back was unconditional, so when two jobs are linked to the same experiment, the *older* job settling *last* overwrote the newer job's status and `lastJob` — the panel showed the experiment as failed/succeeded based on a superseded run.

## Approach

- `writeBackExperiment` (packages/mimir/src/services/server.ts) now applies a stale-settle guard before touching the experiment record: if the `jobs` table holds another job linked to the same experiment that was submitted *after* this one (compared on `createdAt`, with the job id's sequence suffix `job-<ms>-<seq>` as the tie-break for same-millisecond submits), the newer job owns the experiment's state. The stale settle then leaves `status` and `lastJob` untouched and only appends its line to `EXPERIMENT_LOG.md` (the append-only history stays complete).
- The guard works in both settle orders: old-settles-last can't clobber the newer result, and old-settles-first can't flip the status while the newer job is still running.
- No wiki domain schema change: the guard derives staleness from the runtime-only `jobs` table, so the domain version stays 2 and no new record fields were added.
- No new status vocabulary: the write-back keeps using the existing `ExperimentStatus` (`running`/`success`/`failed`) that the UI already maps.

## Tests

- Two new behavior tests in `packages/mimir/tests/ssh-jobs.spec.ts` (memory-backed domain, fake `ssh` shim extended with a `mimir-slow` branch):
  1. old job settling last does not overwrite the newer job's `success`/`lastJob` (both outcomes still appear in `EXPERIMENT_LOG.md`);
  2. old job failing first leaves the experiment `running` while the newer job still runs, then the newer job's settle writes back normally.
- `npm test`: 464 passed (baseline 462 + 2 new).
- `npx tsc -b packages/mimir packages/ui-mimir`: clean (after `pnpm --filter dsh-mimir run bundle` generates `lib/typert.remote-client.d.ts`, as in the root `build` script).