### PR TITLE
feat(mimir): ship nine bundled research skills into the agent skill catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ arXiv literature · persistent research wiki · experiments &amp; remote GPUs ·
 | `figure_save` | Copies a generated figure (any path) into the project's paper `figures/`, records caption/linked-experiment metadata in the wiki, and returns a ready-to-paste LaTeX figure block (SVG sources are auto-converted to PDF — PNG as the raster fallback — when a converter is available) |
 | `latex_compile` | Compiles `main.tex` with parsed file/line diagnostics; multi-engine: `latexmk` or `tectonic` (auto-detected, or an explicit binary path) |
 
+**Nine bundled research skills**
+
+When the host composition mounts a skill registry (the shipped web profile does), Mimir registers nine workflow playbooks into the agent's skill catalog — no setup needed. They encode the research methodology (what to persist in the wiki, which gate comes next) and drive the tools and commands above. A project-level skill with the same name overrides the bundled one, so teams can replace any playbook with their own.
+
+| Skill | Playbook |
+| --- | --- |
+| `research-pipeline` | End-to-end orchestration: ideation → novelty gate → literature → plan → experiments → claim gate → writing → review |
+| `research-lit-review` | Curated, noted literature base in the wiki via `arxiv_search` + `paper_fetch`; Zotero import and arXiv subscriptions when configured |
+| `research-novelty-check` | Verdict-bearing novelty gate — live searches from mechanism / application / result angles before any compute is spent |
+| `research-experiment-plan` | Claim-mapped run order with budgets, wiki experiment records, and Servers-tab feasibility |
+| `research-result-to-claim` | Post-experiment gate: which claims the results support / invalidate / leave pending, with the settling run named |
+| `research-paper-drafting` | Section-by-section LaTeX drafting with an immediate compile loop and supported-claims-only discipline |
+| `research-citation-audit` | Zero-trust bibliography audit: every .bib entry verified against live search, every citation earned |
+| `research-rebuttal` | Grounded, venue-limited rebuttal drafting from parsed reviewer concerns |
+| `research-figure-plan` | Claim-carrying figure design; reproducible production; filing through `figure_save` into the Figures tab |
+
+Disable them with `skills.enabled: false` (see the configuration reference).
+
 ### Web workbench — six views, one overlay
 
 A sidebar toggle opens a 96vw×95vh workbench:
@@ -286,6 +304,10 @@ The agent reaches the same capabilities mid-conversation:
 - `wiki_note` — the wiki's read/write surface, one flat parameter set keyed by `action`: `add_paper`, `add_idea`, `fail_idea`, `add_claim`, `set_claim`, `set_project` (points a project at its paper directory), `add_experiment`, `set_experiment` (status `running`/`success`/`failed`), plus `list` and `get` over the five tables.
 - `latex_compile` — "compile the paper in `paper/`" (`project_dir` parameter); returns parsed file/line diagnostics.
 
+### Bundled skills in practice
+
+The nine bundled skills need no invocation syntax — the agent's skill catalog routes to them from natural requests ("帮我查新一下这个想法", "audit the citations before we submit", "plan the ablations"). They are playbooks, not new capabilities: every step drives the same tools, commands, and wiki tables listed above, so everything a skill does stays visible in the workbench. To override one, drop a same-named `SKILL.md` in your project's skill roots — project entries outrank the bundled runtime ones.
+
 ## Configuration reference
 
 All keys are optional; these are the defaults from `packages/mimir/src/index.ts`:
@@ -302,6 +324,7 @@ All keys are optional; these are the defaults from `packages/mimir/src/index.ts`
 | `backup.intervalMinutes` | `60` | Backup cadence in minutes (positive integer); the first pass runs one minute after plugin start |
 | `backup.keep` | `24` | Keep the newest N backups, prune the rest (positive integer) |
 | `backup.dir` | `backups` | Backup directory, resolved against `workspaceDir` unless absolute |
+| `skills.enabled` | `true` | Register the nine bundled research skills into the composition's skill registry (when one is mounted); `false` skips registration |
 
 Full example with comments: [examples/mimir-agent/cordis.yml](examples/mimir-agent/cordis.yml).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,6 +49,24 @@ arXiv 文献 · 持久化研究 wiki · 实验与远程 GPU · 图表 · LaTeX �
 | `figure_save` | 把生成的图（任意路径）复制进项目论文 `figures/` 目录，wiki 记录 caption/关联实验元数据，返回可直接粘贴的 LaTeX 图片块（机器上有可用转换器时 SVG 会自动转换为 PDF，兜底为 PNG） |
 | `latex_compile` | 编译 `main.tex` 并给出解析后的文件/行号诊断；多引擎：`latexmk` 或 `tectonic`（自动探测，或显式二进制路径） |
 
