### PR TITLE
feat(ui-mimir): restyle the workbench in a restrained Linear-like vis…

### DIFF
--- a/packages/ui-mimir/src/client/ResearchPanel.module.css
+++ b/packages/ui-mimir/src/client/ResearchPanel.module.css
@@ -1,17 +1,20 @@
-/* Research workbench overlay: a wide window over the app frame. The theme's
-   bg-layer tokens are all pure white in light mode, so depth comes from the
-   tinted content well (`--dsw-alias-markdown-code-block`, neutral-50) with
-   white cards floating on it; every token read carries a light-mode fallback
-   so the window reads as a tool, not a blank sheet. The shell.overlay layer
-   is click-through: the backdrop stays pointer-transparent and only the
-   workbench itself opts back into pointer events. */
+/* Research workbench overlay: a wide window over the app frame. The visual
+   language follows the restrained Linear/Vercel idiom: a flat neutral content
+   well (`--mimir-well`) with white cards floating on 1px hairline borders and
+   near-invisible shadows — no tint gradients, no heavy elevation. Depth and
+   accent color live in the panel-private `--mimir-*` tokens below; the dark
+   override re-tunes them independently (not a simple inversion). Every theme
+   color read carries a light-mode fallback so the window reads as a tool even
+   when the host tokens are absent. The shell.overlay layer is click-through:
+   the backdrop stays pointer-transparent and only the workbench itself opts
+   back into pointer events. */
 
 .backdrop {
   position: fixed;
   inset: 0;
   z-index: -1;
-  background: rgb(10 18 38 / 42%);
-  backdrop-filter: blur(5px) saturate(0.9);
+  background: rgb(15 23 42 / 36%);
+  backdrop-filter: blur(4px) saturate(0.9);
   pointer-events: none;
 }
 
@@ -24,12 +27,12 @@
   height: 95vh;
   display: flex;
   border: 1px solid rgb(255 255 255 / 38%);
