### PR TITLE
chore: bump versions to 0.6.0 for release

### DIFF
--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release v0.6.0: arXiv 订阅检新、阅读笔记、探测进度、论文快照、实验状态防覆盖、浅色对比度修复、新演示视频。