+**九个内置科研 skills**
+
+当宿主组合挂载了 skill registry（自带的 web profile 已挂载）时，Mimir 会向 agent 的 skill 目录注册九个工作流 playbook——零配置。它们沉淀的是科研方法论（何时把什么写进 wiki、下一道门槛是什么），驱动上面列出的工具与命令。项目级同名 skill 会覆盖内置版本，团队可以替换掉任何一个 playbook。
+
+| Skill | Playbook |
+| --- | --- |
+| `research-pipeline` | 端到端编排：立意 → 查新门槛 → 文献 → 计划 → 实验 → 主张门槛 → 写作 → 评审 |
+| `research-lit-review` | 经 `arxiv_search` + `paper_fetch` 在 wiki 中建带笔记的文献库；配置后可接 Zotero 导入与 arXiv 订阅 |
+| `research-novelty-check` | 带结论的查新门槛——花算力之前，从机理 / 应用 / 结果三个角度做实时检索 |
+| `research-experiment-plan` | 主张驱动、带预算的运行排序，落到 wiki 实验记录并对照服务器面板可行性 |
+| `research-result-to-claim` | 实验后门槛：结果支撑 / 推翻 / 搁置哪些主张，并指出能定夺的那一组实验 |
+| `research-paper-drafting` | 逐节 LaTeX 写作，随写随编译，只写已支撑的主张 |
+| `research-citation-audit` | 零信任参考文献审计：每条 .bib 记录实时检索验证，每处引用都要名副其实 |
+| `research-rebuttal` | 把审稿意见拆成原子关切，基于证据、在会议篇幅限制内起草回复 |
+| `research-figure-plan` | 设计能支撑主张的图，可复现地产出，并经 `figure_save` 归入图表面板 |
+
+可用 `skills.enabled: false` 关闭（见配置参考）。
+
 ### Web 工作台——六视图，一个浮层
 
 侧栏开关打开 96vw×95vh 工作台：
@@ -286,6 +304,10 @@ agent 在对话中途可以触达同一组能力：
 - `wiki_note`——wiki 的读写面，以 `action` 为键的一套扁平参数：`add_paper`、`add_idea`、`fail_idea`、`add_claim`、`set_claim`、`set_project`（把项目指向它的论文目录）、`add_experiment`、`set_experiment`（状态 `running`/`success`/`failed`），以及对五张表的 `list` 和 `get`。
 - `latex_compile`——“编译 `paper/` 里的论文”（`project_dir` 参数）；返回解析后的文件/行号诊断。
 
+### 内置 skills 实战
+
+九个内置 skill 不需要特殊调用语法——agent 的 skill 目录会从自然语言请求路由过去（“帮我查新一下这个想法”、“提交前审一遍引用”、“规划一下消融实验”）。它们是 playbook 而不是新能力：每一步驱动的都是上面列出的同一组工具、命令和 wiki 表，所以 skill 做的一切都在工作台里可见。要覆盖某一个，把同名 `SKILL.md` 放进项目的 skill 根目录即可——项目级条目优先于内置 runtime 条目。
+
 ## 配置参考
 
 所有键都可缺省；以下默认值来自 `packages/mimir/src/index.ts`：
@@ -302,6 +324,7 @@ agent 在对话中途可以触达同一组能力：
 | `backup.intervalMinutes` | `60` | 备份周期（分钟，正整数）；插件启动 1 分钟后做首次备份 |
 | `backup.keep` | `24` | 保留最近 N 份，超出裁剪（正整数） |
 | `backup.dir` | `backups` | 备份目录，相对 `workspaceDir` 解析（也接受绝对路径） |
+| `skills.enabled` | `true` | 把九个内置科研 skill 注册进组合的 skill registry（已挂载时）；`false` 跳过注册 |
 
 带注释的完整示例见 [examples/mimir-agent/cordis.yml](examples/mimir-agent/cordis.yml)。
 

--- a/examples/mimir-agent/cordis.yml
+++ b/examples/mimir-agent/cordis.yml
@@ -22,3 +22,5 @@
           intervalMinutes: 60         # backup cadence (first pass 1 min after start)
           keep: 24                    # keep the newest N backups, prune the rest
           dir: backups                # backup directory, resolved against workspaceDir
+        skills:
+          enabled: true               # register the nine bundled research skills into the agent's skill catalog

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -61,10 +61,16 @@
     "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-llm": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-session": ">=0.1.0-rc.8",
+    "@deepseek-ai/dsh-skill": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-storage-domain": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-subagent": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-tools": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-typert-protocol": ">=0.1.0-rc.8"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-skill": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@deepseek-ai/schemastery": "^3.18.1",
@@ -79,6 +85,7 @@
     "@deepseek-ai/dsh-invariants": "0.1.0-rc.8",
     "@deepseek-ai/dsh-llm": "0.1.0-rc.8",
     "@deepseek-ai/dsh-session": "0.1.0-rc.8",
+    "@deepseek-ai/dsh-skill": "0.1.0-rc.8",
     "@deepseek-ai/dsh-storage": "0.1.0-rc.8",
     "@deepseek-ai/dsh-storage-domain": "0.1.0-rc.8",
     "@deepseek-ai/dsh-subagent": "0.1.0-rc.8",

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * Research-assistant plugin suite: an arXiv literature surface, a persistent
  * research wiki (papers / ideas / claims / projects), a LaTeX compile tool,
- * and an independent fresh-reviewer loop — the ARIS workflow mechanisms as
- * one dsh-native plugin.
+ * nine bundled research-workflow skills, and an independent fresh-reviewer
+ * loop — the ARIS workflow mechanisms as one dsh-native plugin.
  * @module dsh-mimir
  */
 
@@ -27,6 +27,7 @@ import type { ResearchCommandDeps } from './commands/common.ts'
 import { resolvePaperDir } from './paper-source.ts'
 import { isFigureFile } from './artifacts.ts'
 import { ResearchService } from './service.ts'
+import { registerResearchSkills } from './skills.ts'
 import { startWikiBackupLoop } from './backup.ts'
 import { startArxivSubscriptionLoop } from './arxiv-subscriptions.ts'
 