-  border-radius: 22px;
+  border-radius: 16px;
   background: var(--dsw-specific-menu, #fff);
   box-shadow:
-    0 0 1px rgb(0 0 0 / 12%),
-    0 16px 40px rgb(15 23 42 / 14%),
-    0 40px 100px rgb(15 23 42 / 25%);
+    0 0 1px rgb(0 0 0 / 10%),
+    0 12px 32px rgb(15 23 42 / 12%),
+    0 32px 80px rgb(15 23 42 / 20%);
   pointer-events: auto;
   overflow: hidden;
   /* Native widgets (select popups, checkboxes, scrollbars) follow the light
@@ -38,10 +41,19 @@
   --dsh-scrollbar-thumb: var(--dsw-alias-scrollbar-bg-l2);
   --dsh-scrollbar-thumb-hover: var(--dsw-alias-scrollbar-hover-l2);
   --mimir-accent: #4f7cff;
-  --mimir-accent-strong: #315fe9;
-  --mimir-accent-soft: rgb(79 124 255 / 12%);
+  --mimir-accent-strong: #3b63e0;
+  --mimir-accent-soft: rgb(79 124 255 / 10%);
   --mimir-violet: #7758e8;
-  --mimir-card-shadow: 0 1px 2px rgb(15 23 42 / 4%), 0 10px 30px rgb(45 66 110 / 7%);
+  /* Hairline borders, the flat content well, and the card elevation scale.
+     Cards: 1px hairline + a 2px whisper shadow; hover only deepens the
+     border and lifts the shadow one step — no translate, no glow. */
+  --mimir-hairline: var(--dsw-alias-border-l1, rgb(15 23 42 / 8%));
+  --mimir-hairline-strong: var(--dsw-alias-border-l2, rgb(15 23 42 / 13%));
+  --mimir-well: #f7f8f9;
+  --mimir-radius-card: 12px;
+  --mimir-radius-inner: 10px;
+  --mimir-card-shadow: 0 1px 2px rgb(15 23 42 / 4%);
+  --mimir-card-shadow-hover: 0 1px 2px rgb(15 23 42 / 5%), 0 6px 16px rgb(15 23 42 / 7%);
 }
 
 /* Left rail: brand head + pill nav + the project picker at the bottom.
@@ -53,17 +65,15 @@
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  border-right: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  background:
-    radial-gradient(circle at 0 0, rgb(79 124 255 / 11%), transparent 34%),
-    linear-gradient(180deg, var(--dsw-specific-menu, #fff), var(--dsw-specific-menu, #fff));
+  border-right: 1px solid var(--mimir-hairline);
+  background: var(--dsw-specific-menu, #fff);
 }
 
 .sideHead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 16px 18px;
+  padding: 16px 16px 14px;
 }
 
 .brand {
@@ -76,17 +86,17 @@
 .brandMark {
   display: inline-flex;
   flex: 0 0 auto;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   align-items: center;
   justify-content: center;
   border: 1px solid rgb(255 255 255 / 38%);
-  border-radius: 11px;
+  border-radius: 9px;
   background: linear-gradient(145deg, var(--mimir-accent), var(--mimir-violet));
-  box-shadow: 0 7px 18px rgb(79 124 255 / 28%);
+  box-shadow: 0 2px 8px rgb(79 124 255 / 22%);
   color: #fff;
-  font-size: 15px;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 700;
   letter-spacing: -0.03em;
 }
 
@@ -111,30 +121,30 @@
   align-items: center;
   gap: 8px;
   color: var(--dsw-alias-label-primary, #17233d);
-  font-size: 16px;
-  font-weight: 750;
-  letter-spacing: 0.01em;
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
 }
 
 .close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   padding: 0;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 9px;
-  background: var(--dsw-specific-menu, #fff);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
   color: var(--dsw-alias-label-tertiary, #5b6474);
-  font-size: 18px;
+  font-size: 17px;
   line-height: 1;
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .close:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
   color: var(--dsw-alias-label-secondary, #3c4557);
 }
 
@@ -152,14 +162,14 @@
   width: 26px;
   height: 26px;
   padding: 0;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 8px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
 .iconButton svg {
@@ -168,14 +178,15 @@
 }
 
 .iconButton:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
   color: var(--dsw-alias-label-secondary, #3c4557);
 }
 
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 2px;
   padding: 4px 12px 16px;
 }
 
@@ -183,11 +194,11 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 9px;
-  height: 40px;
-  padding: 0 12px 0 14px;
+  gap: 8px;
+  height: 32px;
+  padding: 0 10px 0 14px;
   border: none;
-  border-radius: 12px;
+  border-radius: 7px;
   background: transparent;
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 13px;
@@ -234,18 +245,18 @@
 }
 
 .navItem:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .navItem[data-active] {
-  background: linear-gradient(90deg, rgb(79 124 255 / 16%), rgb(119 88 232 / 8%));
+  background: var(--mimir-accent-soft);
   color: var(--mimir-accent-strong);
-  font-weight: 600;
+  font-weight: 550;
 }
 
 .navItem[data-active] .navCount {
   background: var(--dsw-specific-menu, #fff);
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  color: var(--mimir-accent-strong);
 }
 
 /* One visible focus ring for every keyboard-reachable control in the panel.
@@ -273,6 +284,7 @@
 .paperTab:focus-visible,
 .toastClose:focus-visible,
 .serverSelect:focus-visible,
+.serverMessage:focus-visible,
 .paperCardTitle a:focus-visible,
 .experimentLog a:focus-visible,
 .projectCheck input:focus-visible {
@@ -291,25 +303,24 @@
   background: var(--dsw-alias-state-business-primary, #4176e6);
 }
 
-/* The 3px accent bar on the active tab's left edge. */
+/* The 2px accent bar on the active tab's left edge — solid, no glow. */
 .navItem[data-active]::before {
   content: '';
   position: absolute;
   left: 3px;
-  top: 7px;
-  bottom: 7px;
-  width: 3px;
-  border-radius: 2px;
-  background: linear-gradient(180deg, var(--mimir-accent), var(--mimir-violet));
-  box-shadow: 0 2px 8px rgb(79 124 255 / 35%);
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--mimir-accent);
 }
 
 /* Unified view header: title + subtitle on the left, actions on the right. */
 .viewHead {
   display: flex;
   align-items: center;
-  padding: 2px 2px 8px;
-  border-bottom: 1px solid var(--dsw-alias-border-l1, rgb(15 23 42 / 6%));
+  padding: 0 2px 12px;
+  border-bottom: 1px solid var(--mimir-hairline);
   justify-content: space-between;
   gap: 16px;
   width: 100%;
@@ -318,23 +329,22 @@
 .viewHeadText {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   min-width: 0;
 }
 
 .viewTitle {
   margin: 0;
   color: var(--dsw-alias-label-primary, #17233d);
-  font-size: 21px;
-  font-weight: 750;
-  letter-spacing: -0.02em;
-  letter-spacing: 0.01em;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .viewSubtitle {
   margin: 0;
-  /* label-tertiary is too faint against the content well's tinted gradient;
-     secondary keeps the hierarchy while staying readable. */
+  /* label-tertiary is too faint against the content well; secondary keeps
+     the hierarchy while staying readable. */
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
   line-height: 1.5;
@@ -347,16 +357,17 @@
   gap: 8px;
 }
 
-/* The two button faces: `btn` is the outlined secondary, `btnPrimary` the
-   solid primary. The `data-danger` flag paints a destructive secondary. */
+/* The two button faces: `btn` is the hairline-bordered ghost secondary,
+   `btnPrimary` the solid accent primary. The `data-danger` flag paints a
+   destructive text button — red ink, never a red fill. */
 .btn,
 .btnPrimary {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 30px;
-  padding: 0 14px;
-  border-radius: 9px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 7px;
   font-size: 12.5px;
   font-weight: 500;
   cursor: pointer;
@@ -364,14 +375,14 @@
 }
 
 .btn {
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border: 1px solid var(--mimir-hairline);
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
 }
 
 .btn:hover:not(:disabled) {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 4%));
   color: var(--dsw-alias-label-primary, #17233d);
 }
 
@@ -380,20 +391,20 @@
 }
 
 .btn[data-danger]:hover:not(:disabled) {
-  border-color: var(--dsw-alias-state-error-secondary, rgb(236 19 19 / 30%));
-  background: var(--dsw-alias-state-error-secondary, rgb(236 19 19 / 8%));
+  border-color: var(--dsw-alias-state-error-secondary, rgb(236 19 19 / 24%));
+  background: var(--dsw-alias-state-error-secondary, rgb(236 19 19 / 6%));
 }
 
 .btnPrimary {
   border: 1px solid transparent;
-  background: linear-gradient(135deg, var(--mimir-accent), var(--mimir-accent-strong));
+  background: var(--mimir-accent);
   color: var(--dsw-alias-label-primary-foreground, #fff);
-  box-shadow: 0 2px 6px rgb(65 118 230 / 25%);
+  box-shadow: 0 1px 2px rgb(15 23 42 / 10%);
 }
 
 .btnPrimary:hover:not(:disabled) {
-  background: var(--dsw-alias-button-primary-hover, #2f5fd0);
-  box-shadow: 0 4px 10px rgb(65 118 230 / 30%);
+  background: var(--mimir-accent-strong);
+  box-shadow: 0 1px 2px rgb(15 23 42 / 12%);
 }
 
 .btn:disabled,
@@ -417,18 +428,19 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  padding: 14px 16px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 15px;
+  padding: 12px 16px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
   box-shadow: var(--mimir-card-shadow);
 }
 
 .statValue {
-  color: var(--dsw-alias-state-business-primary, #4176e6);
-  font-size: 22px;
-  font-weight: 750;
+  color: var(--dsw-alias-label-primary, #17233d);
+  font-size: 20px;
+  font-weight: 650;
   font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
 }
 
 .statLabel {
@@ -441,15 +453,14 @@
   min-height: 0;
   overflow-y: auto;
   padding: 12px;
-  border-top: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
-  background: rgb(79 124 255 / 3%);
+  border-top: 1px solid var(--mimir-hairline);
 }
 
 /* The rail's bottom line: the keyboard-shortcut hint. */
 .sideFoot {
   margin: 0;
   padding: 10px 16px;
-  border-top: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
+  border-top: 1px solid var(--mimir-hairline);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 11px;
   line-height: 1.5;
@@ -457,10 +468,10 @@
 
 .sectionTitle {
   margin: 0 0 10px;
-  color: var(--dsw-alias-label-secondary, #3c4557);
+  color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.03em;
 }
 
 .hint {
@@ -469,29 +480,41 @@
   line-height: 1.6;
 }
 
+/* Inline failure line: a small error dot plus quiet red text — no filled
+   banner. Rows may carry a retry button at the end. */
 .failure {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--dsw-alias-label-tertiary, #5b6474);
-  font-size: 13px;
+  color: var(--dsw-alias-state-error-primary, #d93026);
+  font-size: 12.5px;
   line-height: 1.6;
 }
 
+.failure::before {
+  content: '';
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentcolor;
+}
+
 .retry {
-  height: 26px;
-  padding: 0 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 13px;
+  height: 24px;
+  padding: 0 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 999px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .retry:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .projectList {
@@ -507,7 +530,7 @@
   width: 100%;
   padding: 7px 10px;
   border: 1px solid transparent;
-  border-radius: 10px;
+  border-radius: 8px;
   background: transparent;
   text-align: left;
   cursor: pointer;
@@ -515,13 +538,13 @@
 }
 
 .projectRow:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .projectRow[data-selected] {
-  border-color: rgb(79 124 255 / 24%);
+  border-color: var(--mimir-hairline);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 6px 18px rgb(45 66 110 / 8%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 /* Project titles wrap to two lines before clamping, so a long title like a
@@ -544,8 +567,9 @@
   font-size: 12px;
 }
 
-/* The content well: tinted, so the white cards carry the hierarchy. Flex
-   column so the paper view stretches to the full workbench height. */
+/* The content well: a flat quiet neutral so the white hairline cards carry
+   the hierarchy. Flex column so the paper view stretches to the full
+   workbench height. */
 .content {
   flex: 1;
   min-width: 0;
@@ -553,11 +577,8 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  padding: 28px 34px;
-  background:
-    radial-gradient(circle at 92% 0, rgb(119 88 232 / 8%), transparent 28%),
-    radial-gradient(circle at 25% 0, rgb(79 124 255 / 7%), transparent 25%),
-    var(--dsw-alias-interactive-bg-hover, #f5f7fb);
+  padding: 24px 32px;
+  background: var(--mimir-well);
 }
 
 /* Shared empty state: a centered dashed card with a glyph and copy. */
@@ -568,8 +589,8 @@
   justify-content: center;
   gap: 8px;
   padding: 48px 24px;
-  border: 1.5px dashed var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  border-radius: 12px;
+  border: 1px dashed var(--mimir-hairline-strong);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 13px;
@@ -593,26 +614,27 @@
 }
 
 .overviewCard {
-  padding: 28px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 18px;
+  padding: 20px 24px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
   box-shadow: var(--mimir-card-shadow);
 }
 
 .overviewTitle {
-  margin: 0 0 16px;
+  margin: 0 0 14px;
   color: var(--dsw-alias-label-primary, #17233d);
-  font-size: 20px;
-  font-weight: 720;
+  font-size: 16px;
+  font-weight: 600;
   line-height: 1.4;
+  letter-spacing: -0.01em;
 }
 
 .stageBar {
   display: flex;
   gap: 4px;
-  margin: 0 0 20px;
-  padding: 5px;
+  margin: 0 0 16px;
+  padding: 4px;
   list-style: none;
   border-radius: 999px;
   background: var(--dsw-alias-markdown-code-block, #f1f3f5);
@@ -620,7 +642,7 @@
 
 .stageStep {
   flex: 1;
-  padding: 7px 0;
+  padding: 6px 0;
   border-radius: 999px;
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 12px;
@@ -629,24 +651,23 @@
 }
 
 .stageStep[data-reached] {
-  background: var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 12%));
   color: var(--dsw-alias-state-business-primary, #4176e6);
 }
 
 .stageStep[data-current] {
-  background: linear-gradient(135deg, var(--mimir-accent), var(--mimir-violet));
-  color: var(--dsw-alias-label-primary-foreground, #fff);
+  background: var(--dsw-specific-menu, #fff);
+  color: var(--mimir-accent-strong);
   font-weight: 600;
-  box-shadow: 0 2px 6px rgb(65 118 230 / 35%);
+  box-shadow: 0 1px 2px rgb(15 23 42 / 8%);
 }
 
 .overviewMeta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 12px 24px;
-  margin: 0 0 20px;
-  padding: 16px;
-  border-radius: 12px;
+  margin: 0 0 16px;
+  padding: 14px 16px;
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
 }
 
@@ -672,8 +693,8 @@
 }
 
 .artifactList li {
-  padding: 3px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  padding: 2px 10px;
+  border: 1px solid var(--mimir-hairline);
   border-radius: 999px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
@@ -683,9 +704,9 @@
 /* Overview recent activity: two columns — the latest remote jobs and the
    latest experiment runs — filling the overview's lower half. */
 .activitySection {
-  padding: 24px 28px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 18px;
+  padding: 20px 24px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
   box-shadow: var(--mimir-card-shadow);
 }
@@ -716,13 +737,13 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 10px;
-  border-radius: 9px;
+  padding: 6px 8px;
+  border-radius: 7px;
   transition: background-color 0.15s ease;
 }
 
 .activityItem:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .activityName {
@@ -773,11 +794,11 @@
   flex: 0 0 200px;
   min-height: 0;
   overflow-y: auto;
-  padding: 14px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 /* Collapsed rail: just a slim strip carrying the expand button. */
@@ -806,7 +827,7 @@
 }
 
 .railToggle:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .railHead {
@@ -848,7 +869,7 @@
 }
 
 .outlineItem:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .outlineLine {
@@ -936,10 +957,10 @@ li.dropIndicator {
   flex-direction: column;
   gap: 10px;
   padding: 14px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 12px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 /* Editor gets 3 shares, preview 2 — the source is the primary surface. The
@@ -969,7 +990,7 @@ li.dropIndicator {
   position: absolute;
   inset: 0 5px;
   border-radius: 1px;
-  background: var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  background: var(--mimir-hairline-strong);
   content: '';
   transition: background-color 0.15s ease;
 }
@@ -1017,8 +1038,8 @@ li.dropIndicator {
 }
 
 .savePill {
-  padding: 3px 12px;
-  border: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
+  padding: 2px 10px;
+  border: 1px solid var(--mimir-hairline);
   border-radius: 999px;
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
   color: var(--dsw-alias-label-tertiary, #5b6474);
@@ -1050,8 +1071,9 @@ li.dropIndicator {
   gap: 8px;
   margin: 0;
   padding: 8px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-left: 2px solid var(--dsw-alias-state-warn-label, #b25000);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
   color: var(--dsw-alias-label-primary, #17233d);
   font-size: 12px;
@@ -1063,8 +1085,8 @@ li.dropIndicator {
   display: flex;
   flex: 1;
   min-height: 0;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
   overflow: hidden;
 }
@@ -1073,7 +1095,7 @@ li.dropIndicator {
   flex: 0 0 auto;
   padding: 10px 8px;
   overflow: hidden;
-  border-right: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
+  border-right: 1px solid var(--mimir-hairline);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-family: var(--dsw-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: 13px;
@@ -1185,22 +1207,21 @@ li.dropIndicator {
 }
 
 .compileButton {
-  height: 30px;
-  padding: 0 16px;
+  height: 28px;
+  padding: 0 14px;
   border: none;
-  border-radius: 15px;
-  background: var(--dsw-alias-button-primary-fill, #4176e6);
+  border-radius: 7px;
+  background: var(--mimir-accent);
   color: var(--dsw-alias-label-primary-foreground, #fff);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgb(65 118 230 / 30%);
+  box-shadow: 0 1px 2px rgb(15 23 42 / 10%);
   transition: background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .compileButton:hover:not(:disabled) {
-  background: var(--dsw-alias-button-primary-hover, #2f5fd0);
-  box-shadow: 0 4px 10px rgb(65 118 230 / 35%);
+  background: var(--mimir-accent-strong);
 }
 
 .compileButton:disabled {
@@ -1239,8 +1260,8 @@ li.dropIndicator {
   gap: 8px;
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
@@ -1252,8 +1273,8 @@ li.dropIndicator {
 }
 
 .issue:hover:not(:disabled) {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
+  border-color: var(--mimir-hairline-strong);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .issue:disabled {
@@ -1275,9 +1296,9 @@ li.dropIndicator {
 .issueFix {
   flex-shrink: 0;
   align-self: center;
-  padding: 4px 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 8px;
+  padding: 3px 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-state-business-primary, #4176e6);
   font-size: 12px;
@@ -1371,8 +1392,8 @@ li.dropIndicator {
   flex: 1;
   min-height: 0;
   width: 100%;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
 }
 
@@ -1385,8 +1406,8 @@ li.dropIndicator {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border: 1.5px dashed var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  border-radius: 10px;
+  border: 1px dashed var(--mimir-hairline-strong);
+  border-radius: var(--mimir-radius-inner);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 13px;
 }
@@ -1411,18 +1432,17 @@ li.dropIndicator {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 18px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 17px;
+  padding: 16px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
   box-shadow: var(--mimir-card-shadow);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  transition: box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
 .paperCard:hover {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  box-shadow: 0 16px 36px rgb(45 66 110 / 12%);
-  transform: translateY(-2px);
+  border-color: var(--mimir-hairline-strong);
+  box-shadow: var(--mimir-card-shadow-hover);
 }
 
 .paperCardTitle {
@@ -1471,7 +1491,7 @@ li.dropIndicator {
 .paperNotes {
   margin: 0;
   padding: 8px 12px;
-  border-radius: 10px;
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
@@ -1491,8 +1511,8 @@ li.dropIndicator {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  padding: 1px 9px;
+  border: 1px solid var(--mimir-hairline);
   border-radius: 999px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
@@ -1503,13 +1523,14 @@ li.dropIndicator {
 }
 
 .tagPill:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 4%));
 }
 
 .tagPill[data-active] {
-  border-color: var(--dsw-alias-state-business-primary, #4176e6);
-  background: var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 12%));
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  border-color: transparent;
+  background: var(--mimir-accent-soft);
+  color: var(--mimir-accent-strong);
 }
 
 .tagPill[data-kind='project'] {
@@ -1572,8 +1593,8 @@ li.dropIndicator {
   flex-direction: column;
   gap: 8px;
   padding: 10px 12px;
-  border: 1px dashed var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  border-radius: 10px;
+  border: 1px dashed var(--mimir-hairline-strong);
+  border-radius: var(--mimir-radius-inner);
 }
 
 .paperEditorLabel {
@@ -1642,11 +1663,11 @@ li.dropIndicator {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 16px 18px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .papersResults {
@@ -1660,8 +1681,8 @@ li.dropIndicator {
   flex-direction: column;
   gap: 6px;
   padding: 12px 14px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
 }
 
 .paperResultHead {
@@ -1704,15 +1725,15 @@ li.dropIndicator {
 
 .paperPdfActions .btn[data-active] {
   border-color: transparent;
-  background: var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 15%));
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  background: var(--mimir-accent-soft);
+  color: var(--mimir-accent-strong);
 }
 
 .paperPdfFrame {
   width: 100%;
   height: 480px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-specific-menu, #fff);
 }
 
@@ -1729,14 +1750,14 @@ li.dropIndicator {
 .experimentTableWrap,
 .metricCharts,
 .experimentLog {
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .experimentTableWrap {
-  padding: 16px 18px;
+  padding: 16px;
   overflow-x: auto;
 }
 
@@ -1749,21 +1770,22 @@ li.dropIndicator {
   border-collapse: collapse;
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 13px;
+  font-variant-numeric: tabular-nums;
 }
 
 .experimentTable th {
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--mimir-hairline);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   text-align: left;
 }
 
 .experimentTable td {
-  padding: 9px 10px;
-  border-bottom: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--mimir-hairline);
   vertical-align: top;
 }
 
@@ -1773,11 +1795,12 @@ li.dropIndicator {
 
 .experimentStatus {
   display: inline-block;
-  padding: 2px 12px;
+  padding: 1px 10px;
   border-radius: 999px;
   background: var(--dsw-alias-markdown-code-block, #f1f3f5);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
+  font-weight: 500;
 }
 
 .experimentStatus[data-status='running'] {
@@ -1796,18 +1819,19 @@ li.dropIndicator {
 }
 
 .metricsToggle {
-  padding: 2px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  padding: 1px 10px;
+  border: 1px solid var(--mimir-hairline);
   border-radius: 999px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .metricsToggle:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 4%));
 }
 
 .metricsList {
@@ -1834,7 +1858,7 @@ li.dropIndicator {
 /* Metric comparison: one hand-drawn SVG bar chart per shared numeric key. */
 
 .metricCharts {
-  padding: 16px 18px;
+  padding: 16px;
 }
 
 .metricCharts .sectionTitle {
@@ -1849,8 +1873,8 @@ li.dropIndicator {
 
 .metricChart {
   padding: 10px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
 }
 
@@ -1914,7 +1938,7 @@ li.dropIndicator {
 }
 
 .experimentLog {
-  padding: 18px 20px;
+  padding: 16px 20px;
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 13px;
   line-height: 1.7;
@@ -1989,18 +2013,18 @@ li.dropIndicator {
   flex-direction: column;
   gap: 6px;
   padding: 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
   text-align: left;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
 .figureCard:hover,
 .figureCard:focus-within {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
+  border-color: var(--mimir-hairline-strong);
+  box-shadow: var(--mimir-card-shadow-hover);
 }
 
 .figurePreview {
@@ -2033,18 +2057,18 @@ li.dropIndicator {
 .figureAction {
   height: 24px;
   padding: 0 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 8px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 11px;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgb(0 0 0 / 10%);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .figureAction:hover {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
   color: var(--dsw-alias-label-primary, #17233d);
 }
 
@@ -2062,7 +2086,7 @@ li.dropIndicator {
 .figureThumb {
   width: 100%;
   height: 150px;
-  border-radius: 10px;
+  border-radius: 8px;
   object-fit: contain;
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
 }
@@ -2072,7 +2096,7 @@ li.dropIndicator {
   align-items: center;
   justify-content: center;
   height: 150px;
-  border-radius: 10px;
+  border-radius: 8px;
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 13px;
@@ -2154,18 +2178,18 @@ li.dropIndicator {
 .serverCard {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 16px 18px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  gap: 8px;
+  padding: 14px 16px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
 .serverCard:hover {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
+  border-color: var(--mimir-hairline-strong);
+  box-shadow: var(--mimir-card-shadow-hover);
 }
 
 .serverCardHead {
@@ -2175,11 +2199,11 @@ li.dropIndicator {
 }
 
 /* The probe-status dot: green online, red offline, grey never probed, and a
-   pulsing blue while a probe is in flight. */
+   pulsing blue while a probe is in flight. 8px, with a soft state-tinted ring. */
 .serverDot {
   flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
+  width: 8px;
+  height: 8px;
   margin-top: 6px;
   border-radius: 50%;
   background: var(--dsw-alias-border-l3, rgb(0 0 0 / 20%));
@@ -2231,14 +2255,16 @@ li.dropIndicator {
   text-overflow: ellipsis;
 }
 
-/* The textual twin of the dot, painted in the same state color. */
+/* The textual twin of the dot: a pale tint pill with colored ink. */
 .serverState {
   flex: 0 0 auto;
-  padding: 2px 10px;
+  padding: 1px 8px;
   border-radius: 999px;
   background: var(--dsw-alias-markdown-code-block, #f1f3f5);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 11px;
+  font-weight: 500;
+  line-height: 1.6;
 }
 
 .serverState[data-state='online'] {
@@ -2282,8 +2308,8 @@ li.dropIndicator {
   max-width: 140px;
   height: 28px;
   padding: 0 6px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 6px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-primary, #17233d);
   font-size: 12px;
@@ -2296,14 +2322,40 @@ li.dropIndicator {
   font-variant-numeric: tabular-nums;
 }
 
+/* The settled probe's failure detail: a quiet inline error line instead of a
+   filled red banner — a 2px error bar, one truncated line of red ink, click
+   (or the title tooltip) reveals the full message. */
 .serverMessage {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
   margin: 0;
-  padding: 6px 10px;
-  border-radius: 8px;
-  background: var(--dsw-alias-state-error-secondary, rgb(236 19 19 / 8%));
+  padding: 1px 0 1px 8px;
+  border: none;
+  border-left: 2px solid var(--dsw-alias-state-error-primary, #d93026);
+  border-radius: 1px;
+  background: transparent;
   color: var(--dsw-alias-state-error-primary, #d93026);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.5;
+  text-align: left;
+  cursor: pointer;
+}
+
+.serverMessageText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.serverMessage[data-open] {
+  align-items: flex-start;
+}
+
+.serverMessage[data-open] .serverMessageText {
+  white-space: normal;
   word-break: break-word;
 }
 
@@ -2312,7 +2364,7 @@ li.dropIndicator {
   flex-direction: column;
   gap: 8px;
   padding: 10px 12px;
-  border-radius: 10px;
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
 }
 
@@ -2378,11 +2430,11 @@ li.dropIndicator {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 16px 18px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%), 0 4px 16px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .serverForm .sectionTitle {
@@ -2416,8 +2468,8 @@ li.dropIndicator {
   width: 100%;
   height: 32px;
   padding: 0 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 9px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-primary, #17233d);
   font-size: 13px;
@@ -2430,8 +2482,8 @@ li.dropIndicator {
 }
 
 .input:focus {
-  border-color: var(--dsw-alias-state-business-primary, #4176e6);
-  box-shadow: 0 0 0 3px var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 15%));
+  border-color: var(--mimir-accent);
+  box-shadow: 0 0 0 3px var(--mimir-accent-soft);
 }
 
 .input:disabled {
@@ -2487,8 +2539,8 @@ li.dropIndicator {
   flex-direction: column;
   gap: 8px;
   padding: 8px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-specific-menu, #fff);
 }
 
@@ -2537,7 +2589,7 @@ li.dropIndicator {
   flex-direction: column;
   gap: 8px;
   padding-top: 10px;
-  border-top: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-top: 1px solid var(--mimir-hairline);
 }
 
 .bibEditGrid {
@@ -2591,8 +2643,8 @@ li.dropIndicator {
   flex-direction: column;
   gap: 10px;
   padding: 12px 14px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-specific-menu, #fff);
 }
 
@@ -2617,11 +2669,11 @@ li.dropIndicator {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 30px;
+  height: 28px;
   margin-left: auto;
-  padding: 0 14px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 9px;
+  padding: 0 12px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12.5px;
@@ -2631,15 +2683,15 @@ li.dropIndicator {
 }
 
 .bibToggle:hover:not(:disabled) {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 4%));
   color: var(--dsw-alias-label-primary, #17233d);
 }
 
 .bibToggle[data-active] {
   border-color: transparent;
-  background: var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 15%));
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  background: var(--mimir-accent-soft);
+  color: var(--mimir-accent-strong);
 }
 
 .bibToggle:disabled {
@@ -2654,10 +2706,10 @@ li.dropIndicator {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 30px;
-  padding: 0 14px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 9px;
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 7px;
   background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12.5px;
@@ -2667,15 +2719,15 @@ li.dropIndicator {
 }
 
 .snapToggle:hover:not(:disabled) {
-  border-color: var(--dsw-alias-border-l3, rgb(0 0 0 / 12%));
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border-color: var(--mimir-hairline-strong);
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 4%));
   color: var(--dsw-alias-label-primary, #17233d);
 }
 
 .snapToggle[data-active] {
   border-color: transparent;
-  background: var(--dsw-alias-state-business-tertiary, rgb(65 118 230 / 15%));
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  background: var(--mimir-accent-soft);
+  color: var(--mimir-accent-strong);
 }
 
 .snapToggle:disabled {
@@ -2709,8 +2761,8 @@ li.dropIndicator {
    markers. Additions paint green, deletions red, on the shared state tokens. */
 .diffView {
   overflow-x: auto;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-alias-markdown-code-block, #f9fafb);
   font-family: var(--dsw-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: 12px;
@@ -2755,16 +2807,17 @@ li.dropIndicator {
 
 .diffGap {
   padding: 2px 10px;
-  border-top: 1px dashed var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-bottom: 1px dashed var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-top: 1px dashed var(--mimir-hairline);
+  border-bottom: 1px dashed var(--mimir-hairline);
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 11.5px;
   text-align: center;
   user-select: none;
 }
 
-/* A shared elevated surface language across the data-heavy views. Kept after
-   their individual rules so every view finishes with the same visual depth. */
+/* A shared elevated surface language across the data-heavy views: 1px
+   hairline + the whisper shadow, one radius. Kept after their individual
+   rules so every view finishes with the same visual depth. */
 .papersSearchPanel,
 .experimentTableWrap,
 .figureCard,
@@ -2772,35 +2825,42 @@ li.dropIndicator {
 .outlineRail,
 .editorPane,
 .previewPane {
-  border-radius: 17px;
+  border-radius: var(--mimir-radius-card);
   box-shadow: var(--mimir-card-shadow);
 }
 
 .figureCard,
 .serverCard {
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  transition: box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
 .figureCard:hover,
 .figureCard:focus-within,
 .serverCard:hover {
-  box-shadow: 0 16px 36px rgb(45 66 110 / 12%);
-  transform: translateY(-2px);
+  border-color: var(--mimir-hairline-strong);
+  box-shadow: var(--mimir-card-shadow-hover);
 }
 
 /* Dark palette: the host theme presenter flips `body[data-ds-dark-theme]` and
-   every `--dsw-*` alias above follows the dark base palette on its own — only
-   the panel-private tokens (the LaTeX syntax colors) and the dimmer need a
-   dark value. The editor's dark ground is the theme's bluish-900 well, so the
-   syntax colors are picked for it (all ≥ 4.5:1 against it). */
+   every `--dsw-*` alias above follows the dark base palette on its own — the
+   panel-private tokens are re-tuned here independently. The well drops to a
+   layered neutral dark (never pure black) so the slightly lighter card
+   surfaces still read as cards; hairlines go to white-alpha strokes; shadows
+   deepen instead of lightening. The editor's dark ground is the theme's
+   bluish-900 well, so the syntax colors are picked for it (all ≥ 4.5:1
+   against it). */
 :global(body[data-ds-dark-theme]) .workbench {
   border-color: rgb(255 255 255 / 10%);
   color-scheme: dark;
   --mimir-accent: #6f9cff;
-  --mimir-accent-strong: #5b86ee;
-  --mimir-accent-soft: rgb(111 156 255 / 15%);
+  --mimir-accent-strong: #8fb0ff;
+  --mimir-accent-soft: rgb(111 156 255 / 14%);
   --mimir-violet: #9a7cf3;
-  --mimir-card-shadow: 0 1px 2px rgb(0 0 0 / 16%), 0 14px 34px rgb(0 0 0 / 14%);
+  --mimir-hairline: var(--dsw-alias-border-l1, rgb(255 255 255 / 9%));
+  --mimir-hairline-strong: var(--dsw-alias-border-l2, rgb(255 255 255 / 15%));
+  --mimir-well: #17191e;
+  --mimir-card-shadow: 0 1px 2px rgb(0 0 0 / 24%);
+  --mimir-card-shadow-hover: 0 1px 2px rgb(0 0 0 / 28%), 0 8px 20px rgb(0 0 0 / 24%);
   --mimir-tok-command: #8ab0f8;
   --mimir-tok-comment: #8ba091;
   --mimir-tok-math: #b79dfa;
@@ -2823,16 +2883,16 @@ li.dropIndicator {
   align-items: center;
   gap: 2px;
   padding: 2px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  border: 1px solid var(--mimir-hairline);
+  border-radius: 9px;
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
 }
 
 .paperTab {
   height: 24px;
   padding: 0 10px;
   border: none;
-  border-radius: 8px;
+  border-radius: 7px;
   background: transparent;
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 12px;
@@ -2842,7 +2902,7 @@ li.dropIndicator {
 
 .paperTab[data-active] {
   background: var(--dsw-specific-menu, #fff);
-  color: var(--dsw-alias-state-business-primary, #4176e6);
+  color: var(--mimir-accent-strong);
   font-weight: 600;
   box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
 }
@@ -2877,7 +2937,7 @@ li.dropIndicator {
     flex-wrap: wrap;
     align-items: center;
     border-right: none;
-    border-bottom: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+    border-bottom: 1px solid var(--mimir-hairline);
   }
 
   .sideHead {
@@ -2917,13 +2977,13 @@ li.dropIndicator {
     bottom: 2px;
     left: 14px;
     width: auto;
-    height: 3px;
+    height: 2px;
   }
 
   .sideProjects {
     flex: 1 1 100%;
     max-height: 96px;
-    border-top: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 4%));
+    border-top: 1px solid var(--mimir-hairline);
   }
 
   .sideProjects .projectList {
@@ -2979,7 +3039,7 @@ li.dropIndicator {
 .experimentLog blockquote {
   margin: 8px 0;
   padding: 2px 12px;
-  border-left: 3px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-left: 2px solid var(--mimir-hairline-strong);
   color: var(--dsw-alias-label-tertiary, #5b6474);
 }
 
@@ -2996,7 +3056,7 @@ li.dropIndicator {
 .experimentLog hr {
   margin: 12px 0;
   border: none;
-  border-top: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-top: 1px solid var(--mimir-hairline);
 }
 
 .experimentLog table {
@@ -3008,12 +3068,12 @@ li.dropIndicator {
 .experimentLog th,
 .experimentLog td {
   padding: 5px 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border: 1px solid var(--mimir-hairline);
   text-align: left;
 }
 
 .experimentLog th {
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 5%));
   color: var(--dsw-alias-label-primary, #17233d);
   font-weight: 600;
 }
@@ -3029,11 +3089,11 @@ li.dropIndicator {
 
 /* The overview's data section: wiki snapshot export and the import flow. */
 .dataSection {
-  padding: 24px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  padding: 20px 24px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%), 0 4px 16px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .dataActions {
@@ -3071,11 +3131,11 @@ li.dropIndicator {
   gap: 10px;
   align-items: flex-start;
   padding: 10px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-left: 3px solid var(--dsw-alias-state-business-primary, #4176e6);
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-left: 2px solid var(--dsw-alias-state-business-primary, #4176e6);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 2px 6px rgb(0 0 0 / 8%), 0 8px 24px rgb(0 0 0 / 10%);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 6%), 0 12px 32px rgb(15 23 42 / 12%);
   color: var(--dsw-alias-label-primary, #17233d);
   font-size: 13px;
   line-height: 1.5;
@@ -3142,10 +3202,10 @@ li.dropIndicator {
   align-items: flex-end;
   gap: 10px 14px;
   padding: 14px 16px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 14px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .jobForm .field[data-wide] {
@@ -3166,11 +3226,12 @@ li.dropIndicator {
 
 .jobStatus {
   display: inline-block;
-  padding: 2px 12px;
+  padding: 1px 10px;
   border-radius: 999px;
   background: var(--dsw-alias-markdown-code-block, #f1f3f5);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
+  font-weight: 500;
 }
 
 .jobStatus[data-status='running'] {
@@ -3192,6 +3253,7 @@ li.dropIndicator {
   margin-left: 6px;
   color: var(--dsw-alias-label-tertiary, #5b6474);
   font-size: 11px;
+  font-variant-numeric: tabular-nums;
 }
 
 /* The experiment row's last-job write-back badge, under the status pill. */
@@ -3230,6 +3292,8 @@ li.dropIndicator {
 }
 
 .jobOutput pre[data-kind='stderr'] {
+  border-left: 2px solid var(--dsw-alias-state-error-primary, #d93026);
+  border-radius: 2px 8px 8px 2px;
   color: var(--dsw-alias-state-error-primary, #d93026);
 }
 
@@ -3265,8 +3329,8 @@ li.dropIndicator {
   gap: 8px;
   max-height: 560px;
   padding: 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-inner);
   background: var(--dsw-specific-menu, #fff);
 }
 
@@ -3278,10 +3342,11 @@ li.dropIndicator {
   flex-direction: column;
   gap: 8px;
   margin: 0 0 12px;
-  padding: 10px 12px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
-  border-radius: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--mimir-hairline);
+  border-radius: var(--mimir-radius-card);
   background: var(--dsw-specific-menu, #fff);
+  box-shadow: var(--mimir-card-shadow);
 }
 
 .paperNotesTitle {
@@ -3374,10 +3439,10 @@ li.dropIndicator {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 2px 10px;
-  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  padding: 1px 9px;
+  border: 1px solid var(--mimir-hairline);
   border-radius: 999px;
-  background: var(--dsw-alias-interactive-bg-hover, rgb(38 49 72 / 6%));
+  background: var(--dsw-specific-menu, #fff);
   color: var(--dsw-alias-label-secondary, #3c4557);
   font-size: 12px;
   line-height: 1.6;
@@ -3401,7 +3466,7 @@ li.dropIndicator {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border-top: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-top: 1px solid var(--mimir-hairline);
   padding-top: 8px;
 }
 

--- a/packages/ui-mimir/src/client/ServersView.tsx
+++ b/packages/ui-mimir/src/client/ServersView.tsx
@@ -107,6 +107,8 @@ export function ServersView({
   const [actionError, setActionError] = useState<string | null>(null)
   const [activeTag, setActiveTag] = useState<string | null>(null)
   const [tagInput, setTagInput] = useState('')
+  /** The card whose probe-failure line is expanded; null collapses them all. */
+  const [openMessageId, setOpenMessageId] = useState<string | null>(null)
 
   // The view mounts only while its tab is active: load the list once, then
   // probe every listed server exactly once (a settled or in-flight probe
@@ -374,12 +376,24 @@ export function ServersView({
                     )}
                 </p>
                 {settled !== null && settled.message !== null && (
-                  <p className={css.serverMessage} role="status">
-                    {settled.stage !== undefined && (
-                      <span className={css.serverProbeFailStage}>{t(PROBE_FAILURE_KEYS[settled.stage])}：</span>
-                    )}
-                    {settled.message}
-                  </p>
+                  /* The probe failure renders as a quiet one-line error row:
+                     truncated by default, the title tooltip shows it on hover
+                     and the click toggles the full text (aria-expanded). */
+                  <button
+                    type="button"
+                    className={css.serverMessage}
+                    data-open={openMessageId === record.id || undefined}
+                    aria-expanded={openMessageId === record.id}
+                    title={settled.message}
+                    onClick={() => { setOpenMessageId(prev => (prev === record.id ? null : record.id)) }}
+                  >
+                    <span className={css.serverMessageText}>
+                      {settled.stage !== undefined && (
+                        <span className={css.serverProbeFailStage}>{t(PROBE_FAILURE_KEYS[settled.stage])}：</span>
+                      )}
+                      {settled.message}
+                    </span>
+                  </button>
                 )}
                 {settled !== null && settled.state === 'online' && (
                   settled.gpus.length === 0 ? (


### PR DESCRIPTION
…ual language

Pure visual pass over the research workbench — no functional or interaction changes, host package untouched.

- Replace filled red probe-failure banners with a quiet inline error line: 2px error bar, single truncated line, hover tooltip and click-to-expand (aria-expanded)
- Cards move to 1px hairline borders + a 2px whisper shadow, one 12px radius scale, and a subtle hover (deeper border + one shadow step, no translate)
- Flat neutral content well (#f7f8f9 light) replacing the tint gradients; dark mode gets an independently tuned layered neutral (#17191e well, white-alpha hairlines, deeper shadows — no inversion)
- Unified type scale: view title 18/600, section 12/600, card title 14/600, body 13, auxiliary 12; tabular-nums on numeric surfaces
- Status display keeps the dot + pale-tint pill language (8px dot, lighter pills); danger actions are red-ink ghost buttons
- Buttons: solid accent primary (no gradient/glow), hairline ghost secondary; side nav active state simplified to accent-soft fill + 2px solid indicator bar

Tests: 517/517 green; tsc -b packages/ui-mimir clean.

## 改动内容

<!-- 简述做了什么、为什么。关联 Issue：Closes #xx -->

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿
- [ ] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（本仓库 `pnpm run build` 会处理）
- [ ] README.md / README.zh.md 保持逐节对齐（如涉及功能描述）
- [ ] ROADMAP.md 已更新（如涉及队列条目）

## 截图

<!-- UI 改动必填 -->
