### PR TITLE
feat(mimir,ui-mimir): staged progress display for the server probe

### DIFF
--- a/packages/mimir/src/services/server.ts
+++ b/packages/mimir/src/services/server.ts
@@ -100,14 +100,15 @@ function probeTcp(host: string, port: number): Promise<TcpProbeOutcome> {
 /** Outcome of the best-effort GPU readout over ssh. */
 type GpuProbeOutcome =
   | { readonly ok: true; readonly gpus: readonly ServerGpuView[] }
-  | { readonly ok: false; readonly message: string }
+  | { readonly ok: false; readonly stage: 'ssh' | 'gpu'; readonly message: string }
 
 /**
  * Read one server's GPU table over a batch-mode ssh call. Best-effort: an ssh
  * or `nvidia-smi` failure is the `ok: false` branch, never a rejection, so the
  * caller can still report the server itself as reachable.
  * @param record - the server to probe (host, port, and login user).
- * @returns the parsed GPU rows, or the failure message.
+ * @returns the parsed GPU rows, or the failure stage (`ssh` session vs `gpu`
+ * readout) plus the failure message.
  */
 async function probeGpus(record: ServerRecord): Promise<GpuProbeOutcome> {
   try {
@@ -137,7 +138,14 @@ async function probeGpus(record: ServerRecord): Promise<GpuProbeOutcome> {
     const stderr = typeof error === 'object' && error !== null && 'stderr' in error
       ? String((error as { stderr: unknown }).stderr).trim()
       : ''
-    return { ok: false, message: stderr !== '' ? stderr : error instanceof Error ? error.message : 'ssh probe failed' }
+    const message = stderr !== '' ? stderr : error instanceof Error ? error.message : 'ssh probe failed'
+    // Stage classification: the ssh client exits 255 when the SESSION itself
+    // failed (connect, auth, or the connect timeout); any other exit code is
+    // the remote command's own status, and a timeout kill / spawn error only
+    // surfaces after the 8s budget — past the 5s connect window — so both
+    // land on the `gpu` stage.
+    const code = (error as { code?: unknown }).code
+    return { ok: false, stage: code === 255 ? 'ssh' : 'gpu', message }
   }
 }
 
@@ -242,7 +250,10 @@ export async function deleteServer(
  * connect (failure settles the view `offline`), then — only when the TCP
  * probe connected and the record names a login user — a batch-mode ssh
  * `nvidia-smi` readout whose failure downgrades the GPU table to empty
- * without flipping the state.
+ * without flipping the state. The settled view reports the stage where the
+ * probe stopped (`stage`: the failed stage on failure, the deepest completed
+ * stage on success) and the per-stage latencies (`tcpLatencyMs`,
+ * `gpuLatencyMs`) so the panel can say which stage hung or failed.
  * @param deps - open wiki domain.
  * @param request - the record id; an unknown id is `server-not-found`.
  * @returns the settled probe view.
@@ -263,6 +274,7 @@ export async function checkServer(
       gpus: Object.freeze([]),
       checkedAt: new Date().toISOString(),
       message: tcp.message,
+      stage: 'tcp',
     })
   }
   if (record.username === '') {
@@ -272,8 +284,11 @@ export async function checkServer(
       gpus: Object.freeze([]),
       checkedAt: new Date().toISOString(),
       message: null,
+      stage: 'tcp',
+      tcpLatencyMs: tcp.latencyMs,
     })
   }
+  const gpuStartedAt = Date.now()
   const gpu = await probeGpus(record)
   return success<ServerStatusView>({
     state: 'online',
@@ -281,6 +296,9 @@ export async function checkServer(
     gpus: gpu.ok ? gpu.gpus : Object.freeze([]),
     checkedAt: new Date().toISOString(),
     message: gpu.ok ? null : `gpu probe failed: ${gpu.message}`,
+    stage: gpu.ok ? 'gpu' : gpu.stage,
+    tcpLatencyMs: tcp.latencyMs,
+    gpuLatencyMs: Date.now() - gpuStartedAt,
   })
 }
 

--- a/packages/mimir/src/types.ts
+++ b/packages/mimir/src/types.ts
@@ -445,6 +445,9 @@ export interface ServerGpuView {
   readonly memoryTotalMb: number
 }
 