@@ -100,6 +101,7 @@ export { convertSvgFigure, svgConverterNames, svgProductName, whichOnPath, SVG_C
 export type { SvgConversion, SvgConversionDeps, SvgConverterKind, SvgConverterSpec, SvgRunner } from './svg-convert.ts'
 export { ResearchService } from './service.ts'
 export type { ResearchServiceConfig } from './service.ts'
+export { BUNDLED_SKILLS, registerResearchSkills } from './skills.ts'
 export {
   ARXIV_SUBSCRIPTIONS_FILE,
   ARXIV_SUBSCRIPTION_CHECK_RESULTS,
@@ -210,6 +212,15 @@ export interface Config {
      */
     dir?: string
   }
+  /** Bundled research-skill registration knobs. */
+  skills?: {
+    /**
+     * Master switch (default true); false skips registering the nine bundled
+     * research skills into the composition's skill registry. Registrations
+     * only happen when a `skills` service is mounted at all.
+     */
+    enabled?: boolean
+  }
 }
 
 /** Schemastery configuration for the research suite. */
@@ -240,6 +251,9 @@ export const Config: z<Config> = z.object({
     keep: z.number().step(1).min(1).max(Number.MAX_SAFE_INTEGER).default(24),
     dir: z.string().default('backups'),
   }).default({ enabled: true, intervalMinutes: 60, keep: 24, dir: 'backups' }),
+  skills: z.object({
+    enabled: z.boolean().default(true),
+  }).default({ enabled: true }),
 })
 
 /** Fully defaulted config view used by tools and commands. */
@@ -259,6 +273,7 @@ interface ResolvedConfig {
     readonly keep: number
     readonly dir: string
   }
+  readonly skills: { readonly enabled: boolean }
 }
 
 /** Validate defaults even when a caller invokes apply() without Loader normalization. */
@@ -278,6 +293,7 @@ function resolveConfig(config: Config): ResolvedConfig {
     keep: config.backup?.keep ?? 24,
     dir: config.backup?.dir ?? 'backups',
   }
+  const skills = { enabled: config.skills?.enabled ?? true }
   if (workspaceDir.trim().length === 0) throw new TypeError('workspaceDir must be a non-empty path')
   if (reviewer.provider.trim().length === 0) throw new TypeError('reviewer.provider must be a non-empty provider name')
   if (!Number.isSafeInteger(reviewer.maxRounds) || reviewer.maxRounds < 1) throw new TypeError('reviewer.maxRounds must be a positive safe integer')
