### PR TITLE
chore: bump versions to 0.7.0 for release

### DIFF
--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release v0.7.0: Zotero 集成 + Linear 式视觉升级。