+/** One stage of the `checkServer` probe pipeline: TCP connect, ssh session, GPU readout. */
+export type ServerProbeStage = 'tcp' | 'ssh' | 'gpu'
+
 /** The settled outcome of one `checkServer` probe. */
 export interface ServerStatusView {
   /** `online` once the TCP probe connects; the GPU readout is best-effort on top. */
@@ -456,6 +459,16 @@ export interface ServerStatusView {
   readonly checkedAt: string
   /** Failure detail (offline reason or the skipped/failed GPU probe); null when clean. */
   readonly message: string | null
+  /**
+   * Stage where the probe settled: the FAILED stage on failure, the deepest
+   * completed stage on success (`tcp` for a TCP-only record without a login
+   * user). Optional — older hosts omit it.
+   */
+  readonly stage?: ServerProbeStage | undefined
+  /** TCP handshake latency in ms (the stage-wise twin of `latencyMs`); absent when the TCP probe never connected. */
+  readonly tcpLatencyMs?: number | undefined
+  /** Wall-clock ms of the ssh GPU readout; absent when it never ran. */
+  readonly gpuLatencyMs?: number | undefined
 }
 
 /** `listServers` result: every remembered server, most recently updated first. */

--- a/packages/mimir/tests/service.spec.ts
+++ b/packages/mimir/tests/service.spec.ts
@@ -9,7 +9,7 @@
  * sockets — no mocks (the arXiv API itself is stubbed at `fetch`).
  */
 
-import { mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createServer } from 'node:net'
@@ -249,7 +249,7 @@ describe('ResearchService server CRUD', () => {
 })
 
 describe('ResearchService.checkServer', () => {
-  it('settles an unreachable address as offline with the socket message', async () => {
+  it('settles an unreachable address as offline with the socket message, stopped at the tcp stage', async () => {
     const { service } = await harness()
     const created = await service.saveServer({
       server: { ...SERVER_INPUT, host: '127.0.0.1', port: 19999 },
@@ -261,6 +261,9 @@ describe('ResearchService.checkServer', () => {
     expect(checked.value.latencyMs).toBeNull()
     expect(checked.value.gpus).toEqual([])
     expect(checked.value.message).toBeTruthy()
+    expect(checked.value.stage).toBe('tcp')
+    expect(checked.value.tcpLatencyMs).toBeUndefined()
+    expect(checked.value.gpuLatencyMs).toBeUndefined()
     expect(Date.parse(checked.value.checkedAt)).not.toBeNaN()
   })
 
@@ -286,19 +289,23 @@ describe('ResearchService.checkServer', () => {
       expect(checked.value.latencyMs).toBeGreaterThanOrEqual(0)
       expect(checked.value.gpus).toEqual([])
       expect(checked.value.message).toBeNull()
+      expect(checked.value.stage).toBe('tcp')
+      expect(checked.value.tcpLatencyMs).toBeGreaterThanOrEqual(0)
+      expect(checked.value.gpuLatencyMs).toBeUndefined()
     } finally {
       await new Promise<void>((resolveClose) => { listener.close(() => { resolveClose() }) })
     }
   })
 
-  it('keeps a reachable server online when the ssh GPU readout fails', async () => {
+  it('keeps a reachable server online when the ssh session itself fails, stopped at the ssh stage', async () => {
     const listener = createServer((socket) => { socket.destroy() })
     await new Promise<void>((resolveListen) => { listener.listen(0, '127.0.0.1', resolveListen) })
     try {
       const port = (listener.address() as AddressInfo).port
       const { service } = await harness()
       // A username is set, so the probe attempts ssh against a socket that is
-      // not an sshd: the readout fails but the server stays online.
+      // not an sshd: the readout fails (ssh exits 255, a session failure) but
+      // the server stays online.
       const created = await service.saveServer({
         server: { ...SERVER_INPUT, host: '127.0.0.1', port },
       })
@@ -308,11 +315,88 @@ describe('ResearchService.checkServer', () => {
       expect(checked.value.state).toBe('online')
       expect(checked.value.gpus).toEqual([])
       expect(checked.value.message).toContain('gpu probe failed')
+      expect(checked.value.stage).toBe('ssh')
+      expect(checked.value.tcpLatencyMs).toBeGreaterThanOrEqual(0)
+      expect(checked.value.gpuLatencyMs).toBeGreaterThanOrEqual(0)
     } finally {
       await new Promise<void>((resolveClose) => { listener.close(() => { resolveClose() }) })
     }
   }, 20_000)
+
+  it('lands a remote nvidia-smi failure on the gpu stage (non-255 exit)', async () => {
+    const listener = createServer()
+    await new Promise<void>((resolveListen) => { listener.listen(0, '127.0.0.1', resolveListen) })
+    try {
+      const port = (listener.address() as AddressInfo).port
+      await stubFakeSshForGpuProbe()
+      const { service } = await harness()
+      // The fake ssh exits 3 (a remote command failure, not a session
+      // failure) when the login user names the gpu-fail marker.
+      const created = await service.saveServer({
+        server: { ...SERVER_INPUT, host: '127.0.0.1', port, username: 'gpu-fail' },
+      })
+      if (!created.ok) throw new Error('create failed')
+      const checked = await service.checkServer({ id: created.value.server.id })
+      if (!checked.ok) throw new Error('check rejected')
+      expect(checked.value.state).toBe('online')
+      expect(checked.value.gpus).toEqual([])
+      expect(checked.value.message).toContain('gpu probe failed')
+      expect(checked.value.stage).toBe('gpu')
+      expect(checked.value.tcpLatencyMs).toBeGreaterThanOrEqual(0)
+      expect(checked.value.gpuLatencyMs).toBeGreaterThanOrEqual(0)
+    } finally {
+      await new Promise<void>((resolveClose) => { listener.close(() => { resolveClose() }) })
+    }
+  })
+
+  it('reaches the gpu stage with the parsed table when the readout succeeds', async () => {
+    const listener = createServer()
+    await new Promise<void>((resolveListen) => { listener.listen(0, '127.0.0.1', resolveListen) })
+    try {
+      const port = (listener.address() as AddressInfo).port
+      await stubFakeSshForGpuProbe()
+      const { service } = await harness()
+      const created = await service.saveServer({
+        server: { ...SERVER_INPUT, host: '127.0.0.1', port },
+      })
+      if (!created.ok) throw new Error('create failed')
+      const checked = await service.checkServer({ id: created.value.server.id })
+      if (!checked.ok) throw new Error('check rejected')
+      expect(checked.value.state).toBe('online')
+      expect(checked.value.message).toBeNull()
+      expect(checked.value.stage).toBe('gpu')
+      expect(checked.value.gpus).toEqual([
+        { name: 'Fake GPU 0', utilizationPct: 37, memoryUsedMb: 2048, memoryTotalMb: 24576 },
+      ])
+      expect(checked.value.tcpLatencyMs).toBeGreaterThanOrEqual(0)
+      expect(checked.value.gpuLatencyMs).toBeGreaterThanOrEqual(0)
+    } finally {
+      await new Promise<void>((resolveClose) => { listener.close(() => { resolveClose() }) })
+    }
+  })
 })
+
+/**
+ * Shim a fake `ssh` onto PATH for the GPU-stage checkServer tests: it prints
+ * one `nvidia-smi` CSV row, or exits 3 (a remote command failure, distinct
+ * from the ssh session's own 255) when the login user names `gpu-fail`.
+ * PATH restores via `vi.unstubAllEnvs`.
+ */
+async function stubFakeSshForGpuProbe(): Promise<void> {
+  const binDir = await mkdtemp(join(tmpdir(), 'mimir-fake-ssh-gpu-'))
+  const script = [
+    '#!/bin/bash',
+    'for arg in "$@"; do',
+    '  case "$arg" in *gpu-fail@*) echo "nvidia-smi exploded" >&2; exit 3 ;; esac',
+    'done',
+    'echo "Fake GPU 0, 37, 2048, 24576"',
+    'exit 0',
+    '',
+  ].join('\n')
+  await writeFile(join(binDir, 'ssh'), script)
+  await chmod(join(binDir, 'ssh'), 0o755)
+  vi.stubEnv('PATH', `${binDir}:${process.env.PATH ?? ''}`)
+}
 
 const ARXIV_FEED = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -336,7 +420,7 @@ const ARXIV_ENTRY = {
   url: 'https://arxiv.org/abs/2103.00020v2',
 }
 
-afterEach(() => { vi.unstubAllGlobals() })
+afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs() })
 
 describe('parseArxivFeed', () => {
   it('parses entries, unescapes entities, and derives abs urls', () => {

--- a/packages/ui-mimir/src/client/ResearchPanel.module.css
+++ b/packages/ui-mimir/src/client/ResearchPanel.module.css
@@ -3302,3 +3302,19 @@ li.dropIndicator {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* feat/probe-progress: the in-flight probe's staged progress line — the stage
+   label painted in the in-progress (business) color, the worst-case ETA hint
+   in the tertiary label color, and the settled per-stage failure label. */
+.serverProbeStage {
+  color: var(--dsw-alias-state-business-primary, #4176e6);
+}
+
+.serverProbeEta {
+  margin-left: 6px;
+  color: var(--dsw-alias-label-tertiary, #5b6474);
+}
+
+.serverProbeFailStage {
+  font-weight: 600;
+}

--- a/packages/ui-mimir/src/client/ServersView.tsx
+++ b/packages/ui-mimir/src/client/ServersView.tsx
@@ -12,7 +12,7 @@ import type { ExperimentRecord, ServerInput, ServerRecord } from 'dsh-mimir/type
 import type {
   ResearchFailureView, ResearchJobsView, ResearchProjectSlice, ResearchServersView, ServerCheckState,
 } from './controller.ts'
-import { collectServerTags, failureCopy, filterServers, relativeTime, type ResearchT } from './view-common.ts'
+import { collectServerTags, failureCopy, filterServers, PROBE_FAILURE_KEYS, PROBE_STAGE_KEYS, probeStageOf, relativeTime, type ResearchT } from './view-common.ts'
 import { EmptyState } from './EmptyState.tsx'
 import { ViewHead } from './ViewHead.tsx'
 import { JobsSection } from './JobsSection.tsx'
@@ -48,6 +48,28 @@ function dotStateOf(check: ServerCheckState | undefined): string {
   if (check === undefined) return 'unknown'
   if (check === 'checking') return 'checking'
   return check.state
+}
+
+/**
+ * The in-flight probe's staged progress line. The host reports the stage only
+ * once the probe settles, so while it runs the label is inferred from the
+ * elapsed time and the probe's per-stage budgets (TCP 4s → SSH 5s → GPU
+ * readout), with a worst-case ETA hint. The interval only ticks while this
+ * line is mounted (i.e. while the card's probe is in flight).
+ */
+function ProbeProgressLine({ t }: { readonly t: ResearchT }) {
+  const [elapsedMs, setElapsedMs] = useState(0)
+  useEffect(() => {
+    const startedAt = Date.now()
+    const timer = setInterval(() => { setElapsedMs(Date.now() - startedAt) }, 250)
+    return () => { clearInterval(timer) }
+  }, [])
+  return (
+    <>
+      <span className={css.serverProbeStage} role="status">{t(PROBE_STAGE_KEYS[probeStageOf(elapsedMs)])}</span>
+      <span className={css.serverProbeEta}>{t('servers.probe.eta')}</span>
+    </>
+  )
 }
 
 /**
@@ -343,7 +365,7 @@ export function ServersView({
                 )}
                 <p className={css.serverProbe}>
                   {settled === null
-                    ? checking ? t('servers.state.checking') : t('servers.neverChecked')
+                    ? checking ? <ProbeProgressLine t={t} /> : t('servers.neverChecked')
                     : (
                       <>
                         {settled.latencyMs !== null && <span>{settled.latencyMs} ms · </span>}
@@ -352,7 +374,12 @@ export function ServersView({
                     )}
                 </p>
                 {settled !== null && settled.message !== null && (
-                  <p className={css.serverMessage} role="status">{settled.message}</p>
+                  <p className={css.serverMessage} role="status">
+                    {settled.stage !== undefined && (
+                      <span className={css.serverProbeFailStage}>{t(PROBE_FAILURE_KEYS[settled.stage])}：</span>
+                    )}
+                    {settled.message}
+                  </p>
                 )}
                 {settled !== null && settled.state === 'online' && (
                   settled.gpus.length === 0 ? (

--- a/packages/ui-mimir/src/client/locales.ts
+++ b/packages/ui-mimir/src/client/locales.ts
@@ -363,6 +363,14 @@ export const zh = {
   'time.hoursAgo': '小时前',
   'time.daysAgo': '天前',
   'error.retry': '重试',
+  // feat/probe-progress: staged server probe progress labels and per-stage failure labels.
+  'servers.probe.stage.tcp': 'TCP 连通性探测…',
+  'servers.probe.stage.ssh': 'SSH 连接…',
+  'servers.probe.stage.gpu': '读取 GPU 占用…',
+  'servers.probe.eta': '最长约 17 秒',
+  'servers.probe.fail.tcp': 'TCP 不可达',
+  'servers.probe.fail.ssh': 'SSH 连接或认证失败',
+  'servers.probe.fail.gpu': 'GPU 读取失败',
 } satisfies Record<string, string>
 
 /** The research namespace key union. */
@@ -738,4 +746,12 @@ export const en = {
   'time.hoursAgo': 'h ago',
   'time.daysAgo': 'd ago',
   'error.retry': 'Retry',
+  // feat/probe-progress: staged server probe progress labels and per-stage failure labels.
+  'servers.probe.stage.tcp': 'Probing TCP reachability…',
+  'servers.probe.stage.ssh': 'Connecting over SSH…',
+  'servers.probe.stage.gpu': 'Reading GPU usage…',
+  'servers.probe.eta': 'up to ~17 s',
+  'servers.probe.fail.tcp': 'TCP unreachable',
+  'servers.probe.fail.ssh': 'SSH connection or auth failed',
+  'servers.probe.fail.gpu': 'GPU readout failed',
 } satisfies Record<ResearchKey, string>

--- a/packages/ui-mimir/src/client/view-common.ts
+++ b/packages/ui-mimir/src/client/view-common.ts
@@ -4,7 +4,8 @@
  * the figure route
  * URL builder, the experiments comparison-chart helpers (numeric metric
  * keys, chart rows, bar widths, value formatting), the library tag
- * collection/filter helpers, and the figure-upload drop filter
+ * collection/filter helpers, the server probe stage inference
+ * ({@link probeStageOf}), and the figure-upload drop filter
  * ({@link filterDropFiles}). No JSX, no subscriptions.
  * @module dsh-client-ui-mimir/client/view-common
  */
@@ -370,6 +371,42 @@ export function collectServerTags(servers: readonly ServerRecord[]): string[] {
   const tags = new Set<string>()
   for (const server of servers) for (const tag of server.tags) tags.add(tag)
   return [...tags].sort()
+}
+
+/** One stage of the server probe pipeline (mirrors `ServerProbeStage` of dsh-mimir). */
+export type ProbeStage = 'tcp' | 'ssh' | 'gpu'
+
+/** End of the TCP stage's time window in ms (the host's TCP probe timeout). */
+export const PROBE_TCP_WINDOW_MS = 4000
+/**
+ * End of the SSH stage's time window in ms: the TCP budget plus the ssh
+ * connect timeout (4s + 5s). Past this the probe is reading the GPU table.
+ */
+export const PROBE_SSH_WINDOW_MS = 9000
+
+/**
+ * The probe stage the panel should DISPLAY after `elapsedMs` of an in-flight
+ * probe, derived from the host's per-stage timeouts (pure client-side
+ * inference — the host only reports the stage once the probe settles).
+ */
+export function probeStageOf(elapsedMs: number): ProbeStage {
+  if (elapsedMs < PROBE_TCP_WINDOW_MS) return 'tcp'
+  if (elapsedMs < PROBE_SSH_WINDOW_MS) return 'ssh'
+  return 'gpu'
+}
+
+/** Locale key of one in-flight probe stage's progress label. */
+export const PROBE_STAGE_KEYS: Record<ProbeStage, ResearchKey> = {
+  tcp: 'servers.probe.stage.tcp',
+  ssh: 'servers.probe.stage.ssh',
+  gpu: 'servers.probe.stage.gpu',
+}
+
+/** Locale key of one settled probe's per-stage failure label (the host's `stage`). */
+export const PROBE_FAILURE_KEYS: Record<ProbeStage, ResearchKey> = {
+  tcp: 'servers.probe.fail.tcp',
+  ssh: 'servers.probe.fail.ssh',
+  gpu: 'servers.probe.fail.gpu',
 }
 
 /** Filter the server list by one active tag; a null selector passes everything. */

--- a/packages/ui-mimir/tests/probe-progress.spec.ts
+++ b/packages/ui-mimir/tests/probe-progress.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Behavior tests for the server probe stage inference behind the servers
+ * view's staged progress line: the elapsed-time → stage derivation and the
+ * locale key maps for the in-flight stages and the settled failure stages.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  PROBE_FAILURE_KEYS, PROBE_STAGE_KEYS, PROBE_SSH_WINDOW_MS, PROBE_TCP_WINDOW_MS, probeStageOf,
+} from '../src/client/view-common.ts'
+import { zh } from '../src/client/locales.ts'
+
+describe('probeStageOf', () => {
+  it('shows the TCP stage inside the TCP budget (0–4s)', () => {
+    expect(probeStageOf(0)).toBe('tcp')
+    expect(probeStageOf(PROBE_TCP_WINDOW_MS - 1)).toBe('tcp')
+  })
+
+  it('shows the SSH stage between the TCP and SSH budgets (4–9s)', () => {
+    expect(probeStageOf(PROBE_TCP_WINDOW_MS)).toBe('ssh')
+    expect(probeStageOf(PROBE_SSH_WINDOW_MS - 1)).toBe('ssh')
+  })
+
+  it('shows the GPU stage past the SSH budget (9s+), however long it runs', () => {
+    expect(probeStageOf(PROBE_SSH_WINDOW_MS)).toBe('gpu')
+    expect(probeStageOf(60_000)).toBe('gpu')
+  })
+})
+
+describe('probe stage locale keys', () => {
+  it('covers every stage in both the progress and the failure key maps', () => {
+    expect(Object.keys(PROBE_STAGE_KEYS).sort()).toEqual(['gpu', 'ssh', 'tcp'])
+    expect(Object.keys(PROBE_FAILURE_KEYS).sort()).toEqual(['gpu', 'ssh', 'tcp'])
+  })
+
+  it('points at keys that exist in the dictionaries', () => {
+    for (const key of Object.values(PROBE_STAGE_KEYS)) expect(zh[key]).toBeTruthy()
+    for (const key of Object.values(PROBE_FAILURE_KEYS)) expect(zh[key]).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## 背景

服务器卡片点「探测」后只显示一行不变的「探测中…」，最坏约 17 秒（TCP 4s + SSH 连接 5s + nvidia-smi 8s），用户无法区分「慢」和「卡死」。

## 改动

**宿主端（packages/mimir）**
- `ServerStatusView` 新增三个 **optional** wire 字段（向后兼容，wiki schema 保持 version 2，ServerRecord 未动）：
  - `stage?: 'tcp' | 'ssh' | 'gpu'` — 探测停在哪一阶段：失败时是失败的阶段，成功时是最深完成阶段（无登录用户的 TCP-only 记录为 `'tcp'`）
  - `tcpLatencyMs?: number` — TCP 握手延迟
  - `gpuLatencyMs?: number` — ssh GPU 读取的墙钟耗时
- 失败阶段分类规则：ssh 客户端自身退出码 **255**（连接/认证/连接超时失败）→ `'ssh'`；其他退出码（远端 nvidia-smi 自身的失败）及超时 kill → `'gpu'`。

**UI（packages/ui-mimir）**
- 探测进行中：按耗时推演阶段文案（纯客户端推演，`probeStageOf`）：0–4s「TCP 连通性探测…」→ 4–9s「SSH 连接…」→ 9s+「读取 GPU 占用…」，旁边常显「最长约 17 秒」预期提示；250ms interval 仅在该行挂载时 tick。
- 探测失败：错误行前加阶段标签（「TCP 不可达」「SSH 连接或认证失败」「GPU 读取失败」），后接宿主原始 message。
- 新文案 7 个 key 中英双语，集中在 locales 两个字典末尾的 `feat/probe-progress` 注释块；CSS 新规则集中在文件末尾注释块，颜色全部走 `var(--dsw-*, 兜底)`，深浅色通用。

## 验证

- `npm test`：498 全绿（基线 491 + 新增 7：宿主 2、UI 5）
- `npx tsc -b packages/mimir`、（bundle 后）`npx tsc -b packages/ui-mimir` 均无错
- 宿主端单测覆盖：TCP 失败 → `stage:'tcp'`、TCP-only 成功 → `'tcp'`、ssh 会话失败（真实 socket 非 sshd，exit 255）→ `'ssh'`、远端命令失败（fake ssh exit 3）→ `'gpu'`、读取成功 → `'gpu'` + 解析出的 GPU 表

Co-authored-by: 1692775560 <1692775560@users.noreply.github.com>