@@ -288,7 +304,7 @@ function resolveConfig(config: Config): ResolvedConfig {
   if (!Number.isSafeInteger(backup.intervalMinutes) || backup.intervalMinutes < 1) throw new TypeError('backup.intervalMinutes must be a positive safe integer')
   if (!Number.isSafeInteger(backup.keep) || backup.keep < 1) throw new TypeError('backup.keep must be a positive safe integer')
   if (backup.dir.trim().length === 0) throw new TypeError('backup.dir must be a non-empty path')
-  return { workspaceDir, reviewer, latex, arxiv, zotero, subscriptions, backup }
+  return { workspaceDir, reviewer, latex, arxiv, zotero, subscriptions, backup, skills }
 }
 
 /**
@@ -582,6 +598,13 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   registerPlanCommand(ctx, deps)
   registerReviewCommand(ctx, deps)
   registerPaperCommands(ctx, deps)
+
+  // Bundled research skills: runtime contributions to the composition's
+  // skill registry when one is mounted (ctx.inject makes the dependency
+  // optional — bare compositions load the suite without it).
+  if (resolved.skills.enabled) {
+    registerResearchSkills(ctx)
+  }
 
   // Scheduled wiki backup: first pass one minute after start (startup stays
   // fast), then every intervalMinutes; failures warn and the loop retries

--- a/packages/mimir/src/skills.ts
+++ b/packages/mimir/src/skills.ts
@@ -1,0 +1,466 @@
+/**
+ * Bundled research skills: the ARIS-style workflow playbooks shipped inside
+ * the plugin itself. Each skill is a `ctx.skills.register()` runtime
+ * contribution (rank 250 — project-level skills still outrank them, user-level
+ * ones yield), so the suite works out of the box in any composition that
+ * mounts the skill registry, and stays silent in one that does not. Bodies
+ * reference only surfaces this package actually provides: the `arxiv_search`,
+ * `paper_fetch`, `wiki_note`, `figure_save`, and `latex_compile` tools, the
+ * `research-idea` / `research-plan` / `research-review` / `paper-write` /
+ * `paper-compile` commands, the workspace artifacts (IDEA_REPORT.md,
+ * EXPERIMENT_PLAN.md, EXPERIMENT_LOG.md, NARRATIVE_REPORT.md), and the web
+ * workbench tabs.
+ *
+ * The content lives as template literals for the same reason templates.ts
+ * cites: published packages ship `lib/` only, so runtime assets must ride the
+ * bundle.
+ * @module dsh-mimir/src/skills
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+// Type-only: pulls the ctx.skills Context merge; the service itself is
+// consumed optionally through ctx.inject below.
+import type {} from '@deepseek-ai/dsh-skill'
+
+/** One bundled skill body plus its routing metadata. */
+interface BundledSkill {
+  readonly name: string
+  readonly description: string
+  readonly whenToUse: string
+  readonly content: string
+}
+
+const SHARED_RULES = String.raw`
+## Standing rules
+
+- Persist every durable finding with \`wiki_note\` the moment you have it —
+  papers into \`papers\`, hypotheses into \`ideas\`, claims into \`claims\`,
+  run outcomes into \`experiments\`. The web workbench renders these tables;
+  a finding that is only in the chat is lost work.
+- Failed directions are assets: close them out with
+  \`wiki_note { action: 'fail_idea', ... }\` (the wiki never deletes ideas) so
+  the next pass does not re-walk a dead end.
+- Keep the project record honest: \`wiki_note { action: 'set_project' }\`
+  with stage \`idea\` / \`plan\` / \`experiment\` / \`writing\` / \`done\` as
+  the work crosses each gate.
+- Prefer one verified fact over three plausible ones. Cite arXiv ids, file
+  paths, and experiment ids as evidence pointers, never from memory alone.
+`
+
+export const RESEARCH_PIPELINE = String.raw`
+# Research Pipeline — end-to-end orchestration
+
+Drive one research project through the full Mimir loop. Run the stages in
+order; do not skip a gate to save time — each gate exists because skipping it
+once cost a paper.
+
+## Stages
+
+1. **Ideation** — run the \`research-idea\` command on the direction. It
+   produces IDEA_REPORT.md and registers ideas in the wiki. If the user
+   already has a written idea, record it with
+   \`wiki_note { action: 'add_idea' }\` and move on.
+2. **Novelty gate** — invoke the \`research-novelty-check\` skill on the
+   leading idea. A "known" verdict is not failure: pivot the angle and
+   re-check once. Two independent "known" verdicts kill the idea — record
+   \`fail_idea\` and pick the next one.
+3. **Literature base** — invoke the \`research-lit-review\` skill until the
+   wiki holds the 8–15 papers that define the problem, the baselines, and
+   the evaluation protocol you will be judged against.
+4. **Plan** — run \`research-plan\`. It turns IDEA_REPORT.md into
+   EXPERIMENT_PLAN.md and registers every claim as \`pending\`. If claims
+   look wrong, fix the plan before any compute is spent.
+5. **Experiments** — invoke \`research-experiment-plan\` to sequence the
+   runs, then execute. Log every run with
+   \`wiki_note { action: 'add_experiment' }\` and keep EXPERIMENT_LOG.md
+   append-only current.
+6. **Claim gate** — invoke \`research-result-to-claim\` before writing a
+   single section. Unsupported claims get cut or get more experiments;
+   they never get written as if supported.
+7. **Writing** — run \`paper-write\` (or invoke \`research-paper-drafting\`
+   for a slower, section-by-section pass with human checkpoints). Compile
+   early and often with \`latex_compile\`.
+8. **Review** — run \`research-review\`. WARN/FAIL verdicts come back as
+   issues; revise and re-run until PASS or the round budget is spent, then
+   surface the remaining issues to the user honestly.
+9. **Done** — \`set_project\` stage \`done\`. If reviews arrive from a venue,
+   invoke \`research-rebuttal\`.
+
+## Escalation
+
+Stop and ask the user when: the novelty gate kills every idea on the table;
+the compute budget implied by EXPERIMENT_PLAN.md exceeds what the registered
+servers can run; or two consecutive review rounds fail on the same issue.
+` + SHARED_RULES
+
+export const RESEARCH_LIT_REVIEW = String.raw`
+# Literature Review — build the wiki's paper base
+
+Turn a research direction into a curated, noted, citable paper set in the
+wiki's \`papers\` table (rendered in the workbench's 文献 / Literature tab).
+
+## Loop
+
+1. **Search** with \`arxiv_search\`: start broad (the problem statement), then
+   narrow (the specific method family, the benchmark, the strongest
+   baseline). Rewrite the query at least twice — first-pass queries miss
+   half the field.
+2. **Triage** each result by title + abstract: defining works, must-beat
+   baselines, and the evaluation suite. Skip anything you cannot state a
+   concrete reason to keep.
+3. **Persist** each keeper immediately:
+   \`wiki_note { action: 'add_paper', arxiv_id, title, authors, summary, url,
+   notes }\` — \`notes\` carries YOUR one-paragraph read: what it does, what
+   it leaves open, why it matters to this project. An entry without notes is
+   a bookmark, not a review.
+4. **Fetch** the PDF with \`paper_fetch\` for any paper you will cite for a
+   specific claim — the workbench's reader plus its note sidebar is the
+   deep-reading surface.
+5. **Zotero** — if the user has configured \`zotero.apiKey\` / \`userId\`,
+   the 文献 tab can import whole collections and export the wiki back to
+   .bib; suggest it when the user mentions an existing Zotero library.
+6. **Subscriptions** — for a long-running project, suggest adding an arXiv
+   subscription in the 文献 tab so new papers surface daily.
+
+## Done when
+
+The wiki holds enough papers that you can name, without searching again: the
+problem's origin, the two strongest baselines, the standard benchmark, and
+the one result nobody has explained. State those four to the user as the
+review's summary.
+` + SHARED_RULES
+
+export const RESEARCH_NOVELTY_CHECK = String.raw`
+# Novelty Check — is this idea already done?
+
+Verdict-bearing gate: decide whether the literature already contains the
+proposed contribution. Run it BEFORE writing code or spending compute.
+
+## Method
+
+1. **Distill** the idea to its load-bearing sentence: "we are the first to
+   <do X> <for Y> <achieving Z>". If you cannot write that sentence, the
+   idea is not ready for a novelty check — say so.
+2. **Attack it** with \`arxiv_search\` from three directions: the mechanism
+   (X), the application (Y), and the claimed result (Z). Use the search
+   syntax the tool supports (field prefixes, \`AND\`/\`OR\`), and read
+   abstracts of every plausible hit — title-level dismissal is how novelty
+   checks fail.
+3. **Widen once**: if arXiv is thin, check the adjacent venues by name in
+   the query (the field knows its conferences).
+4. **Judge** honestly:
+   - **Known** — a prior work does X for Y. Name it with its arXiv id.
+   - **Adjacent** — X exists but not for Y, or Y is addressed but not by X.
+     The delta must be stated in one sentence; if that sentence is weak, the
+     verdict is effectively known.
+   - **Novel** — nothing within the search's reach does X for Y, and the
+     closest three works each miss a named piece.
+5. **Record** the verdict in the wiki: attach it to the idea's notes, or on
+   "known", \`wiki_note { action: 'fail_idea', reason }\` citing the killing
+   paper.
+
+## Hard rules
+
+- Never issue "novel" from memory of the field — only from searches run in
+  this session.
+- "I found nothing" with weak queries means nothing. Show the queries.
+- One strong killing paper outweighs any amount of enthusiasm.
+` + SHARED_RULES
+
+export const RESEARCH_EXPERIMENT_PLAN = String.raw`
+# Experiment Plan — claim-driven validation design
+
+Turn EXPERIMENT_PLAN.md's claims into a concrete run order. Every run exists
+to move one claim out of \`pending\`; a run that maps to no claim is cut.
+
+## Design
+
+1. **List the claims** from the wiki (\`wiki_note { action: 'list',
+   table: 'claims' }\`). For each, name the single result that would support
+   it and the single result that would kill it.
+2. **Sequence**: main result first (the table the paper lives or dies by),
+   then ablations ordered by claim coverage per GPU-hour, then robustness
+   (seeds, datasets). Baselines run before or alongside, never after.
+3. **Budget**: state the compute each run needs and where it runs — check
+   the 服务器 / Servers tab for registered machines and their GPU probe
+   results before promising a schedule. Jobs can be dispatched and tracked
+   from that tab; their ids belong in the experiment records.
+4. **Register** every planned run:
+   \`wiki_note { action: 'add_experiment', project_id, name, metrics }\`
+   with the hypothesis in the name and the target metrics explicit.
+5. **Write it down**: keep EXPERIMENT_PLAN.md as the human-readable mirror
+   (setup, baselines, ablation matrix, decision rules for pivoting).
+
+## During execution
+
+- EXPERIMENT_LOG.md is append-only: one block per run with config, seed,
+  result, and verdict against the hypothesis.
+- On run completion, \`wiki_note { action: 'set_experiment', status:
+  'success' | 'failed', metrics, log_path }\` — never leave runs \`running\`
+  once they finish; stale running rows corrupt the panel's status view.
+- A failed run still updates claims: negative evidence is evidence.
+` + SHARED_RULES
+
+export const RESEARCH_RESULT_TO_CLAIM = String.raw`
+# Result-to-Claim Gate — what do the experiments actually prove?
+
+Verdict-bearing gate between experiments and writing. The question is never
+"are the results good" but "which claims do these results support".
+
+## Procedure
+
+1. Pull the claims (\`wiki_note { action: 'list', table: 'claims' }\`) and
+   the experiments (\`action: 'list', table: 'experiments'\`).
+2. For each claim, lay the evidence beside it: which runs, which metrics,
+   which baselines beaten (or not). Read EXPERIMENT_LOG.md, not summaries of
+   summaries.
+3. Judge each claim:
+   - **Supported** — the named evidence directly shows it, including the
+     comparison against the strongest baseline, not an easy one.
+     \`wiki_note { action: 'set_claim', status: 'supported', evidence }\`
+     with evidence pointing at experiment ids / log paths.
+   - **Invalidated** — the evidence contradicts it. Mark
+     \`status: 'invalidated'\` and say what the results suggest instead; an
+     invalidated main claim usually pivots the paper's story.
+   - **Pending** — evidence is missing, mixed, or under-powered (one seed,
+     no significance, wrong baseline). Name the ONE run that would settle it.
+4. **Report** the routing to the user: claims supported → write; claims
+   pending → the exact supplementary runs; claims invalidated → pivot
+   options with their costs.
+
+## Hard rules
+
+- No claim advances on vibes, trends, or "the number looks right".
+- The paper may only assert claims marked \`supported\`; \`pending\` claims
+  are written as limitations or not at all.
+` + SHARED_RULES
+
+export const RESEARCH_PAPER_DRAFTING = String.raw`
+# Paper Drafting — section by section, compile as you go
+
+Draft the LaTeX paper inside the project's paper directory. For the
+one-shot scaffolding path use the \`paper-write\` command instead; this
+skill is the deliberate, checkpointed path.
+
+## Setup
+
+1. Read the wiki first: supported claims, the experiment table, the paper
+   list. The paper's skeleton is the claim list, not a generic ML template.
+2. Confirm the paper directory (the workbench's 论文 / Paper tab shows it)
+   and that \`main.tex\` + \`references.bib\` exist; scaffold from the
+   suite's templates if not.
+
+## Per-section loop
+
+For each section, in paper order (abstract LAST, but keep a stub):
+
+1. Draft against the evidence: every number in the text traces to an
+   experiment record; every \\cite{} key exists in the .bib (add missing
+   entries from the wiki's papers — the 文献 tab can also export the wiki to
+   .bib).
+2. Compile with \`latex_compile\` immediately. Fix errors before writing the
+   next section — LaTeX errors compound and the log parser pinpoints them
+   one at a time.
+3. Checkpoint with the user after the introduction and after the
+   experiments section: these two carry the story and the evidence, and a
+   wrong direction there wastes the rest.
+
+## Standards
+
+- Claims discipline: assert only \`supported\` claims; \`pending\` evidence
+  goes to limitations.
+- Figures: plan them with the \`research-figure-plan\` skill; reference only
+  files that exist in the paper directory's \`figures/\`.
+- The workbench compiles and snapshots on success, so the user can diff and
+  revert — do not hand-edit around history; compile through the tool.
+` + SHARED_RULES
+
+export const RESEARCH_CITATION_AUDIT = String.raw`
+# Citation Audit — every bib entry real, every citation earned
+
+Verdict-bearing audit before submission. Two questions: does each cited work
+exist as described, and does the citing sentence actually need it?
+
+## Procedure
+
+1. **Inventory**: parse the paper directory's .bib (the suite's bibtex
+   parser keeps it structured) and list every \\cite{} in the .tex with its
+   sentence.
+2. **Existence**: for each entry, verify against a live source —
+   \`arxiv_search\` by title (and author surname when the title is common).
+   Flag: hallucinated titles, wrong authors, wrong years, wrong venues,
+   arXiv id pointing at a different paper (version drift counts).
+3. **Context**: for each citation sentence, read the cited abstract and
+   judge whether the sentence's claim is one the cited work supports.
+   Flag: citing a paper for something it explicitly does not do, citing a
+   survey as if it were the original, citing a baseline's reimplementation
+   instead of the source.
+4. **Coverage**: uncited entries in the .bib are either dead weight (remove)
+   or a sign a related-work paragraph went missing (flag).
+5. **Fix or report**: mechanical fixes (wrong year, dead entries) apply
+   directly and recompile with \`latex_compile\`; judgment calls (wrong-
+   context citations) go to the user as a numbered list — never silently
+   rewrite the scholarship.
+
+## Hard rules
+
+- Verify from searches run in this session; training-memory bibliographies
+  are the exact failure mode this audit exists to catch.
+- Every flag cites the evidence: the search query, the found record, the
+  mismatch.
+` + SHARED_RULES
+
+export const RESEARCH_REBUTTAL = String.raw`
+# Rebuttal — answer the reviews you got, not the ones you wanted
+
+Draft a grounded, venue-limited response to external reviews.
+
+## Procedure
+
+1. **Parse** the reviews into atomic concerns: one row per concrete
+   question, criticism, or requested experiment. Merge duplicates across
+   reviewers; note who raised what.
+2. **Triage** each concern:
+   - *Answerable from the paper/logs* — answer with section, table, or
+     experiment-id pointers. Quote numbers exactly as logged.
+   - *Needs new evidence* — scope the smallest experiment that answers it,
+     check feasibility against the rebuttal window and the registered
+     servers, and only promise what can actually be run.
+   - *Misunderstanding* — correct it once, politely, with the exact quote
+     from the paper that already addresses it.
+3. **Draft** response-first: every answer opens with the concession or the
+   correction, then the evidence. No new claims appear in a rebuttal that
+   the paper's evidence cannot already carry — mark anything speculative as
+   future work explicitly.
+4. **Budget** to the venue's limit (characters/pages). Cut adjectives
+   before cutting evidence.
+5. **Track** any experiments run for the rebuttal like real ones:
+   \`wiki_note { action: 'add_experiment' }\`, EXPERIMENT_LOG.md, and
+   \`set_claim\` updates if they move a claim.
+
+## Hard rules
+
+- Never fabricate a result to satisfy a reviewer; an honest "we cannot run
+  this in the window, here is the closest existing evidence" beats a
+  invented number every time.
+- Tone: grateful for real catches, firm on misreadings, never defensive.
+` + SHARED_RULES
+
+export const RESEARCH_FIGURE_PLAN = String.raw`
+# Figure Plan — figures that carry claims, filed where they belong
+
+Design and produce the paper's figures so each one earns its column width.
+
+## Plan
+
+1. For each supported claim, decide the figure or table that makes a
+   reviewer believe it in five seconds: the main-result figure first, one
+   mechanism/Architecture overview, then ablations.
+2. Write a one-line spec per figure: what varies on each axis, which
+   baselines appear, what the reader should conclude. A figure without that
+   sentence is decoration — cut it.
+
+## Produce
+
+- Prefer reproducible sources: plot scripts reading EXPERIMENT_LOG.md data
+  over hand-drawn numbers; TikZ/pgfplots or matplotlib output committed
+  beside the paper.
+- Save every figure through \`figure_save\` (or the 图表 / Figures tab's
+  upload) so it lands in the paper directory's \`figures/\` AND in the
+  wiki's figure registry with a caption and source note — figures saved any
+  other way are invisible to the workbench.
+- SVG sources convert through the workbench's converter (configure
+  \`svg.converter\` — resvg/inkscape/rsvg/chromium — or install librsvg for
+  vector PDF output).
+
+## Verify
+
+- \`latex_compile\` after adding figures; a missing file or a blown
+  \\includegraphics width is caught by the compile, not by eye.
+- Check the compiled PDF preview in the 论文 tab: every figure legible at
+  column width, referenced in the text, and captioned with its takeaway.
+` + SHARED_RULES
+
+/** Every skill bundled with the suite, in catalog order. */
+export const BUNDLED_SKILLS: readonly BundledSkill[] = [
+  {
+    name: 'research-pipeline',
+    description: 'Orchestrate one project through the full research loop: ideation, novelty gate, literature, plan, experiments, claim gate, writing, review. Use when the user says "做科研", "research pipeline", "从想法到论文", or wants the whole workflow driven end to end.',
+    whenToUse: 'Starting or resuming a research project that should move through every Mimir stage in order.',
+    content: RESEARCH_PIPELINE,
+  },
+  {
+    name: 'research-lit-review',
+    description: 'Build a curated, noted literature base in the research wiki via arxiv_search + paper_fetch, with Zotero import and arXiv subscriptions when configured. Use when the user says "文献综述", "lit review", "调研一下", or needs the paper base for a direction.',
+    whenToUse: 'A direction needs its defining works, baselines, and evaluation suite collected into the wiki with notes.',
+    content: RESEARCH_LIT_REVIEW,
+  },
+  {
+    name: 'research-novelty-check',
+    description: 'Verdict-bearing novelty gate: attack an idea with live arXiv searches from mechanism, application, and result angles before any compute is spent. Use when the user says "查新", "novelty check", "有没有人做过", or before committing to an idea.',
+    whenToUse: 'Before implementing or spending compute on an idea whose novelty is unverified.',
+    content: RESEARCH_NOVELTY_CHECK,
+  },
+  {
+    name: 'research-experiment-plan',
+    description: 'Turn registered claims into a sequenced, budgeted experiment roadmap mapped to wiki experiment records and the Servers tab. Use when the user says "实验方案", "experiment plan", "ablation matrix", or needs a run order.',
+    whenToUse: 'A plan exists and needs concrete, claim-mapped runs with budgets and tracking.',
+    content: RESEARCH_EXPERIMENT_PLAN,
+  },
+  {
+    name: 'research-result-to-claim',
+    description: 'Judge which claims the finished experiments actually support, invalidate, or leave pending — with the exact settling run named. Use when the user says "结果分析", "结果支撑什么", "result to claim", or after experiments finish and before writing.',
+    whenToUse: 'Experiments have finished and the paper must only assert what the evidence carries.',
+    content: RESEARCH_RESULT_TO_CLAIM,
+  },
+  {
+    name: 'research-paper-drafting',
+    description: 'Draft the LaTeX paper section by section with an immediate latex_compile loop and evidence discipline (supported claims only). Use when the user says "写论文", "draft paper", "逐节写", or wants a checkpointed alternative to the paper-write command.',
+    whenToUse: 'Writing or revising the paper deliberately, section by section, with compiles between.',
+    content: RESEARCH_PAPER_DRAFTING,
+  },
+  {
+    name: 'research-citation-audit',
+    description: 'Zero-trust bibliography audit: verify every .bib entry exists via live search and every citation sentence is earned. Use when the user says "审查引用", "citation audit", "核对参考文献", or before submission.',
+    whenToUse: 'Before submission, or whenever bibliography integrity is in doubt.',
+    content: RESEARCH_CITATION_AUDIT,
+  },
+  {
+    name: 'research-rebuttal',
+    description: 'Draft a grounded, venue-limited rebuttal: parse reviews into atomic concerns, triage by evidence, answer response-first without new unsupported claims. Use when the user says "rebuttal", "回复审稿", "OpenReview response", or reviews arrive.',
+    whenToUse: 'External reviews have arrived and need a safe, evidence-bound response.',
+    content: RESEARCH_REBUTTAL,
+  },
+  {
+    name: 'research-figure-plan',
+    description: 'Design claim-carrying figures, produce them reproducibly, and file them through figure_save so the Figures tab and the paper stay in sync. Use when the user says "画图", "figure plan", "论文配图", or a paper needs its figures designed.',
+    whenToUse: 'A paper or report needs figures planned, produced, and registered in the workbench.',
+    content: RESEARCH_FIGURE_PLAN,
+  },
+]
+
+/**
+ * Register the bundled skills into the composition's skill registry when one
+ * is mounted. The `skills` service is deliberately NOT in the plugin's
+ * `inject`: compositions without a skill registry (a bare CLI pipeline, a
+ * minimal embed) still load the full suite, and registration simply never
+ * happens there. `ctx.inject` fires the callback as soon as the registry
+ * arrives and scopes the registrations to that child context, so teardown
+ * order rides the normal effect stack. Same-name project skills outrank
+ * these runtime entries (rank 250), so users can override any bundled
+ * playbook from their project roots.
+ * @param ctx - the plugin's context.
+ */
+export function registerResearchSkills(ctx: Context): void {
+  ctx.inject(['skills'], (skillsCtx: Context) => {
+    for (const skill of BUNDLED_SKILLS) {
+      skillsCtx.skills.register({
+        name: skill.name,
+        description: skill.description,
+        whenToUse: skill.whenToUse,
+        content: skill.content,
+        source: 'bundled',
+      })
+    }
+  })
+}

