### PR TITLE
feat: read-only Zotero Web API integration (library → wiki → .bib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ pnpm run typecheck   # tsc -b both packages; assumes a prior build (ui-mimir
 
 Layout:
 
-- `packages/mimir` — the host plugin (`dsh-mimir`): commands, tools, wiki domain, reviewer loop, LaTeX compile, BibTeX management, paper snapshots, arXiv keyword subscriptions with scheduled new-paper checks, the `research` Remote namespace (45 methods), and the `/research/pdf` / `/research/figure` / `/research/figure-upload` routes.
+- `packages/mimir` — the host plugin (`dsh-mimir`): commands, tools, wiki domain, reviewer loop, LaTeX compile, BibTeX management, paper snapshots, arXiv keyword subscriptions with scheduled new-paper checks, the `research` Remote namespace (50 methods), and the `/research/pdf` / `/research/figure` / `/research/figure-upload` routes.
 - `packages/ui-mimir` — the browser workbench (`dsh-client-ui-mimir`): sidebar toggle + overlay panel.
 - `packages/typert-protocol` — vendored, never-published source copy of the Typert protocol (see below).
 - `examples/mimir-agent` — the cordis patch used in the Quickstart.

--- a/README.zh.md
+++ b/README.zh.md
@@ -341,7 +341,7 @@ pnpm run typecheck   # tsc -b 两个包；需先构建（ui-mimir 引用生成�
 
 目录结构：
 
-- `packages/mimir`——宿主插件（`dsh-mimir`）：命令、工具、wiki domain、评审循环、LaTeX 编译、BibTeX 管理、论文快照、arXiv 关键词订阅（定时检查新论文）、`research` Remote 命名空间（45 个方法），以及 `/research/pdf` / `/research/figure` / `/research/figure-upload` 路由。
+- `packages/mimir`——宿主插件（`dsh-mimir`）：命令、工具、wiki domain、评审循环、LaTeX 编译、BibTeX 管理、论文快照、arXiv 关键词订阅（定时检查新论文）、`research` Remote 命名空间（50 个方法），以及 `/research/pdf` / `/research/figure` / `/research/figure-upload` 路由。
 - `packages/ui-mimir`——浏览器工作台（`dsh-client-ui-mimir`）：侧栏开关 + 浮层面板。
 - `packages/typert-protocol`——Typert 协议的 vendored 源码副本，从不发布（见下）。
 - `examples/mimir-agent`——快速上手使用的 cordis patch。

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -73,10 +73,18 @@ export type {
   ResearchSearchArxivResult,
   ResearchSubmitJobResult,
   ResearchSuccess,
+  ResearchCheckZoteroResult,
+  ResearchZoteroCollectionsResult,
+  ResearchZoteroExportResult,
+  ResearchZoteroImportResult,
+  ResearchZoteroSearchResult,
   ServerGpuView,
   ServerInput,
   ServerRecord,
   ServerStatusView,
+  ZoteroCollectionView,
+  ZoteroItemView,
+  ZoteroStatusView,
 } from './types.ts'
 export { researchWikiDomainSpec } from './store.ts'
 export type { ResearchWikiDomain } from './store.ts'
@@ -119,6 +127,8 @@ export { compileLatex, renderLatexResult, createLatexCompileTool, resolveLatexEn
 export type { LatexCompileResult, LatexToolOptions, LatexEngineKind, ResolvedLatexEngine, LatexEngineProbe } from './tools/latex.ts'
 export { createArxivSearchTool, createPaperFetchTool, fetchArxivPdf, fetchArxivSearch, paperPdfFileName, parseArxivFeed, ARXIV_PDF_MAX_BYTES } from './tools/arxiv.ts'
 export type { ArxivEntry, ArxivSearchOptions } from './tools/arxiv.ts'
+export { createZoteroClient } from './tools/zotero.ts'
+export type { ZoteroBibRequest, ZoteroClient, ZoteroClientConfig, ZoteroCollection, ZoteroFetch, ZoteroItem } from './tools/zotero.ts'
 export { createWikiNoteTool } from './tools/wiki.ts'
 export { createFigureSaveTool } from './tools/figure.ts'
 export { buildWikiSnapshot } from './wiki-snapshot.ts'
@@ -168,6 +178,17 @@ export interface Config {
     /** Default result cap for `arxiv_search` (default 10). */
     maxResults?: number
   }
+  /**
+   * Zotero Web API credentials (read-only integration; both absent disables
+   * it). The key is a secret: it is read from this config only, sent to the
+   * API as a header, and never written to the wiki, a log, or the panel.
+   */
+  zotero?: {
+    /** Web API key from zotero.org/settings/keys; '' counts as unconfigured. */
+    apiKey?: string
+    /** Numeric user id shown on the settings page; '' counts as unconfigured. */
+    userId?: string
+  }
   /** arXiv subscription new-paper check knobs. */
   subscriptions?: {
     /** Master switch of the scheduled check (default true); false disables the timer entirely. */
@@ -205,6 +226,10 @@ export const Config: z<Config> = z.object({
   arxiv: z.object({
     maxResults: z.number().step(1).min(1).max(100).default(10),
   }).default({ maxResults: 10 }),
+  zotero: z.object({
+    apiKey: z.string().default(''),
+    userId: z.string().default(''),
+  }).default({ apiKey: '', userId: '' }),
   subscriptions: z.object({
     enabled: z.boolean().default(true),
     intervalMinutes: z.number().step(1).min(1).max(Number.MAX_SAFE_INTEGER).default(1440),
@@ -223,6 +248,7 @@ interface ResolvedConfig {
   readonly reviewer: { readonly provider: string; readonly maxRounds: number }
   readonly latex: { readonly engine: string; readonly timeoutMs: number }
   readonly arxiv: { readonly maxResults: number }
+  readonly zotero: { readonly apiKey: string; readonly userId: string }
   readonly subscriptions: {
     readonly enabled: boolean
     readonly intervalMinutes: number
@@ -241,6 +267,7 @@ function resolveConfig(config: Config): ResolvedConfig {
   const reviewer = { provider: config.reviewer?.provider ?? 'spawn', maxRounds: config.reviewer?.maxRounds ?? 3 }
   const latex = { engine: config.latex?.engine ?? 'auto', timeoutMs: config.latex?.timeoutMs ?? 120_000 }
   const arxiv = { maxResults: config.arxiv?.maxResults ?? 10 }
+  const zotero = { apiKey: config.zotero?.apiKey ?? '', userId: config.zotero?.userId ?? '' }
   const subscriptions = {
     enabled: config.subscriptions?.enabled ?? true,
     intervalMinutes: config.subscriptions?.intervalMinutes ?? 1440,
@@ -261,7 +288,7 @@ function resolveConfig(config: Config): ResolvedConfig {
   if (!Number.isSafeInteger(backup.intervalMinutes) || backup.intervalMinutes < 1) throw new TypeError('backup.intervalMinutes must be a positive safe integer')
   if (!Number.isSafeInteger(backup.keep) || backup.keep < 1) throw new TypeError('backup.keep must be a positive safe integer')
   if (backup.dir.trim().length === 0) throw new TypeError('backup.dir must be a non-empty path')
-  return { workspaceDir, reviewer, latex, arxiv, subscriptions, backup }
+  return { workspaceDir, reviewer, latex, arxiv, zotero, subscriptions, backup }
 }
 
 /**
@@ -567,6 +594,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     domain,
     latex: resolved.latex,
     backup: { ...resolved.backup, dir: backupDir },
+    zotero: resolved.zotero,
   })
   if (resolved.backup.enabled) {
     ctx.effect(

--- a/packages/mimir/src/service.ts
+++ b/packages/mimir/src/service.ts
@@ -2,7 +2,7 @@
  * The `research` Remote namespace: the host half of the web research panel.
  * This file is a thin facade — it keeps the class, the `super(ctx,
  * 'research')` registration, the config type, the Context augmentation, and
- * all 45 `@Remote` signatures intact, and forwards every method body to a
+ * all 50 `@Remote` signatures intact, and forwards every method body to a
  * pure-function domain module under `./services`. It owns no domain logic:
  * the mutable instance state (`compileStatus` map, `jobSeq` counter) rides a
  * single {@link ServiceState} object created here, so every
@@ -62,6 +62,11 @@ import type {
   ResearchUpdateExperimentResult,
   ResearchUpdatePaperResult,
   ResearchWikiSnapshot,
+  ResearchCheckZoteroResult,
+  ResearchZoteroCollectionsResult,
+  ResearchZoteroExportResult,
+  ResearchZoteroImportResult,
+  ResearchZoteroSearchResult,
   SectionMove,
   SectionOutlineTitles,
   ServerInput,
@@ -70,6 +75,7 @@ import type {
 import * as paper from './services/paper.ts'
 import * as paperSnapshots from './services/paper-snapshots.ts'
 import * as library from './services/library.ts'
+import * as zotero from './services/zotero.ts'
 import * as subscriptions from './services/subscriptions.ts'
 import * as experiment from './services/experiment.ts'
 import * as server from './services/server.ts'
@@ -107,11 +113,21 @@ export interface ResearchServiceConfig {
    * process runner apply.
    */
   readonly svg?: SvgConversionDeps
+  /**
+   * Resolved Zotero Web API credentials; absent (or empty) disables the
+   * integration — every Zotero Remote method then rejects `invalid-input`
+   * (`checkZotero` reports `unconfigured`). The key is a secret: it only
+   * ever reaches the API as a header.
+   */
+  readonly zotero?: {
+    readonly apiKey: string
+    readonly userId: string
+  }
 }
 
 /**
  * Host service behind the web research panel. Thin facade: keeps the
- * `research` Remote namespace and all 45 `@Remote` signatures; every method
+ * `research` Remote namespace and all 50 `@Remote` signatures; every method
  * body forwards to a domain module under `./services`. Owns no domain logic.
  */
 export class ResearchService extends TypertRemoteService {
@@ -135,6 +151,7 @@ export class ResearchService extends TypertRemoteService {
       latex: config.latex,
       ...(config.backup === undefined ? {} : { backup: config.backup }),
       ...(config.svg === undefined ? {} : { svg: config.svg }),
+      ...(config.zotero === undefined ? {} : { zotero: config.zotero }),
     }
     this.state = { compileStatus: new Map(), jobSeq: 0 }
   }
@@ -185,6 +202,36 @@ export class ResearchService extends TypertRemoteService {
   @Remote('fetchPaperPdf')
   fetchPaperPdf(request: { arxivId: string }): Promise<ResearchFetchPaperPdfResult> {
     return library.fetchPaperPdf(this.deps, request)
+  }
+
+  // zotero domain: read-only bridge to a configured Zotero user library
+  @Remote('checkZotero')
+  checkZotero(): Promise<ResearchCheckZoteroResult> {
+    return zotero.checkZotero(this.deps)
+  }
+
+  @Remote('listZoteroCollections')
+  listZoteroCollections(): Promise<ResearchZoteroCollectionsResult> {
+    return zotero.listZoteroCollections(this.deps)
+  }
+
+  @Remote('searchZotero')
+  searchZotero(request: { query: string; maxResults?: number }): Promise<ResearchZoteroSearchResult> {
+    return zotero.searchZotero(this.deps, request)
+  }
+
+  @Remote('importZoteroItem')
+  importZoteroItem(request: { key: string }): Promise<ResearchZoteroImportResult> {
+    return zotero.importZoteroItem(this.deps, request)
+  }
+
+  @Remote('exportZoteroCollectionToBib')
+  exportZoteroCollectionToBib(request: {
+    projectId: string
+    collectionKey: string
+    dir?: string | undefined
+  }): Promise<ResearchZoteroExportResult> {
+    return zotero.exportZoteroCollectionToBib(this.deps, request)
   }
 
   // subscription domain: arXiv new-paper checks (pure filesystem storage)

--- a/packages/mimir/src/services/paper.ts
+++ b/packages/mimir/src/services/paper.ts
@@ -17,14 +17,13 @@ import {
   savePaperSourceFile,
   saveTextFileOptimistic,
 } from '../paper-source.ts'
-import { bibKeyOf, entryFromPaper, parseBibtex, serializeBibtex } from '../bibtex.ts'
+import { entryFromPaper, parseBibtex, serializeBibtex } from '../bibtex.ts'
 import { compileLatex } from '../tools/latex.ts'
 import type { LatexToolOptions } from '../tools/latex.ts'
 import { captureCompileSnapshot } from './paper-snapshots.ts'
 import type { ResearchWikiDomain } from '../store.ts'
 import type {
   BibEntry,
-  PaperRecord,
   ResearchBibliographyResult,
   ResearchCompileResult,
   ResearchCompileStatusResult,
@@ -360,22 +359,23 @@ export async function saveBibliography(
 }
 
 /**
- * Append `@misc` entries for the given remembered papers to the addressed
- * project's `references.bib`, skipping citation keys already present. Every
- * arXiv id must name a wiki paper (`paper-not-found` on the first unknown
- * one — nothing is written then). The read-merge-write runs inside the
+ * Append parsed BibTeX entries to the addressed project's `references.bib`,
+ * skipping citation keys already present. The paper directory itself must
+ * exist (`paper-not-found` otherwise). The read-merge-write runs inside the
  * writer lock, so a concurrent panel save or agent write cannot be lost.
+ * Shared by `importPapersToBib` (entries projected from wiki papers) and the
+ * Zotero collection export (entries parsed from the API's BibTeX).
  * @param deps - workspace root and open wiki domain.
- * @param request - the selected project, the arXiv ids to append, and an
+ * @param request - the selected project, the entries to append, and an
  * optional explicit paper directory.
  * @returns the appended and the already-present citation keys, or
  * `project-not-found`/`paper-not-found`/`invalid-dir`.
  */
-export async function importPapersToBib(
+export async function appendBibEntries(
   deps: PaperDeps,
   request: {
     projectId: string
-    arxivIds: string[]
+    entries: readonly BibEntry[]
     dir?: string | undefined
   },
 ): Promise<ResearchImportBibResult> {
@@ -392,13 +392,6 @@ export async function importPapersToBib(
     if (isNotFound(error)) return rejected({ code: 'paper-not-found' })
     throw error
   }
-  const papers = deps.domain.table('papers')
-  const sources = new Map<string, PaperRecord>()
-  for (const arxivId of request.arxivIds) {
-    const paper = papers.get(arxivId)
-    if (paper === undefined) return rejected({ code: 'paper-not-found' })
-    sources.set(arxivId, paper)
-  }
   const bibPath = join(dir, 'references.bib')
   return await withFileLock(bibPath, async (): Promise<ResearchImportBibResult> => {
     const snapshot = await readPaperSource(bibPath)
@@ -406,17 +399,50 @@ export async function importPapersToBib(
     const present = new Set(entries.map(entry => entry.key))
     const added: string[] = []
     const skipped: string[] = []
-    for (const [arxivId, paper] of sources) {
-      const key = bibKeyOf(arxivId)
-      if (present.has(key)) { skipped.push(key); continue }
-      entries.push(entryFromPaper(paper))
-      present.add(key)
-      added.push(key)
+    for (const incoming of request.entries) {
+      if (present.has(incoming.key)) { skipped.push(incoming.key); continue }
+      entries.push(incoming)
+      present.add(incoming.key)
+      added.push(incoming.key)
     }
     if (added.length > 0) {
       await writeFileAtomic(bibPath, serializeBibtex(entries), { mode: 0o666 })
     }
     return success({ added: Object.freeze(added), skipped: Object.freeze(skipped) })
+  })
+}
+
+/**
+ * Append `@misc` entries for the given remembered papers to the addressed
+ * project's `references.bib`, skipping citation keys already present. Every
+ * arXiv id must name a wiki paper (`paper-not-found` on the first unknown
+ * one — nothing is written then). The merge itself rides
+ * {@link appendBibEntries}.
+ * @param deps - workspace root and open wiki domain.
+ * @param request - the selected project, the arXiv ids to append, and an
+ * optional explicit paper directory.
+ * @returns the appended and the already-present citation keys, or
+ * `project-not-found`/`paper-not-found`/`invalid-dir`.
+ */
+export async function importPapersToBib(
+  deps: PaperDeps,
+  request: {
+    projectId: string
+    arxivIds: string[]
+    dir?: string | undefined
+  },
+): Promise<ResearchImportBibResult> {
+  const papers = deps.domain.table('papers')
+  const entries: BibEntry[] = []
+  for (const arxivId of request.arxivIds) {
+    const paper = papers.get(arxivId)
+    if (paper === undefined) return rejected({ code: 'paper-not-found' })
+    entries.push(entryFromPaper(paper))
+  }
+  return appendBibEntries(deps, {
+    projectId: request.projectId,
+    entries,
+    ...(request.dir === undefined ? {} : { dir: request.dir }),
   })
 }
 

--- a/packages/mimir/src/services/zotero.ts
+++ b/packages/mimir/src/services/zotero.ts
@@ -1,0 +1,238 @@
+/**
+ * Zotero domain module: the read-only bridge between a configured Zotero
+ * user library and the research wiki — connection probe, collection list,
+ * full-text item search, single-item import into the papers table, and a
+ * collection's BibTeX merged into a project's `references.bib`. Thin
+ * forwarding of the `zotero.*` Remote methods lives in `service.ts`. The API
+ * key only ever reaches the client (an HTTP header); it is never written to
+ * the wiki, a log, or a result message. Without a configured key/user id
+ * every method but the probe rejects `invalid-input` with configuration
+ * guidance; the probe reports `unconfigured` instead (its job IS the status).
+ * @module dsh-mimir/src/services/zotero
+ */
+
+import { parseBibtex } from '../bibtex.ts'
+import { createZoteroClient } from '../tools/zotero.ts'
+import type { ZoteroClientConfig, ZoteroItem } from '../tools/zotero.ts'
+import type {
+  ArxivEntry,
+  PaperRecord,
+  ResearchCheckZoteroResult,
+  ResearchZoteroCollectionsResult,
+  ResearchZoteroExportResult,
+  ResearchZoteroImportResult,
+  ResearchZoteroSearchResult,
+} from '../types.ts'
+import { rejected, success } from './common.ts'
+import { importPaper } from './library.ts'
+import { appendBibEntries } from './paper.ts'
+import type { PaperDeps } from './paper.ts'
+
+/** Everything the Zotero domain functions need from the service scope. */
+export interface ZoteroDeps extends PaperDeps {
+  /** Resolved Zotero knobs; absent (or empty) means the integration is off. */
+  readonly zotero?: ZoteroClientConfig | undefined
+}
+
+/** Timeout of one Zotero API request made on the panel's behalf. */
+const ZOTERO_FETCH_TIMEOUT_MS = 15_000
+/** Default result cap of one panel-driven Zotero search. */
+const ZOTERO_SEARCH_DEFAULT_MAX_RESULTS = 10
+/** Hard result cap of one panel-driven Zotero search. */
+const ZOTERO_SEARCH_MAX_RESULTS = 50
+/** Papers-table id prefix of an imported item that carries no arXiv id. */
+const ZOTERO_PAPER_ID_PREFIX = 'zotero-'
+
+/** The failure every Zotero Remote method shares while the plugin config lacks credentials. */
+const UNCONFIGURED = Object.freeze({
+  code: 'invalid-input' as const,
+  message: 'Zotero is not configured: set zotero.apiKey and zotero.userId in the mimir plugin config (cordis.yml); create a key at https://www.zotero.org/settings/keys',
+})
+
+/** The configured client, or the shared `invalid-input` rejection when unconfigured. */
+function clientOf(deps: ZoteroDeps) {
+  const config = deps.zotero
+  if (config === undefined || config.apiKey.trim() === '' || config.userId.trim() === '') {
+    return undefined
+  }
+  return createZoteroClient(config)
+}
+
+/** Map one settled client failure to the shared `operation-failed` branch. */
+function failed(error: unknown, fallback: string) {
+  return rejected({
+    code: 'operation-failed',
+    message: error instanceof Error ? error.message : fallback,
+  })
+}
+
+/**
+ * Probe the configured Zotero credentials. This method never rejects:
+ * `unconfigured` (no key/user id in the plugin config), `ok` (the API
+ * accepted a cheap authenticated read), or `failed` with the reason.
+ * @param deps - open wiki domain and the resolved Zotero knobs.
+ * @returns the settled connection status for the panel's Zotero section.
+ */
+export async function checkZotero(deps: ZoteroDeps): Promise<ResearchCheckZoteroResult> {
+  const client = clientOf(deps)
+  if (client === undefined) return success({ state: 'unconfigured' })
+  try {
+    await client.testConnection(AbortSignal.timeout(ZOTERO_FETCH_TIMEOUT_MS))
+    return success({ state: 'ok' })
+  } catch (error) {
+    return success({
+      state: 'failed',
+      message: error instanceof Error ? error.message : 'zotero connection check failed',
+    })
+  }
+}
+
+/**
+ * List the configured user library's collections (key, name, item count).
+ * Unconfigured is `invalid-input`; transport/HTTP failures settle as
+ * `operation-failed` with the underlying message.
+ * @param deps - open wiki domain and the resolved Zotero knobs.
+ * @returns the collections for the panel's export picker.
+ */
+export async function listZoteroCollections(deps: ZoteroDeps): Promise<ResearchZoteroCollectionsResult> {
+  const client = clientOf(deps)
+  if (client === undefined) return rejected(UNCONFIGURED)
+  try {
+    const collections = await client.listCollections(AbortSignal.timeout(ZOTERO_FETCH_TIMEOUT_MS))
+    return success({ collections: Object.freeze(collections) })
+  } catch (error) {
+    return failed(error, 'zotero collection listing failed')
+  }
+}
+
+/**
+ * Search the configured user library on the panel's behalf. The query must
+ * be non-empty (`invalid-input` otherwise); the request carries a hard 15s
+ * timeout and failures settle as `operation-failed`.
+ * @param deps - open wiki domain and the resolved Zotero knobs.
+ * @param request - the free-text query and an optional result cap
+ * (default 10, hard cap 50).
+ * @returns the parsed items, the API's order preserved.
+ */
+export async function searchZotero(
+  deps: ZoteroDeps,
+  request: { query: string; maxResults?: number },
+): Promise<ResearchZoteroSearchResult> {
+  const client = clientOf(deps)
+  if (client === undefined) return rejected(UNCONFIGURED)
+  const query = request.query.trim()
+  if (query === '') return rejected({ code: 'invalid-input', message: 'query must be non-empty' })
+  const maxResults = request.maxResults ?? ZOTERO_SEARCH_DEFAULT_MAX_RESULTS
+  if (!Number.isSafeInteger(maxResults) || maxResults < 1 || maxResults > ZOTERO_SEARCH_MAX_RESULTS) {
+    return rejected({ code: 'invalid-input', message: `maxResults must be an integer between 1 and ${ZOTERO_SEARCH_MAX_RESULTS}` })
+  }
+  try {
+    const results = await client.searchItems(query, maxResults, AbortSignal.timeout(ZOTERO_FETCH_TIMEOUT_MS))
+    return success({ results: Object.freeze(results) })
+  } catch (error) {
+    return failed(error, 'zotero search failed')
+  }
+}
+
+/**
+ * Import one Zotero item into the wiki's papers table. An item whose
+ * `extra`/`url` yields an arXiv id rides the regular `importPaper` upsert
+ * (keyed by the bare arXiv id); any other item lands under
+ * `zotero-<item key>` with its provenance (Zotero key, DOI, URL) recorded in
+ * the notes. Re-importing refreshes metadata but preserves the workbench's
+ * notes, tags, and project links.
+ * @param deps - open wiki domain and the resolved Zotero knobs.
+ * @param request - the Zotero item key.
+ * @returns whether the paper was newly imported, plus its papers-table id.
+ */
+export async function importZoteroItem(
+  deps: ZoteroDeps,
+  request: { key: string },
+): Promise<ResearchZoteroImportResult> {
+  const client = clientOf(deps)
+  if (client === undefined) return rejected(UNCONFIGURED)
+  const key = request.key.trim()
+  if (key === '') return rejected({ code: 'invalid-input', message: 'key must be non-empty' })
+  let item: ZoteroItem
+  try {
+    item = await client.getItem(key, AbortSignal.timeout(ZOTERO_FETCH_TIMEOUT_MS))
+  } catch (error) {
+    return failed(error, 'zotero item fetch failed')
+  }
+  if (item.title.trim() === '') {
+    return rejected({ code: 'invalid-input', message: `zotero item '${key}' has no title` })
+  }
+  if (item.arxivId !== null) {
+    // The arXiv path: hand a synthesized entry to the regular import upsert.
+    const entry: ArxivEntry = {
+      id: item.arxivId,
+      title: item.title,
+      authors: [...item.authors],
+      summary: '',
+      published: item.year === '' ? '' : `${item.year}-01-01T00:00:00Z`,
+      url: `https://arxiv.org/abs/${item.arxivId}`,
+    }
+    const outcome = await importPaper(deps, { entry })
+    if (!outcome.ok) return outcome
+    return success({ imported: outcome.value.imported, paperId: item.arxivId })
+  }
+  const paperId = `${ZOTERO_PAPER_ID_PREFIX}${key}`
+  const table = deps.domain.table('papers')
+  const existing = table.get(paperId)
+  const provenance = [
+    `Imported from Zotero (item ${key}).`,
+    item.doi === '' ? '' : `DOI: ${item.doi}.`,
+    item.url === '' ? '' : `URL: ${item.url}.`,
+  ].filter(line => line !== '').join(' ')
+  const record: PaperRecord = {
+    arxivId: paperId,
+    title: item.title,
+    authors: [...item.authors],
+    summary: '',
+    url: item.url,
+    notes: existing?.notes ?? provenance,
+    // A re-import refreshes the Zotero metadata but never wipes the
+    // workbench-curated organization fields.
+    tags: [...(existing?.tags ?? [])],
+    projectIds: [...(existing?.projectIds ?? [])],
+    addedAt: existing?.addedAt ?? new Date().toISOString(),
+  }
+  await table.put(paperId, record)
+  return success({ imported: existing === undefined, paperId })
+}
+
+/**
+ * Export one Zotero collection as BibTeX and merge it into the addressed
+ * project's `references.bib`, skipping citation keys already present (the
+ * merge itself rides the shared `appendBibEntries` lock). An empty or
+ * unparseable export is a successful no-op.
+ * @param deps - workspace root, open wiki domain, and the resolved Zotero knobs.
+ * @param request - the selected project, the collection key, and an optional
+ * explicit paper directory.
+ * @returns the appended and the already-present citation keys, or
+ * `invalid-input` (unconfigured), `operation-failed` (API), or the merge's
+ * `project-not-found`/`paper-not-found`/`invalid-dir`.
+ */
+export async function exportZoteroCollectionToBib(
+  deps: ZoteroDeps,
+  request: { projectId: string; collectionKey: string; dir?: string | undefined },
+): Promise<ResearchZoteroExportResult> {
+  const client = clientOf(deps)
+  if (client === undefined) return rejected(UNCONFIGURED)
+  const collectionKey = request.collectionKey.trim()
+  if (collectionKey === '') return rejected({ code: 'invalid-input', message: 'collectionKey must be non-empty' })
+  let bibtex: string
+  try {
+    bibtex = await client.getItemsBibTeX(
+      { collectionKey },
+      AbortSignal.timeout(ZOTERO_FETCH_TIMEOUT_MS),
+    )
+  } catch (error) {
+    return failed(error, 'zotero BibTeX export failed')
+  }
+  return appendBibEntries(deps, {
+    projectId: request.projectId,
+    entries: parseBibtex(bibtex),
+    ...(request.dir === undefined ? {} : { dir: request.dir }),
+  })
+}

--- a/packages/mimir/src/tools/zotero.ts
+++ b/packages/mimir/src/tools/zotero.ts
@@ -1,0 +1,271 @@
+/**
+ * Zotero Web API client (read-only): a connection probe, the collection
+ * list, a full-text item search, a single-item read, and BibTeX export. The
+ * JSON payloads are parsed with plain defensive handling (the API's item
+ * shape is broad; only the fields the panel needs are read). The API key
+ * rides the `Zotero-API-Key` header — it never enters a URL, a log line, or
+ * an error message. Rate limiting (HTTP 429/503 with `Retry-After`) is
+ * honored with exactly one delayed retry; the caller owns the abort/timeout
+ * signal. Pure network in, structured data out — no fs, no wiki types.
+ * @module dsh-mimir/src/tools/zotero
+ */
+
+/** Credentials of one Zotero user library (group libraries are out of scope). */
+export interface ZoteroClientConfig {
+  /** Web API key from zotero.org/settings/keys. */
+  readonly apiKey: string
+  /** Numeric user id shown on the same settings page. */
+  readonly userId: string
+}
+
+/** Injectable fetch shape (tests substitute a mock; production uses the global). */
+export type ZoteroFetch = (url: string, init: RequestInit) => Promise<Response>
+
+/** One Zotero collection as the panel lists it. */
+export interface ZoteroCollection {
+  readonly key: string
+  readonly name: string
+  readonly itemCount: number
+}
+
+/** One Zotero item reduced to the fields the literature workbench shows. */
+export interface ZoteroItem {
+  readonly key: string
+  readonly title: string
+  /** Display names of the item's creators, in order. */
+  readonly authors: string[]
+  /** Four-digit publication year, or '' when the date does not carry one. */
+  readonly year: string
+  /** DOI, or '' when the item has none. */
+  readonly doi: string
+  /** Bare arXiv id recovered from `extra`/`url`, or null when absent. */
+  readonly arxivId: string | null
+  /** Journal/proceedings title, or '' for item types without one. */
+  readonly publicationTitle: string
+  /** Best external link: the item URL, else the DOI resolver link, else ''. */
+  readonly url: string
+}
+
+/** One BibTeX export request: either explicit item keys or one collection. */
+export type ZoteroBibRequest =
+  | { readonly itemKeys: readonly string[]; readonly collectionKey?: undefined }
+  | { readonly collectionKey: string; readonly itemKeys?: undefined }
+
+/** The read-only client surface the Zotero domain module consumes. */
+export interface ZoteroClient {
+  /** Probe the credentials: resolves when the API accepts them, rejects otherwise. */
+  readonly testConnection: (signal: AbortSignal) => Promise<void>
+  /** List every collection of the configured user library. */
+  readonly listCollections: (signal: AbortSignal) => Promise<ZoteroCollection[]>
+  /** Full-text search (`qmode=everything`) capped at `limit` items. */
+  readonly searchItems: (query: string, limit: number, signal: AbortSignal) => Promise<ZoteroItem[]>
+  /** Read one item by key; rejects with HTTP 404's message for an unknown key. */
+  readonly getItem: (key: string, signal: AbortSignal) => Promise<ZoteroItem>
+  /** Export items as BibTeX text (paginated for collections). */
+  readonly getItemsBibTeX: (request: ZoteroBibRequest, signal: AbortSignal) => Promise<string>
+}
+
+/** API base URL (a safety invariant, not a tunable). */
+const ZOTERO_API_BASE = 'https://api.zotero.org'
+/** Page size of one collection BibTeX export page (the API caps export formats at 150). */
+const ZOTERO_BIB_PAGE_LIMIT = 100
+/** Safety bound on the export pagination loop. */
+const ZOTERO_BIB_MAX_PAGES = 50
+/** Default wait before the single rate-limit retry when no usable Retry-After arrives. */
+const ZOTERO_RETRY_DEFAULT_MS = 1000
+/** Cap of the rate-limit wait (a panel action must not park for minutes). */
+const ZOTERO_RETRY_MAX_MS = 10_000
+
+/** Wait `ms`, rejecting early when the signal aborts. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'))
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/** Milliseconds to wait before the retry, from the response's Retry-After header. */
+function retryDelayMs(response: Response): number {
+  const seconds = Number(response.headers.get('retry-after'))
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, ZOTERO_RETRY_MAX_MS)
+  }
+  return ZOTERO_RETRY_DEFAULT_MS
+}
+
+/**
+ * Run one authenticated GET against the Zotero API. A 429/503 (rate limited
+ * or backing off) is retried exactly once after the response's Retry-After
+ * wait; every non-OK status then rejects with status and URL (never the key).
+ */
+async function request(
+  fetchImpl: ZoteroFetch,
+  apiKey: string,
+  url: string,
+  signal: AbortSignal,
+): Promise<Response> {
+  const init: RequestInit = { headers: { 'Zotero-API-Key': apiKey }, signal }
+  let response = await fetchImpl(url, init)
+  if (response.status === 429 || response.status === 503) {
+    await sleep(retryDelayMs(response), signal)
+    response = await fetchImpl(url, init)
+  }
+  if (!response.ok) {
+    throw new Error(`zotero API request failed: HTTP ${String(response.status)} for ${url}`)
+  }
+  return response
+}
+
+/** Read one string field of a parsed JSON object, '' for anything else. */
+function stringField(record: Record<string, unknown>, name: string): string {
+  const value = record[name]
+  return typeof value === 'string' ? value : ''
+}
+
+/** Recover a bare arXiv id from one item's `extra` field or URL, or null. */
+function extractArxivId(extra: string, url: string): string | null {
+  const candidates = [
+    /arxiv:\s*([^\s\]]+)/i.exec(extra)?.[1],
+    /arxiv\.org\/abs\/([^\s/?#]+)/i.exec(url)?.[1],
+  ]
+  for (const candidate of candidates) {
+    if (candidate === undefined) continue
+    const id = candidate.trim()
+    if (/^[a-zA-Z0-9._/-]+$/.test(id)) return id
+  }
+  return null
+}
+
+/**
+ * Reduce one raw Zotero API item to a {@link ZoteroItem}; undefined for
+ * child items (attachments, notes) and malformed payloads.
+ */
+function parseItem(raw: unknown): ZoteroItem | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const envelope = raw as Record<string, unknown>
+  const data = envelope.data
+  if (typeof data !== 'object' || data === null) return undefined
+  const fields = data as Record<string, unknown>
+  const itemType = stringField(fields, 'itemType')
+  if (itemType === 'attachment' || itemType === 'note') return undefined
+  const key = stringField(envelope, 'key')
+  if (key === '') return undefined
+  const creators = Array.isArray(fields.creators) ? fields.creators : []
+  const authors = creators.flatMap((creator): string[] => {
+    if (typeof creator !== 'object' || creator === null) return []
+    const record = creator as Record<string, unknown>
+    const single = stringField(record, 'name')
+    if (single !== '') return [single]
+    const name = `${stringField(record, 'firstName')} ${stringField(record, 'lastName')}`.trim()
+    return name === '' ? [] : [name]
+  })
+  const year = /\d{4}/.exec(stringField(fields, 'date'))?.[0] ?? ''
+  const doi = stringField(fields, 'DOI')
+  const itemUrl = stringField(fields, 'url')
+  return {
+    key,
+    title: stringField(fields, 'title'),
+    authors,
+    year,
+    doi,
+    arxivId: extractArxivId(stringField(fields, 'extra'), itemUrl),
+    publicationTitle: stringField(fields, 'publicationTitle'),
+    url: itemUrl !== '' ? itemUrl : doi === '' ? '' : `https://doi.org/${doi}`,
+  }
+}
+
+/** Parse one items-endpoint JSON body, dropping child/malformed items. */
+function parseItems(body: string): ZoteroItem[] {
+  const parsed: unknown = JSON.parse(body)
+  if (!Array.isArray(parsed)) return []
+  return parsed.flatMap(raw => {
+    const item = parseItem(raw)
+    return item === undefined ? [] : [item]
+  })
+}
+
+/** Parse one collections-endpoint JSON body. */
+function parseCollections(body: string): ZoteroCollection[] {
+  const parsed: unknown = JSON.parse(body)
+  if (!Array.isArray(parsed)) return []
+  const collections: ZoteroCollection[] = []
+  for (const raw of parsed) {
+    if (typeof raw !== 'object' || raw === null) continue
+    const envelope = raw as Record<string, unknown>
+    const data = envelope.data
+    const meta = envelope.meta
+    if (typeof data !== 'object' || data === null) continue
+    const key = stringField(envelope, 'key')
+    const name = stringField(data as Record<string, unknown>, 'name')
+    if (key === '') continue
+    const numItems = typeof meta === 'object' && meta !== null
+      ? (meta as Record<string, unknown>).numItems
+      : undefined
+    collections.push({ key, name, itemCount: typeof numItems === 'number' ? numItems : 0 })
+  }
+  return collections
+}
+
+/**
+ * Build the read-only Zotero Web API client for one configured user library.
+ * @param config - API key and user id (from the plugin config).
+ * @param fetchImpl - injectable fetch (tests); the ambient global otherwise,
+ * resolved per call so a stubbed global applies.
+ * @returns the client surface.
+ */
+export function createZoteroClient(config: ZoteroClientConfig, fetchImpl?: ZoteroFetch): ZoteroClient {
+  const base = `${ZOTERO_API_BASE}/users/${encodeURIComponent(config.userId)}`
+  const call = (url: string, signal: AbortSignal): Promise<Response> =>
+    request(fetchImpl ?? globalThis.fetch, config.apiKey, url, signal)
+  return {
+    async testConnection(signal) {
+      // One cheap authenticated read: 200 proves key + user id, 403/404 reject.
+      await call(`${base}/collections?limit=1`, signal)
+    },
+    async listCollections(signal) {
+      return parseCollections(await (await call(`${base}/collections?limit=100`, signal)).text())
+    },
+    async searchItems(query, limit, signal) {
+      const url = `${base}/items?q=${encodeURIComponent(query)}&qmode=everything&limit=${String(limit)}`
+      return parseItems(await (await call(url, signal)).text())
+    },
+    async getItem(key, signal) {
+      const body = await (await call(`${base}/items/${encodeURIComponent(key)}`, signal)).text()
+      const [item] = parseItems(`[${body}]`)
+      if (item === undefined) throw new Error(`zotero item '${key}' is not a reference item`)
+      return item
+    },
+    async getItemsBibTeX(bibRequest, signal) {
+      if (bibRequest.itemKeys !== undefined) {
+        if (bibRequest.itemKeys.length === 0) return ''
+        const keys = bibRequest.itemKeys.map(key => encodeURIComponent(key)).join(',')
+        return (await call(`${base}/items?format=bibtex&itemKey=${keys}`, signal)).text()
+      }
+      const chunks: string[] = []
+      const collection = encodeURIComponent(bibRequest.collectionKey)
+      let start = 0
+      for (let page = 0; page < ZOTERO_BIB_MAX_PAGES; page += 1) {
+        const url = `${base}/collections/${collection}/items?format=bibtex&limit=${String(ZOTERO_BIB_PAGE_LIMIT)}&start=${String(start)}`
+        const response = await call(url, signal)
+        const text = await response.text()
+        if (text.trim() === '') break
+        chunks.push(text)
+        const total = Number(response.headers.get('total-results'))
+        start += ZOTERO_BIB_PAGE_LIMIT
+        if (!Number.isFinite(total) || start >= total) break
+      }
+      return chunks.join('\n')
+    },
+  }
+}

--- a/packages/mimir/src/types.ts
+++ b/packages/mimir/src/types.ts
@@ -551,6 +551,68 @@ export type ResearchImportBibResult = ResearchResult<{
   readonly skipped: readonly string[]
 }>
 
+/** One Zotero collection as the panel lists it. */
+export interface ZoteroCollectionView {
+  readonly key: string
+  readonly name: string
+  readonly itemCount: number
+}
+
+/** One Zotero item reduced to the fields the literature workbench shows. */
+export interface ZoteroItemView {
+  readonly key: string
+  readonly title: string
+  /** Display names of the item's creators, in order. */
+  readonly authors: readonly string[]
+  /** Four-digit publication year, or '' when the date does not carry one. */
+  readonly year: string
+  /** DOI, or '' when the item has none. */
+  readonly doi: string
+  /** Bare arXiv id recovered from `extra`/`url`, or null when absent. */
+  readonly arxivId: string | null
+  /** Journal/proceedings title, or '' for item types without one. */
+  readonly publicationTitle: string
+  /** Best external link: the item URL, else the DOI resolver link, else ''. */
+  readonly url: string
+}
+
+/** The settled outcome of one `checkZotero` probe. */
+export interface ZoteroStatusView {
+  /**
+   * `unconfigured` when the plugin config carries no API key/user id,
+   * `ok` when the API accepted the credentials, `failed` otherwise.
+   */
+  readonly state: 'unconfigured' | 'ok' | 'failed'
+  /** Failure reason when the state is `failed`; absent otherwise. */
+  readonly message?: string | undefined
+}
+
+/** `checkZotero` result: the settled connection status (never a business failure). */
+export type ResearchCheckZoteroResult = ResearchResult<ZoteroStatusView>
+
+/** `listZoteroCollections` result: every collection of the configured user library. */
+export type ResearchZoteroCollectionsResult = ResearchResult<{
+  readonly collections: readonly ZoteroCollectionView[]
+}>
+
+/** `searchZotero` result: the parsed items matching the query. */
+export type ResearchZoteroSearchResult = ResearchResult<{
+  readonly results: readonly ZoteroItemView[]
+}>
+
+/** `importZoteroItem` result: whether the paper was newly imported, plus its papers-table id. */
+export type ResearchZoteroImportResult = ResearchResult<{
+  readonly imported: boolean
+  /** The papers-table key: the bare arXiv id, or `zotero-<item key>` for arXiv-less items. */
+  readonly paperId: string
+}>
+
+/** `exportZoteroCollectionToBib` result: appended and already-present citation keys. */
+export type ResearchZoteroExportResult = ResearchResult<{
+  readonly added: readonly string[]
+  readonly skipped: readonly string[]
+}>
+
 /** The seven research-wiki tables, in domain order (the runtime-only `jobs` table is excluded). */
 export type ResearchWikiTableName = 'papers' | 'ideas' | 'claims' | 'projects' | 'experiments' | 'servers' | 'figures'
 

--- a/packages/mimir/tests/zotero.spec.ts
+++ b/packages/mimir/tests/zotero.spec.ts
@@ -1,0 +1,390 @@
+/**
+ * Behavior tests for the Zotero integration: the read-only Web API client
+ * (injected mock fetch: parsing, pagination, auth header, the single
+ * rate-limit retry), and the five Remote methods over a real memory-backed
+ * domain (unconfigured failure vocabulary, import idempotence and PaperRecord
+ * mapping, the BibTeX merge/dedup, and the wiki-schema-stays-v2 regression).
+ * No test touches the real api.zotero.org.
+ */
+
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import { ResearchService } from '../src/service.ts'
+import { createZoteroClient } from '../src/tools/zotero.ts'
+import type { ZoteroFetch } from '../src/tools/zotero.ts'
+import type { ProjectRecord } from '../src/types.ts'
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+/** One journal-article item body the API would return (arXiv id in `extra`). */
+const ARXIV_ITEM = {
+  key: 'ABCD2345',
+  version: 3,
+  data: {
+    key: 'ABCD2345',
+    itemType: 'journalArticle',
+    title: 'Attention Is All You Need',
+    creators: [
+      { creatorType: 'author', firstName: 'Ashish', lastName: 'Vaswani' },
+      { creatorType: 'author', name: 'Google Brain' },
+    ],
+    date: '2017-06-12',
+    DOI: '10.5555/3295222.3295349',
+    url: '',
+    publicationTitle: 'Advances in Neural Information Processing Systems',
+    extra: 'arXiv: 1706.03762 [cs.CL]',
+  },
+}
+
+/** One book item without any arXiv trace (the `zotero-<key>` import path). */
+const PLAIN_ITEM = {
+  key: 'WXYZ9876',
+  version: 1,
+  data: {
+    key: 'WXYZ9876',
+    itemType: 'book',
+    title: 'Deep Learning',
+    creators: [{ creatorType: 'author', firstName: 'Ian', lastName: 'Goodfellow' }],
+    date: '2016',
+    DOI: '10.1000/xyz',
+    url: 'https://example.com/deep-learning',
+    extra: '',
+  },
+}
+
+/** A response whose JSON body is the given payload. */
+function json(payload: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(payload), { status, headers })
+}
+
+describe('createZoteroClient', () => {
+  const CONFIG = { apiKey: 'secret-key', userId: '12345678' }
+  const SIGNAL = AbortSignal.timeout(5000)
+
+  it('sends the API key as a header, never in the URL', async () => {
+    let seenUrl = ''
+    let seenKey = ''
+    const fetchMock: ZoteroFetch = async (url, init) => {
+      seenUrl = url
+      seenKey = (init.headers as Record<string, string>)['Zotero-API-Key'] ?? ''
+      return json([])
+    }
+    const client = createZoteroClient(CONFIG, fetchMock)
+    await client.listCollections(SIGNAL)
+    expect(seenKey).toBe('secret-key')
+    expect(seenUrl).toBe('https://api.zotero.org/users/12345678/collections?limit=100')
+    expect(seenUrl).not.toContain('secret-key')
+  })
+
+  it('parses collections down to key, name, and item count', async () => {
+    const client = createZoteroClient(CONFIG, async () => json([
+      { key: 'COLL1', data: { key: 'COLL1', name: 'Papers' }, meta: { numItems: 7 } },
+      { key: 'COLL2', data: { key: 'COLL2', name: 'Books' }, meta: {} },
+      { data: { name: 'broken' } },
+    ]))
+    await expect(client.listCollections(SIGNAL)).resolves.toEqual([
+      { key: 'COLL1', name: 'Papers', itemCount: 7 },
+      { key: 'COLL2', name: 'Books', itemCount: 0 },
+    ])
+  })
+
+  it('parses search items and recovers arXiv ids from extra and url', async () => {
+    let seenUrl = ''
+    const client = createZoteroClient(CONFIG, async (url) => {
+      seenUrl = url
+      return json([
+        ARXIV_ITEM,
+        { key: 'URLARXIV', data: { key: 'URLARXIV', itemType: 'preprint', title: 'T', url: 'https://arxiv.org/abs/2401.00099v2' } },
+        { key: 'ATTACH', data: { key: 'ATTACH', itemType: 'attachment', title: 'fulltext.pdf' } },
+        { key: 'NOTE', data: { key: 'NOTE', itemType: 'note', note: 'a note' } },
+      ])
+    })
+    const items = await client.searchItems('attention', 25, SIGNAL)
+    expect(seenUrl).toContain('q=attention&qmode=everything&limit=25')
+    expect(items).toHaveLength(2)
+    expect(items[0]).toEqual({
+      key: 'ABCD2345',
+      title: 'Attention Is All You Need',
+      authors: ['Ashish Vaswani', 'Google Brain'],
+      year: '2017',
+      doi: '10.5555/3295222.3295349',
+      arxivId: '1706.03762',
+      publicationTitle: 'Advances in Neural Information Processing Systems',
+      url: 'https://doi.org/10.5555/3295222.3295349',
+    })
+    expect(items[1]?.arxivId).toBe('2401.00099v2')
+    expect(items[1]?.year).toBe('')
+  })
+
+  it('reads one item and rejects an attachment as not-a-reference', async () => {
+    const client = createZoteroClient(CONFIG, async () => json(PLAIN_ITEM))
+    const item = await client.getItem('WXYZ9876', SIGNAL)
+    expect(item.title).toBe('Deep Learning')
+    expect(item.arxivId).toBeNull()
+    const attachments = createZoteroClient(CONFIG, async () =>
+      json({ key: 'ATTACH', data: { key: 'ATTACH', itemType: 'attachment', title: 'fulltext.pdf' } }))
+    await expect(attachments.getItem('ATTACH', SIGNAL)).rejects.toThrow('not a reference item')
+  })
+
+  it('exports explicit item keys as BibTeX and short-circuits an empty key list', async () => {
+    let fetches = 0
+    let seenUrl = ''
+    const client = createZoteroClient(CONFIG, async (url) => {
+      fetches += 1
+      seenUrl = url
+      return new Response('@misc{a,\n  title = {A}\n}\n', { status: 200 })
+    })
+    await expect(client.getItemsBibTeX({ itemKeys: [] }, SIGNAL)).resolves.toBe('')
+    expect(fetches).toBe(0)
+    const bib = await client.getItemsBibTeX({ itemKeys: ['ABCD2345', 'WXYZ9876'] }, SIGNAL)
+    expect(bib).toContain('@misc{a,')
+    expect(seenUrl).toContain('format=bibtex&itemKey=ABCD2345,WXYZ9876')
+  })
+
+  it('paginates a collection export by the Total-Results header', async () => {
+    const seenStarts: string[] = []
+    const client = createZoteroClient(CONFIG, async (url) => {
+      const start = new URL(url).searchParams.get('start') ?? ''
+      seenStarts.push(start)
+      return new Response(`@misc{page${start},\n  title = {T}\n}\n`, {
+        status: 200,
+        headers: start === '0' ? { 'Total-Results': '120' } : {},
+      })
+    })
+    const bib = await client.getItemsBibTeX({ collectionKey: 'COLL1' }, SIGNAL)
+    expect(seenStarts).toEqual(['0', '100'])
+    expect(bib).toContain('@misc{page0,')
+    expect(bib).toContain('@misc{page100,')
+  })
+
+  it('retries a 429 once after Retry-After, then reports the failure', async () => {
+    let attempts = 0
+    const flaky = createZoteroClient(CONFIG, async () => {
+      attempts += 1
+      return attempts === 1
+        ? new Response('slow down', { status: 429, headers: { 'Retry-After': '0' } })
+        : json([])
+    })
+    await expect(flaky.listCollections(SIGNAL)).resolves.toEqual([])
+    expect(attempts).toBe(2)
+
+    let stubborn = 0
+    const limited = createZoteroClient(CONFIG, async () => {
+      stubborn += 1
+      return new Response('slow down', { status: 429, headers: { 'Retry-After': '0' } })
+    })
+    await expect(limited.listCollections(SIGNAL)).rejects.toThrow('HTTP 429')
+    expect(stubborn).toBe(2)
+  })
+
+  it('rejects HTTP failures with status and URL, never the API key', async () => {
+    const client = createZoteroClient(CONFIG, async () => new Response('forbidden', { status: 403 }))
+    await expect(client.testConnection(SIGNAL)).rejects.toThrow('HTTP 403')
+    await expect(client.testConnection(SIGNAL)).rejects.not.toThrow('secret-key')
+  })
+})
+
+/** Boot a service over a memory-backed domain and a fresh temp workspace. */
+async function harness(zotero?: { apiKey: string; userId: string }) {
+  const ctx = new Context()
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  const domain = await facility.open(researchWikiDomainSpec)
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-zotero-'))
+  const service = new ResearchService(ctx, {
+    workspaceDir,
+    domain,
+    latex: { engine: 'auto', timeoutMs: 1000 },
+    ...(zotero === undefined ? {} : { zotero }),
+  })
+  return { ctx, domain, workspaceDir, service }
+}
+
+const CONFIGURED = { apiKey: 'secret-key', userId: '12345678' }
+
+const PROJECT: ProjectRecord = {
+  id: 'p1',
+  title: 'Project',
+  stage: 'writing',
+  artifacts: [],
+  reviewRounds: 0,
+  updatedAt: '2026-08-20T00:00:00.000Z',
+}
+
+describe('ResearchService zotero methods, unconfigured', () => {
+  it('checkZotero reports unconfigured; the other four reject invalid-input', async () => {
+    const { service } = await harness()
+    await expect(service.checkZotero()).resolves.toEqual({ ok: true, value: { state: 'unconfigured' } })
+    await expect(service.listZoteroCollections())
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input', message: expect.stringContaining('zotero.apiKey') } })
+    await expect(service.searchZotero({ query: 'mesh' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+    await expect(service.importZoteroItem({ key: 'ABCD2345' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+    await expect(service.exportZoteroCollectionToBib({ projectId: 'p1', collectionKey: 'COLL1' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+  })
+
+  it('blank credentials in the config count as unconfigured too', async () => {
+    const { service } = await harness({ apiKey: '  ', userId: '12345678' })
+    await expect(service.checkZotero()).resolves.toEqual({ ok: true, value: { state: 'unconfigured' } })
+  })
+})
+
+describe('ResearchService.checkZotero', () => {
+  it('reports ok when the API accepts the credentials', async () => {
+    vi.stubGlobal('fetch', async () => json([]))
+    const { service } = await harness(CONFIGURED)
+    await expect(service.checkZotero()).resolves.toEqual({ ok: true, value: { state: 'ok' } })
+  })
+
+  it('reports failed with the underlying reason, never the key', async () => {
+    vi.stubGlobal('fetch', async () => new Response('forbidden', { status: 403 }))
+    const { service } = await harness(CONFIGURED)
+    const outcome = await service.checkZotero()
+    expect(outcome).toMatchObject({ ok: true, value: { state: 'failed', message: expect.stringContaining('HTTP 403') } })
+    expect(outcome.ok && outcome.value.message).not.toContain('secret-key')
+  })
+})
+
+describe('ResearchService.listZoteroCollections / searchZotero', () => {
+  it('lists parsed collections', async () => {
+    vi.stubGlobal('fetch', async () => json([
+      { key: 'COLL1', data: { key: 'COLL1', name: 'Papers' }, meta: { numItems: 7 } },
+    ]))
+    const { service } = await harness(CONFIGURED)
+    await expect(service.listZoteroCollections()).resolves.toEqual({
+      ok: true,
+      value: { collections: [{ key: 'COLL1', name: 'Papers', itemCount: 7 }] },
+    })
+  })
+
+  it('searches with validation and maps API failures to operation-failed', async () => {
+    vi.stubGlobal('fetch', async () => json([ARXIV_ITEM]))
+    const { service } = await harness(CONFIGURED)
+    const outcome = await service.searchZotero({ query: 'attention' })
+    expect(outcome).toMatchObject({
+      ok: true,
+      value: { results: [{ key: 'ABCD2345', arxivId: '1706.03762', year: '2017' }] },
+    })
+    await expect(service.searchZotero({ query: '  ' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+    await expect(service.searchZotero({ query: 'mesh', maxResults: 51 }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+    vi.stubGlobal('fetch', async () => { throw new Error('socket hangup') })
+    await expect(service.searchZotero({ query: 'mesh' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'operation-failed', message: 'socket hangup' } })
+  })
+})
+
+describe('ResearchService.importZoteroItem', () => {
+  it('imports an arXiv-carrying item through the regular importPaper path', async () => {
+    vi.stubGlobal('fetch', async () => json(ARXIV_ITEM))
+    const { domain, service } = await harness(CONFIGURED)
+    const outcome = await service.importZoteroItem({ key: 'ABCD2345' })
+    expect(outcome).toEqual({ ok: true, value: { imported: true, paperId: '1706.03762' } })
+    expect(domain.table('papers').get('1706.03762')).toMatchObject({
+      arxivId: '1706.03762',
+      title: 'Attention Is All You Need',
+      authors: ['Ashish Vaswani', 'Google Brain'],
+      url: 'https://arxiv.org/abs/1706.03762',
+    })
+    // A re-import refreshes metadata but preserves workbench-curated notes.
+    await service.updatePaper({ arxivId: '1706.03762', notes: 'keep me' })
+    const again = await service.importZoteroItem({ key: 'ABCD2345' })
+    expect(again).toEqual({ ok: true, value: { imported: false, paperId: '1706.03762' } })
+    expect(domain.table('papers').get('1706.03762')?.notes).toBe('keep me')
+  })
+
+  it('imports an arXiv-less item under zotero-<key> with provenance in the notes', async () => {
+    vi.stubGlobal('fetch', async () => json(PLAIN_ITEM))
+    const { domain, service } = await harness(CONFIGURED)
+    const outcome = await service.importZoteroItem({ key: 'WXYZ9876' })
+    expect(outcome).toEqual({ ok: true, value: { imported: true, paperId: 'zotero-WXYZ9876' } })
+    const record = domain.table('papers').get('zotero-WXYZ9876')
+    expect(record).toMatchObject({
+      arxivId: 'zotero-WXYZ9876',
+      title: 'Deep Learning',
+      authors: ['Ian Goodfellow'],
+      url: 'https://example.com/deep-learning',
+    })
+    expect(record?.notes).toContain('Imported from Zotero (item WXYZ9876)')
+    expect(record?.notes).toContain('DOI: 10.1000/xyz')
+  })
+
+  it('maps a missing item to operation-failed and rejects a blank key', async () => {
+    vi.stubGlobal('fetch', async () => new Response('not found', { status: 404 }))
+    const { service } = await harness(CONFIGURED)
+    await expect(service.importZoteroItem({ key: 'GHOST000' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'operation-failed', message: expect.stringContaining('HTTP 404') } })
+    await expect(service.importZoteroItem({ key: '  ' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+  })
+})
+
+describe('ResearchService.exportZoteroCollectionToBib', () => {
+  const EXPORT_BIB = '@article{vaswani2017attention,\n  title = {Attention Is All You Need},\n  year = {2017}\n}\n\n@misc{existing,\n  title = {Already Here}\n}\n'
+
+  /** Seed the project and its paper directory with one pre-existing bib entry. */
+  async function seedProject() {
+    const { domain, workspaceDir, service } = await harness(CONFIGURED)
+    await domain.table('projects').put(PROJECT.id, PROJECT)
+    const dir = join(workspaceDir, 'paper')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'references.bib'), '@misc{existing,\n  title = {Already Here}\n}\n')
+    return { domain, workspaceDir, service }
+  }
+
+  it('merges the collection BibTeX, skipping citation keys already present', async () => {
+    vi.stubGlobal('fetch', async (url: string) => {
+      expect(String(url)).toContain('/collections/COLL1/items?format=bibtex')
+      return new Response(EXPORT_BIB, { status: 200 })
+    })
+    const { service, workspaceDir } = await seedProject()
+    const outcome = await service.exportZoteroCollectionToBib({ projectId: 'p1', collectionKey: 'COLL1' })
+    expect(outcome).toEqual({ ok: true, value: { added: ['vaswani2017attention'], skipped: ['existing'] } })
+    const text = await readFile(join(workspaceDir, 'paper', 'references.bib'), 'utf8')
+    expect(text).toContain('@article{vaswani2017attention,')
+    // The pre-existing entry survived the merge exactly once.
+    expect(text.match(/@misc\{existing,/g)).toHaveLength(1)
+    // A repeat export adds nothing.
+    const again = await service.exportZoteroCollectionToBib({ projectId: 'p1', collectionKey: 'COLL1' })
+    expect(again).toEqual({ ok: true, value: { added: [], skipped: ['vaswani2017attention', 'existing'] } })
+  })
+
+  it('rejects an unknown project without writing anything', async () => {
+    vi.stubGlobal('fetch', async () => new Response(EXPORT_BIB, { status: 200 }))
+    const { service, workspaceDir } = await seedProject()
+    await expect(service.exportZoteroCollectionToBib({ projectId: 'ghost', collectionKey: 'COLL1' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'project-not-found', projectId: 'ghost' } })
+    const text = await readFile(join(workspaceDir, 'paper', 'references.bib'), 'utf8')
+    expect(text).not.toContain('vaswani2017attention')
+  })
+
+  it('maps API failures to operation-failed', async () => {
+    vi.stubGlobal('fetch', async () => new Response('busy', { status: 500 }))
+    const { service } = await seedProject()
+    await expect(service.exportZoteroCollectionToBib({ projectId: 'p1', collectionKey: 'COLL1' }))
+      .resolves.toMatchObject({ ok: false, error: { code: 'operation-failed', message: expect.stringContaining('HTTP 500') } })
+  })
+})
+
+describe('wiki schema regression', () => {
+  it('the domain spec stays at version 2 with the eight existing tables', () => {
+    expect(researchWikiDomainSpec.version).toBe(2)
+    expect(Object.keys(researchWikiDomainSpec.tables)).toEqual([
+      'papers', 'ideas', 'claims', 'projects', 'experiments', 'servers', 'jobs', 'figures',
+    ])
+  })
+})

--- a/packages/ui-mimir/src/client/PapersView.tsx
+++ b/packages/ui-mimir/src/client/PapersView.tsx
@@ -20,7 +20,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { ArxivEntry, PaperRecord, ResearchProjectView } from 'dsh-mimir/types'
 import type {
   ResearchArxivSearchView, ResearchFailureView, ResearchImportCounts, ResearchPapersView,
-  ResearchSubscriptionsView,
+  ResearchSubscriptionsView, ResearchZoteroSearchView, ResearchZoteroView,
 } from './controller.ts'
 import { collectTags, failureCopy, filterPapers, paperPdfUrl, type ResearchT } from './view-common.ts'
 import { appendReadingNote, parseReadingNotes } from './paper-notes.ts'
@@ -28,6 +28,7 @@ import { buildRelatedWorkPrompt } from './related-work.ts'
 import { EmptyState } from './EmptyState.tsx'
 import { SubscriptionsBar } from './SubscriptionsBar.tsx'
 import { ViewHead } from './ViewHead.tsx'
+import { ZoteroSection } from './ZoteroSection.tsx'
 import css from './ResearchPanel.module.css'
 
 /** Fields the inline editor saves back through `updatePaper`. */
@@ -248,7 +249,9 @@ function AddToBibButton({ paper, projectId, importPapersToBib, onError, t }: {
 export function PapersView({
   papers, arxivSearch, arxivSubscriptions, projects, selectedProjectId, ensurePapers, searchArxiv,
   saveArxivSubscription, deleteArxivSubscription, checkArxivSubscriptions,
-  importPaper, updatePaper, removePaper, importPapersToBib, fetchPaperPdf, requestRelatedWork, t,
+  importPaper, updatePaper, removePaper, importPapersToBib, fetchPaperPdf,
+  zotero, zoteroSearch, recheckZotero, searchZotero, importZoteroItem, exportZoteroCollectionToBib,
+  requestRelatedWork, t,
 }: {
   readonly papers: ResearchPapersView
   readonly arxivSearch: ResearchArxivSearchView | null
@@ -268,6 +271,15 @@ export function PapersView({
     arxivIds: string[],
   ) => Promise<ResearchFailureView | ResearchImportCounts>
   readonly fetchPaperPdf: (arxivId: string) => Promise<ResearchFailureView | null>
+  readonly zotero: ResearchZoteroView
+  readonly zoteroSearch: ResearchZoteroSearchView | null
+  readonly recheckZotero: () => void
+  readonly searchZotero: (query: string) => void
+  readonly importZoteroItem: (key: string) => Promise<ResearchFailureView | null>
+  readonly exportZoteroCollectionToBib: (
+    projectId: string,
+    collectionKey: string,
+  ) => Promise<ResearchFailureView | ResearchImportCounts>
   readonly requestRelatedWork: (prompt: string) => Promise<void>
   readonly t: ResearchT
 }) {
@@ -399,6 +411,18 @@ export function PapersView({
       {actionError !== null && (
         <p className={css.failure} role="alert">{actionError}</p>
       )}
+      <ZoteroSection
+        zotero={zotero}
+        zoteroSearch={zoteroSearch}
+        importedIds={importedIds}
+        selectedProjectId={selectedProjectId}
+        recheckZotero={recheckZotero}
+        searchZotero={searchZotero}
+        importZoteroItem={importZoteroItem}
+        exportZoteroCollectionToBib={exportZoteroCollectionToBib}
+        onError={setActionError}
+        t={t}
+      />
       {arxivSearch !== null && (
         <section className={css.papersSearchPanel}>
           <h3 className={css.sectionTitle}>

--- a/packages/ui-mimir/src/client/ResearchPanel.module.css
+++ b/packages/ui-mimir/src/client/ResearchPanel.module.css
@@ -3450,3 +3450,46 @@ li.dropIndicator {
   margin: 0;
 }
 /* --- end arXiv subscriptions --- */
+
+/* --- Zotero section (feat/zotero): appended block, merged independently of the visual-polish refactor --- */
+.zoteroSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-radius: 10px;
+  background: var(--dsw-specific-menu, #fff);
+}
+
+.zoteroSection .sectionTitle {
+  margin: 0;
+}
+
+.zoteroSection .hint,
+.zoteroSection .failure {
+  margin: 0;
+}
+
+.zoteroControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.zoteroSelect {
+  max-width: 260px;
+  padding: 6px 8px;
+  border: 1px solid var(--dsw-alias-border-l2, rgb(0 0 0 / 10%));
+  border-radius: 8px;
+  background: var(--dsw-specific-menu, #fff);
+  color: var(--dsw-alias-label-primary, #17233d);
+  font-size: 12px;
+}
+
+.zoteroSelect:focus-visible {
+  outline: 2px solid var(--dsw-alias-focus-border, #4f7cff);
+  outline-offset: 1px;
+}
+/* --- end Zotero section --- */

--- a/packages/ui-mimir/src/client/ResearchPanel.tsx
+++ b/packages/ui-mimir/src/client/ResearchPanel.tsx
@@ -122,6 +122,7 @@ export function ResearchPanel({
   requestRelatedWork,
   ensurePapers, searchArxiv, importPaper, removePaper, updatePaper, fetchPaperPdf, loadArtifact, loadFigures, uploadFigures, deleteFigure,
   ensureSubscriptions, saveArxivSubscription, deleteArxivSubscription, checkArxivSubscriptions,
+  ensureZotero, recheckZotero, searchZotero, importZoteroItem, exportZoteroCollectionToBib,
   insertFigure, consumePaperJump, generateMetricFigure,
   deleteExperiment, updateExperiment, saveExperiment, ensureServers, saveServer, deleteServer, checkServer, checkAllServers,
   ensureJobs, refreshJobs, submitJob, deleteJob,
@@ -144,6 +145,8 @@ export function ResearchPanel({
   const papers = useResearch(view => view.papers)
   const arxivSearch = useResearch(view => view.arxivSearch)
   const arxivSubscriptions = useResearch(view => view.arxivSubscriptions)
+  const zotero = useResearch(view => view.zotero)
+  const zoteroSearch = useResearch(view => view.zoteroSearch)
   const experiments = useResearch(view => view.experiments)
   const artifact = useResearch(view => view.artifact)
   const figures = useResearch(view => view.figures)
@@ -173,7 +176,8 @@ export function ResearchPanel({
   useEffect(() => {
     if (open && activeTab === 'papers') ensurePapers()
     if (open && activeTab === 'papers') ensureSubscriptions()
-  }, [open, activeTab, ensurePapers, ensureSubscriptions])
+    if (open && activeTab === 'papers') ensureZotero()
+  }, [open, activeTab, ensurePapers, ensureSubscriptions, ensureZotero])
   // The overview's stat chips count the papers and figures slices, both lazy:
   // warm them when the overview opens so the chips show real numbers instead
   // of dashes; the activity card reads the jobs slice, equally lazy. The
@@ -447,6 +451,12 @@ export function ResearchPanel({
             removePaper={removePaper}
             importPapersToBib={importPapersToBib}
             fetchPaperPdf={fetchPaperPdf}
+            zotero={zotero}
+            zoteroSearch={zoteroSearch}
+            recheckZotero={recheckZotero}
+            searchZotero={searchZotero}
+            importZoteroItem={importZoteroItem}
+            exportZoteroCollectionToBib={exportZoteroCollectionToBib}
             requestRelatedWork={requestRelatedWork}
             t={t}
           />

--- a/packages/ui-mimir/src/client/ZoteroSection.tsx
+++ b/packages/ui-mimir/src/client/ZoteroSection.tsx
@@ -1,0 +1,231 @@
+/**
+ * The papers view's Zotero section: a connection-status line (unconfigured
+ * guidance, a failed probe with retry, or the live collection picker), a
+ * full-text search of the configured library with one-click import into the
+ * wiki, and the "export collection to references.bib" action addressed to
+ * the selected project. All data arrives through props; the component owns
+ * only the picker/search local state.
+ * @module dsh-client-ui-mimir/client/ZoteroSection
+ */
+
+import { useState } from 'react'
+import type { ZoteroItemView } from 'dsh-mimir/types'
+import type {
+  ResearchFailureView, ResearchImportCounts, ResearchZoteroSearchView, ResearchZoteroView,
+} from './controller.ts'
+import { failureCopy, type ResearchT } from './view-common.ts'
+import css from './ResearchPanel.module.css'
+
+/** The papers-table id an item import lands under (mirrors the host's mapping). */
+function paperIdOf(item: ZoteroItemView): string {
+  return item.arxivId ?? `zotero-${item.key}`
+}
+
+/**
+ * @param props - the Zotero slices, the library's imported ids (for the
+ * per-row imported state), the selected project (the export target), the
+ * verbs, and copy.
+ * @returns the section; a bare loading line until the first probe settles.
+ */
+export function ZoteroSection({
+  zotero, zoteroSearch, importedIds, selectedProjectId,
+  recheckZotero, searchZotero, importZoteroItem, exportZoteroCollectionToBib, onError, t,
+}: {
+  readonly zotero: ResearchZoteroView
+  readonly zoteroSearch: ResearchZoteroSearchView | null
+  readonly importedIds: ReadonlySet<string>
+  readonly selectedProjectId: string | null
+  readonly recheckZotero: () => void
+  readonly searchZotero: (query: string) => void
+  readonly importZoteroItem: (key: string) => Promise<ResearchFailureView | null>
+  readonly exportZoteroCollectionToBib: (
+    projectId: string,
+    collectionKey: string,
+  ) => Promise<ResearchFailureView | ResearchImportCounts>
+  readonly onError: (message: string | null) => void
+  readonly t: ResearchT
+}) {
+  const [query, setQuery] = useState('')
+  const [collectionKey, setCollectionKey] = useState('')
+  const [importing, setImporting] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
+  const [exported, setExported] = useState<string | null>(null)
+
+  const submitSearch = (): void => {
+    if (query.trim() === '') return
+    setExported(null)
+    searchZotero(query)
+  }
+  const importItem = (item: ZoteroItemView): void => {
+    if (importing !== null) return
+    setImporting(item.key)
+    onError(null)
+    void importZoteroItem(item.key)
+      .then((failure) => {
+        if (failure !== null) onError(`${t('papers.importFailed')}：${failure.message}`)
+      })
+      .finally(() => { setImporting(null) })
+  }
+  const exportCollection = (): void => {
+    if (exporting || selectedProjectId === null || collectionKey === '') return
+    setExporting(true)
+    setExported(null)
+    onError(null)
+    void exportZoteroCollectionToBib(selectedProjectId, collectionKey)
+      .then((outcome) => {
+        if ('code' in outcome) {
+          onError(`${t('zotero.exportFailed')}：${outcome.message}`)
+        } else {
+          setExported(t('zotero.exported', { added: outcome.added.length, skipped: outcome.skipped.length }))
+        }
+      })
+      .finally(() => { setExporting(false) })
+  }
+
+  if (zotero.status === 'cold' || zotero.status === 'loading') {
+    return <p className={css.hint}>{t('zotero.checking')}</p>
+  }
+  if (zotero.status === 'error') {
+    return (
+      <p className={css.failure} role="alert">
+        {t('zotero.failed')}：{failureCopy(t, zotero.failure)}
+        <button type="button" className={css.btn} onClick={recheckZotero}>
+          {t('projects.retry')}
+        </button>
+      </p>
+    )
+  }
+  if (zotero.state === 'unconfigured') {
+    return (
+      <section className={css.zoteroSection}>
+        <h3 className={css.sectionTitle}>{t('zotero.title')}</h3>
+        <p className={css.hint}>{t('zotero.unconfigured')}</p>
+      </section>
+    )
+  }
+  if (zotero.state === 'failed') {
+    return (
+      <section className={css.zoteroSection}>
+        <h3 className={css.sectionTitle}>{t('zotero.title')}</h3>
+        <p className={css.failure} role="alert">
+          {t('zotero.failed')}{zotero.message === null ? '' : `：${zotero.message}`}
+          <button type="button" className={css.btn} onClick={recheckZotero}>
+            {t('projects.retry')}
+          </button>
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className={css.zoteroSection}>
+      <h3 className={css.sectionTitle}>{t('zotero.title')}</h3>
+      <div className={css.zoteroControls}>
+        {zotero.collections.length === 0 ? (
+          <span className={css.hint}>{t('zotero.noCollections')}</span>
+        ) : (
+          <>
+            <select
+              className={css.zoteroSelect}
+              aria-label={t('zotero.collection')}
+              value={collectionKey}
+              onChange={(event) => { setCollectionKey(event.target.value) }}
+            >
+              <option value="">{t('zotero.collection')}</option>
+              {zotero.collections.map(collection => (
+                <option key={collection.key} value={collection.key}>
+                  {collection.name}（{collection.itemCount}）
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className={css.btn}
+              disabled={exporting || selectedProjectId === null || collectionKey === ''}
+              title={selectedProjectId === null ? t('bib.noProject') : undefined}
+              onClick={exportCollection}
+            >
+              {exporting ? t('zotero.exporting') : t('zotero.export')}
+            </button>
+          </>
+        )}
+      </div>
+      {exported !== null && <p className={css.hint}>{exported}</p>}
+      <form
+        className={css.papersSearchBar}
+        onSubmit={(event) => {
+          event.preventDefault()
+          submitSearch()
+        }}
+      >
+        <input
+          className={css.input}
+          value={query}
+          placeholder={t('zotero.searchPlaceholder')}
+          onChange={event => { setQuery(event.target.value) }}
+        />
+        <button
+          type="submit"
+          className={css.btnPrimary}
+          disabled={query.trim() === '' || zoteroSearch?.status === 'loading'}
+        >
+          {zoteroSearch?.status === 'loading' ? t('papers.searching') : t('papers.search')}
+        </button>
+      </form>
+      {zoteroSearch !== null && (
+        <>
+          {zoteroSearch.status === 'loading' ? (
+            <p className={css.hint}>{t('papers.searching')}</p>
+          ) : zoteroSearch.status === 'error' ? (
+            <p className={css.failure} role="alert">
+              {failureCopy(t, zoteroSearch.failure)}
+              <button type="button" className={css.btn} onClick={() => { searchZotero(zoteroSearch.query) }}>
+                {t('error.retry')}
+              </button>
+            </p>
+          ) : zoteroSearch.list.length === 0 ? (
+            <p className={css.hint}>{t('zotero.searchEmpty')}</p>
+          ) : (
+            <div className={css.papersResults}>
+              {zoteroSearch.list.map(item => (
+                <article key={item.key} className={css.paperResult}>
+                  <div className={css.paperResultHead}>
+                    <h3 className={css.paperCardTitle}>
+                      {item.url === ''
+                        ? item.title
+                        : (
+                          <a href={item.url} target="_blank" rel="noreferrer">
+                            {item.title}
+                          </a>
+                        )}
+                    </h3>
+                    {importedIds.has(paperIdOf(item)) ? (
+                      <button type="button" className={css.btn} disabled>
+                        {t('papers.imported')}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className={css.btnPrimary}
+                        disabled={importing !== null}
+                        onClick={() => { importItem(item) }}
+                      >
+                        {importing === item.key ? t('papers.importing') : t('papers.import')}
+                      </button>
+                    )}
+                  </div>
+                  <p className={css.paperCardMeta}>
+                    {item.authors.length > 0 && `${item.authors.join('，')} · `}
+                    {item.year}
+                    {item.publicationTitle !== '' && ` · ${item.publicationTitle}`}
+                    {item.doi !== '' && ` · DOI: ${item.doi}`}
+                  </p>
+                </article>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/packages/ui-mimir/src/client/controller.ts
+++ b/packages/ui-mimir/src/client/controller.ts
@@ -34,6 +34,7 @@ import type {
   ResearchBibliographyResult,
   ResearchCheckArxivSubscriptionsResult,
   ResearchCheckServerResult,
+  ResearchCheckZoteroResult,
   ResearchCompileResult,
   ResearchCompileStatusResult,
   ResearchCompileStatusView,
@@ -75,16 +76,22 @@ import type {
   ResearchUpdateExperimentResult,
   ResearchUpdatePaperResult,
   ResearchWikiSnapshot,
+  ResearchZoteroCollectionsResult,
+  ResearchZoteroExportResult,
+  ResearchZoteroImportResult,
+  ResearchZoteroSearchResult,
   SectionMove,
   SectionOutlineTitles,
   ServerInput,
   ServerRecord,
   ServerStatusView,
   SubsectionMove,
+  ZoteroCollectionView,
+  ZoteroItemView,
 } from 'dsh-mimir/types'
 
 /**
- * The forty Remote calls this controller needs, exactly as the
+ * The Remote calls this controller needs, exactly as the
  * generated `research` namespace types them.
  */
 export interface ResearchRemote {
@@ -110,6 +117,15 @@ export interface ResearchRemote {
     notes?: string | undefined
   }) => Promise<RemoteResult<ResearchUpdatePaperResult>>
   fetchPaperPdf: (request: { arxivId: string }) => Promise<RemoteResult<ResearchFetchPaperPdfResult>>
+  checkZotero: () => Promise<RemoteResult<ResearchCheckZoteroResult>>
+  listZoteroCollections: () => Promise<RemoteResult<ResearchZoteroCollectionsResult>>
+  searchZotero: (request: { query: string; maxResults?: number }) => Promise<RemoteResult<ResearchZoteroSearchResult>>
+  importZoteroItem: (request: { key: string }) => Promise<RemoteResult<ResearchZoteroImportResult>>
+  exportZoteroCollectionToBib: (request: {
+    projectId: string
+    collectionKey: string
+    dir?: string | undefined
+  }) => Promise<RemoteResult<ResearchZoteroExportResult>>
   listArxivSubscriptions: () => Promise<RemoteResult<ResearchArxivSubscriptionsResult>>
   saveArxivSubscription: (request: { query: string }) => Promise<RemoteResult<ResearchSaveArxivSubscriptionResult>>
   deleteArxivSubscription: (request: { id: string }) => Promise<RemoteResult<ResearchDeleteArxivSubscriptionResult>>
@@ -253,6 +269,26 @@ export interface ResearchArxivSearchView {
   readonly failure: ResearchFailureView | null
 }
 
+/** The papers view's Zotero section: connection status plus the collection list. */
+export interface ResearchZoteroView {
+  readonly status: ResearchLoadStatus
+  /** The settled probe outcome; null while the first check is still cold. */
+  readonly state: 'unconfigured' | 'ok' | 'failed' | null
+  /** The probe's failure reason (state `failed`); null otherwise. */
+  readonly message: string | null
+  /** The configured library's collections; empty until a successful check loads them. */
+  readonly collections: readonly ZoteroCollectionView[]
+  readonly failure: ResearchFailureView | null
+}
+
+/** The Zotero search panel: the last query's outcome (null before any search). */
+export interface ResearchZoteroSearchView {
+  readonly query: string
+  readonly status: 'loading' | 'ready' | 'error'
+  readonly list: readonly ZoteroItemView[]
+  readonly failure: ResearchFailureView | null
+}
+
 /** The arXiv subscription bar of the papers view. */
 export interface ResearchSubscriptionsView {
   readonly status: ResearchLoadStatus
@@ -341,6 +377,10 @@ export interface ResearchView {
   readonly arxivSearch: ResearchArxivSearchView | null
   /** The papers view's arXiv subscription bar. */
   readonly arxivSubscriptions: ResearchSubscriptionsView
+  /** The papers view's Zotero section (connection status plus collections). */
+  readonly zotero: ResearchZoteroView
+  /** The Zotero section's search outcome; null before the first search. */
+  readonly zoteroSearch: ResearchZoteroSearchView | null
   readonly experiments: ResearchProjectSlice<readonly ExperimentRecord[]> | null
   readonly artifact: ResearchArtifactView | null
   readonly figures: ResearchProjectSlice<readonly FigureEntry[]> | null
@@ -375,6 +415,10 @@ const INITIAL_VIEW: ResearchView = Object.freeze({
   arxivSubscriptions: Object.freeze({
     status: 'cold', list: Object.freeze([]), checking: false, failure: null, checkErrors: Object.freeze({}),
   }),
+  zotero: Object.freeze({
+    status: 'cold', state: null, message: null, collections: Object.freeze([]), failure: null,
+  }),
+  zoteroSearch: null,
   experiments: null,
   artifact: null,
   figures: null,
@@ -416,6 +460,8 @@ export class ResearchController implements HostObservable<ResearchView> {
   private backupPromise: Promise<void> | null = null
   private papersPromise: Promise<void> | null = null
   private subscriptionsPromise: Promise<void> | null = null
+  private zoteroPromise: Promise<void> | null = null
+  private zoteroGeneration = 0
   private serversPromise: Promise<void> | null = null
   private jobsPromise: Promise<void> | null = null
   private outlineGeneration = 0
@@ -1344,6 +1390,166 @@ export class ResearchController implements HostObservable<ResearchView> {
       await this.loadPapers()
       this.notify('success', 'toast.pdfFetched')
       return null
+    } catch (error) {
+      return transportFailure(error)
+    }
+  }
+
+  /**
+   * Probe the Zotero connection once, on the papers view's first open; a
+   * successful probe also loads the collection list. A failed or unconfigured
+   * probe stays retryable through {@link recheckZotero}.
+   */
+  ensureZotero(): void {
+    if (this.view.zotero.status === 'ready' || this.zoteroPromise !== null) return
+    this.zoteroPromise = this.loadZotero().finally(() => { this.zoteroPromise = null })
+  }
+
+  /** Re-probe the Zotero connection (the section's retry entry). */
+  recheckZotero(): void {
+    this.zoteroPromise ??= this.loadZotero().finally(() => { this.zoteroPromise = null })
+  }
+
+  /** Run the connection probe; on `ok` follow it with the collection list. */
+  private async loadZotero(): Promise<void> {
+    const publishZotero = (view: ResearchZoteroView): void => {
+      if (this.disposed) return
+      this.publish({ zotero: Object.freeze(view) })
+    }
+    publishZotero({ status: 'loading', state: null, message: null, collections: [], failure: null })
+    try {
+      const carried = await this.remote.checkZotero()
+      if (!carried.ok) {
+        publishZotero({
+          status: 'error', state: null, message: null, collections: [],
+          failure: failureOf(carried.error.code, carried.error.message),
+        })
+        return
+      }
+      const probe = carried.value
+      if (!probe.ok) {
+        publishZotero({
+          status: 'error', state: null, message: null, collections: [],
+          failure: businessFailure(probe.error),
+        })
+        return
+      }
+      const status = probe.value
+      if (status.state !== 'ok') {
+        publishZotero({
+          status: 'ready', state: status.state, message: status.message ?? null,
+          collections: [], failure: null,
+        })
+        return
+      }
+      const listed = await this.remote.listZoteroCollections()
+      if (!listed.ok) {
+        publishZotero({
+          status: 'error', state: null, message: null, collections: [],
+          failure: failureOf(listed.error.code, listed.error.message),
+        })
+        return
+      }
+      if (!listed.value.ok) {
+        publishZotero({
+          status: 'error', state: null, message: null, collections: [],
+          failure: businessFailure(listed.value.error),
+        })
+        return
+      }
+      publishZotero({ status: 'ready', state: 'ok', message: null, collections: listed.value.value.collections, failure: null })
+    } catch (error) {
+      publishZotero({ status: 'error', state: null, message: null, collections: [], failure: transportFailure(error) })
+    }
+  }
+
+  /**
+   * Search the configured Zotero library from the papers view; the outcome
+   * lands in the view's `zoteroSearch` slice. A superseded query never
+   * publishes.
+   * @param query - the free-text query; an empty one never leaves the client.
+   */
+  searchZotero(query: string): void {
+    const trimmed = query.trim()
+    if (trimmed === '') return
+    this.zoteroGeneration += 1
+    const generation = this.zoteroGeneration
+    this.publish({
+      zoteroSearch: Object.freeze({ query: trimmed, status: 'loading', list: Object.freeze([]), failure: null }),
+    })
+    void (async (): Promise<void> => {
+      const publishSearch = (view: ResearchZoteroSearchView): void => {
+        if (this.disposed || generation !== this.zoteroGeneration) return
+        this.publish({ zoteroSearch: Object.freeze(view) })
+      }
+      try {
+        const carried = await this.remote.searchZotero({ query: trimmed })
+        if (!carried.ok) {
+          publishSearch({ query: trimmed, status: 'error', list: [], failure: failureOf(carried.error.code, carried.error.message) })
+          return
+        }
+        const result = carried.value
+        if (!result.ok) {
+          publishSearch({ query: trimmed, status: 'error', list: [], failure: businessFailure(result.error) })
+          return
+        }
+        publishSearch({ query: trimmed, status: 'ready', list: result.value.results, failure: null })
+      } catch (error) {
+        publishSearch({ query: trimmed, status: 'error', list: [], failure: transportFailure(error) })
+      }
+    })()
+  }
+
+  /**
+   * Import one Zotero item into the wiki, then refresh the literature list so
+   * the library grid and the item's imported state repaint. The failure view
+   * of a rejected import is returned so the row can surface it.
+   * @param key - the Zotero item key.
+   * @returns null on success, the settled failure otherwise.
+   */
+  async importZoteroItem(key: string): Promise<ResearchFailureView | null> {
+    try {
+      const carried = await this.remote.importZoteroItem({ key })
+      if (this.disposed) return null
+      if (!carried.ok) return failureOf(carried.error.code, carried.error.message)
+      const result = carried.value
+      if (!result.ok) return businessFailure(result.error)
+      await this.loadPapers()
+      this.notify('success', 'toast.paperImported')
+      return null
+    } catch (error) {
+      return transportFailure(error)
+    }
+  }
+
+  /**
+   * Export one Zotero collection into one project's `references.bib`, then
+   * repaint the open bib panel from the Host's authoritative file. The
+   * settled counts are returned so the invoking button shows its own feedback.
+   * @param projectId - wiki project id.
+   * @param collectionKey - the Zotero collection to export.
+   * @returns the settled counts on success, the failure view otherwise.
+   */
+  async exportZoteroCollectionToBib(
+    projectId: string,
+    collectionKey: string,
+  ): Promise<ResearchFailureView | ResearchImportCounts> {
+    try {
+      const carried = await this.remote.exportZoteroCollectionToBib({
+        projectId, collectionKey, dir: this.dirOf(projectId),
+      })
+      if (!carried.ok) return failureOf(carried.error.code, carried.error.message)
+      const result = carried.value
+      if (!result.ok) return businessFailure(result.error)
+      const counts = Object.freeze({ added: result.value.added, skipped: result.value.skipped })
+      if (this.disposed) return counts
+      this.notify('success', 'toast.bibImported', `× ${counts.added}`)
+      const bib = this.view.bib
+      if (bib !== null && bib.projectId === projectId && bib.status !== 'loading') {
+        this.publish({ bib: Object.freeze({ ...bib, lastImport: counts }) })
+        this.reloadBibliography()
+      }
+      return counts
     } catch (error) {
       return transportFailure(error)
     }

--- a/packages/ui-mimir/src/client/index.ts
+++ b/packages/ui-mimir/src/client/index.ts
@@ -33,7 +33,7 @@ export type {
   ResearchImportCounts, ResearchJobsView, ResearchLoadStatus,
   ResearchOutlineView, ResearchPapersView, ResearchProjectSlice, ResearchRemote,
   ResearchSaveState, ResearchSnapshotDetailView, ResearchSourceView, ResearchSubscriptionsView,
-  ResearchView,
+  ResearchView, ResearchZoteroSearchView, ResearchZoteroView,
 } from './controller.ts'
 export type {
   ResearchPanelInjected, ResearchPanelProps, ResearchPanelStore, ResearchToggleProps,
@@ -183,6 +183,12 @@ export function apply(ctx: ClientContext): void {
       removePaper: (arxivId) => controller.removePaper(arxivId),
       updatePaper: (arxivId, patch) => controller.updatePaper(arxivId, patch),
       fetchPaperPdf: (arxivId) => controller.fetchPaperPdf(arxivId),
+      ensureZotero: () => { controller.ensureZotero() },
+      recheckZotero: () => { controller.recheckZotero() },
+      searchZotero: (query) => { controller.searchZotero(query) },
+      importZoteroItem: key => controller.importZoteroItem(key),
+      exportZoteroCollectionToBib: (projectId, collectionKey) =>
+        controller.exportZoteroCollectionToBib(projectId, collectionKey),
       loadArtifact: (projectId, name) => { controller.loadArtifact(projectId, name) },
       loadFigures: (projectId, force) => { controller.loadFigures(projectId, force) },
       uploadFigures: async (projectId, dir, files, onProgress) => {

--- a/packages/ui-mimir/src/client/locales.ts
+++ b/packages/ui-mimir/src/client/locales.ts
@@ -390,6 +390,20 @@ export const zh = {
   'toast.subscriptionSaved': '订阅已保存',
   'toast.subscriptionNewPapers': '发现新文献',
   // --- end arXiv subscriptions ---
+  // --- Zotero integration (feat/zotero): keep this block contiguous to avoid merge conflicts ---
+  'zotero.title': 'Zotero 文献库',
+  'zotero.checking': '正在检查 Zotero 连接…',
+  'zotero.unconfigured': '尚未配置 Zotero：在 cordis.yml 的 mimir 插件配置中设置 zotero.apiKey 和 zotero.userId（key 在 zotero.org/settings/keys 免费生成，user ID 在同一设置页查看）',
+  'zotero.failed': 'Zotero 连接失败',
+  'zotero.collection': '选择 Collection',
+  'zotero.noCollections': '该文献库还没有 Collection',
+  'zotero.export': '导出 Collection 到参考文献',
+  'zotero.exporting': '导出中…',
+  'zotero.exported': '已导出 {added} 条（{skipped} 条已存在，跳过）',
+  'zotero.exportFailed': 'Zotero 导出失败',
+  'zotero.searchPlaceholder': '搜索 Zotero 文献库…',
+  'zotero.searchEmpty': '没有匹配的 Zotero 条目',
+  // --- end Zotero integration ---
 } satisfies Record<string, string>
 
 /** The research namespace key union. */
@@ -792,4 +806,18 @@ export const en = {
   'toast.subscriptionSaved': 'Subscription saved',
   'toast.subscriptionNewPapers': 'New papers found',
   // --- end arXiv subscriptions ---
+  // --- Zotero integration (feat/zotero): keep this block contiguous to avoid merge conflicts ---
+  'zotero.title': 'Zotero library',
+  'zotero.checking': 'Checking the Zotero connection…',
+  'zotero.unconfigured': 'Zotero is not configured: set zotero.apiKey and zotero.userId in the mimir plugin config in cordis.yml (create a key for free at zotero.org/settings/keys; your user ID is shown on the same settings page)',
+  'zotero.failed': 'Zotero connection failed',
+  'zotero.collection': 'Select a collection',
+  'zotero.noCollections': 'This library has no collections yet',
+  'zotero.export': 'Export collection to bibliography',
+  'zotero.exporting': 'Exporting…',
+  'zotero.exported': 'Exported {added} entries ({skipped} already present, skipped)',
+  'zotero.exportFailed': 'Zotero export failed',
+  'zotero.searchPlaceholder': 'Search your Zotero library…',
+  'zotero.searchEmpty': 'No matching Zotero items',
+  // --- end Zotero integration ---
 } satisfies Record<ResearchKey, string>

--- a/packages/ui-mimir/src/client/slots.ts
+++ b/packages/ui-mimir/src/client/slots.ts
@@ -202,6 +202,32 @@ export interface ResearchPanelInjected {
    * @returns null on success, the settled failure otherwise.
    */
   fetchPaperPdf: (arxivId: string) => Promise<ResearchFailureView | null>
+  /** Probe the Zotero connection once, on the papers view's first open. */
+  ensureZotero: () => void
+  /** Re-probe the Zotero connection (the section's retry entry). */
+  recheckZotero: () => void
+  /**
+   * Search the configured Zotero library; the outcome lands in the view's
+   * `zoteroSearch` slice.
+   * @param query - the free-text query; an empty one never leaves the client.
+   */
+  searchZotero: (query: string) => void
+  /**
+   * Import one Zotero item into the wiki, then refresh the literature list.
+   * @param key - the Zotero item key of one search result row.
+   * @returns null on success, the settled failure otherwise.
+   */
+  importZoteroItem: (key: string) => Promise<ResearchFailureView | null>
+  /**
+   * Export one Zotero collection into one project's `references.bib`.
+   * @param projectId - wiki project id.
+   * @param collectionKey - the Zotero collection to export.
+   * @returns the settled counts on success, the failure view otherwise.
+   */
+  exportZoteroCollectionToBib: (
+    projectId: string,
+    collectionKey: string,
+  ) => Promise<ResearchFailureView | ResearchImportCounts>
   /** Load the server list once, on the servers view's first open. */
   ensureServers: () => void
   /**


### PR DESCRIPTION
## Motivation

Researchers keep their curated literature in Zotero; Mimir's workbench library and the paper's `references.bib` should be reachable from it without copy-pasting. This PR wires the read-only half of the Zotero Web API (phase 1): connection check, collection listing, full-text search, item import into the wiki library, and one-collection BibTeX export merged into a project's bibliography.

## Remote contract (research namespace, 45 → 50 methods)

| Method | Request | Result |
| --- | --- | --- |
| `checkZotero()` | — | `{ state: 'unconfigured' \| 'ok' \| 'failed', message? }` — never rejects; its job IS the status |
| `listZoteroCollections()` | — | `{ collections: [{ key, name, itemCount }] }` |
| `searchZotero({ query, maxResults? })` | query non-empty, cap 1–50 (default 10) | `{ results: [{ key, title, authors, year, doi, arxivId, publicationTitle, url }] }` |
| `importZoteroItem({ key })` | Zotero item key | `{ imported, paperId }` |
| `exportZoteroCollectionToBib({ projectId, collectionKey, dir? })` | wiki project + collection | `{ added, skipped }` citation keys |

Failure vocabulary reuses existing codes: `invalid-input` for unconfigured/bad input, `operation-failed` for transport/HTTP failures, plus the merge's `project-not-found`/`paper-not-found`/`invalid-dir`.

## Configuration

```yaml
# cordis.yml
plugins:
  mimir:
    zotero:
      apiKey: <key from https://www.zotero.org/settings/keys>
      userId: <numeric user id from the same settings page>
```

Both fields default to `''`, which counts as unconfigured — every Zotero remote then rejects `invalid-input` with setup guidance, and the panel shows the configuration hint. **The key is a secret**: it is read from config only, sent to the API as the `Zotero-API-Key` header, and never written to the wiki, logs, error messages, or the UI (which only shows configured/unconfigured).

## PaperRecord mapping (schema stays at version 2)

- Item with an arXiv id (recovered from `extra` `arXiv: …` or an `arxiv.org/abs/…` URL) → regular `importPaper` upsert keyed by the bare arXiv id.
- Item without one → imported under `zotero-<item key>`; the notes record the provenance (`Imported from Zotero (item …). DOI: … URL: …`).
- Re-imports refresh metadata but preserve notes/tags/project links, matching `importPaper` semantics.
- The export rides a new `appendBibEntries` helper extracted from `importPapersToBib` (locked read-merge-write; citation keys already present are skipped).

## Rate limiting

The client (`packages/mimir/src/tools/zotero.ts`, injectable fetch) honors 429/503 with exactly one retry after the response's `Retry-After` (capped at 10 s, 1 s default); a second failure surfaces as `operation-failed`. Every request carries a 15 s `AbortSignal.timeout`, following the arXiv client style. Collection BibTeX export paginates (`limit=100&start=…`; the API caps export formats at 150/page) until the `Total-Results` header is covered.

## UI

The literature view gains a Zotero section: unconfigured guidance, failed-probe retry, collection picker + "export to bibliography" (targets the selected project), and a search box whose result rows import in one click (already-imported rows are detected via the same `arxivId ?? zotero-<key>` id mapping). All copy is bilingual (zh/en, contiguous locale blocks); CSS is an independent block appended at the end of `ResearchPanel.module.css` with `var(--dsw-*, fallback)` colors (merge-friendly with the parallel visual-polish refactor).

## Tests

`npm test`: 517 → **538** (21 new in `packages/mimir/tests/zotero.spec.ts`), all green. Coverage: client parsing/pagination/auth-header/rate-limit-retry with an injected mock fetch; unconfigured failure codes; import idempotence and both PaperRecord mappings; export merge/dedup against a real temp workspace; wiki-domain-stays-v2 regression. `tsc -b` is clean for both packages (after the `dsh-mimir` bundle regenerates the remote types). No test touches the real api.zotero.org.

Not in scope (phase 2 candidates): group libraries, write-back to Zotero, attachment/PDF download.