--- a/packages/mimir/tests/skills.spec.ts
+++ b/packages/mimir/tests/skills.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Behavior tests for the bundled research skills: registration into a real
+ * skill registry (names, routing metadata, loadable bodies), the no-registry
+ * no-op path, and body hygiene (every playbook references surfaces the
+ * plugin actually ships — a skill pointing at a renamed tool is a live lie).
+ * Real SkillRegistry over a bare Context — no mocks.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import SkillRegistry from '@deepseek-ai/dsh-skill'
+import { BUNDLED_SKILLS, registerResearchSkills } from '../src/skills.ts'
+
+/** Tool, command, and artifact names the plugin itself registers/ships. */
+const REAL_SURFACES = [
+  'arxiv_search', 'paper_fetch', 'wiki_note', 'figure_save', 'latex_compile',
+  'research-idea', 'research-plan', 'research-review', 'paper-write', 'paper-compile',
+  'IDEA_REPORT.md', 'EXPERIMENT_PLAN.md', 'EXPERIMENT_LOG.md', 'NARRATIVE_REPORT.md',
+]
+
+describe('bundled research skills', () => {
+  it('ships unique kebab-case skills with routing metadata and real-surface bodies', () => {
+    const names = BUNDLED_SKILLS.map(skill => skill.name)
+    expect(new Set(names).size).toBe(names.length)
+    expect(names).toContain('research-pipeline')
+    expect(names.length).toBe(9)
+    for (const skill of BUNDLED_SKILLS) {
+      expect(skill.name).toMatch(/^research-[a-z-]+$/)
+      expect(skill.description.length).toBeGreaterThan(40)
+      expect(skill.whenToUse.length).toBeGreaterThan(20)
+      expect(skill.content.length).toBeGreaterThan(800)
+      expect(REAL_SURFACES.some(surface => skill.content.includes(surface))).toBe(true)
+    }
+  })
+
+  it('registers every bundled skill into a mounted registry with loadable bodies', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SkillRegistry)
+    registerResearchSkills(ctx)
+    const listed = await ctx.skills.list()
+    const byName = new Map(listed.map(skill => [skill.name, skill]))
+    expect(byName.size).toBe(BUNDLED_SKILLS.length)
+    for (const bundled of BUNDLED_SKILLS) {
+      const summary = byName.get(bundled.name)
+      expect(summary).toBeDefined()
+      expect(summary?.description).toBe(bundled.description)
+      expect(summary?.invocation).toEqual({ modelInvocable: true, userInvocable: true })
+      const definition = await ctx.skills.get(bundled.name)
+      expect(definition?.content).toBe(bundled.content)
+    }
+  })
+
+  it('registers nothing and stays silent when no skill registry is mounted', () => {
+    const ctx = new Context()
+    expect(() => registerResearchSkills(ctx)).not.toThrow()
+  })
+
+  it('keeps project-level duplicates winning over the bundled runtime entries', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SkillRegistry)
+    registerResearchSkills(ctx)
+    // A project-root provider candidate (rank 100) with the same name must
+    // outrank the bundled runtime registration (rank 250).
+    ctx.skills.registerProvider(() => ({
+      name: 'project',
+      async list() {
+        return [{
+          name: 'research-pipeline',
+          description: 'project override',
+          invocation: { modelInvocable: true, userInvocable: true },
+          provider: 'project',
+          source: 'project',
+          rank: 100,
+          locator: { content: 'project body.' },
+        }]
+      },
+      async get(candidate) {
+        return { ...candidate, content: (candidate.locator as { content: string }).content }
+      },
+    }))
+    const listed = await ctx.skills.list()
+    const pipeline = listed.find(skill => skill.name === 'research-pipeline')
+    expect(pipeline?.description).toBe('project override')
+    expect(listed.filter(skill => skill.name.startsWith('research-')).length).toBe(BUNDLED_SKILLS.length)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@deepseek-ai/dsh-session':
         specifier: 0.1.0-rc.8
         version: 0.1.0-rc.8(fbdb1d988541b64ff002d18c4ded7293)
+      '@deepseek-ai/dsh-skill':
+        specifier: 0.1.0-rc.8
+        version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-storage':
         specifier: 0.1.0-rc.8
         version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
@@ -2766,6 +2769,14 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.0.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-skill@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 


### PR DESCRIPTION
## What

Nine ARIS-style workflow playbooks ship inside `dsh-mimir` itself and register into the host's skill registry when one is mounted (the shipped web profile mounts one):

| Skill | Playbook |
| --- | --- |
| `research-pipeline` | 端到端：立意→查新→文献→计划→实验→主张门槛→写作→评审 |
| `research-lit-review` | arxiv_search + paper_fetch 建带笔记的文献库 |
| `research-novelty-check` | 花算力前的查新门槛（机理/应用/结果三角检索） |
| `research-experiment-plan` | 主张驱动的带预算运行排序 |
| `research-result-to-claim` | 实验后判定主张 supported/invalidated/pending |
| `research-paper-drafting` | 逐节写作 + 随写随编译 |
| `research-citation-audit` | 零信任参考文献审计 |
| `research-rebuttal` | 有证据边界、守篇幅限制的审稿回复 |
| `research-figure-plan` | 主张配图设计并经 figure_save 归管 |

## Design

- `ctx.skills.register()` runtime contributions at rank 250 — project-level same-name skills still override; user-level ones yield.
- `skills` is deliberately NOT in plugin `inject`: `ctx.inject(['skills'], …)` makes it soft, so bare compositions (no skill registry) load the full suite unchanged.
- Bodies ride the bundle as template literals (same rationale as templates.ts — published packages ship `lib/` only).
- Every body references only real surfaces: the five tools, five commands, four workspace artifacts, workbench tabs.
- New `skills.enabled` config knob (default `true`); `@deepseek-ai/dsh-skill` added as an **optional** peer (type-only import).

## Tests

+4 tests (542 total green): metadata hygiene, real-registry registration with loadable bodies, no-registry silence, project-override precedence.