### PR TITLE
chore: bump versions to 0.8.1 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ Contributing: branch off `main` (`feature/<name>` or `fix/<name>`), keep `pnpm r
 
 ## Changelog
 
+### 0.8.1
+
+- Fix: a project without a paper directory broke the whole project list (`paperDir` was emitted as an explicit `undefined`, failing the gateway's JSON boundary validation); `submitJob`'s unlinked `experimentId` had the same latent bug. Both keys are now omitted when unset, with regression tests.
+- Paper view: head-row buttons and the save pill no longer wrap character-by-character in narrow panes (project name / compile status absorb the squeeze with ellipsis).
+- Literature view: the new-subscription-papers list is collapsible (default folded; a successful manual check unfolds it once; persists). Sidebar project list is collapsible too, still showing the selected project's name.
+
 ### 0.8.0
 
 - Nine **bundled research skills** (`research-pipeline`, `research-lit-review`, `research-novelty-check`, `research-experiment-plan`, `research-result-to-claim`, `research-paper-drafting`, `research-citation-audit`, `research-rebuttal`, `research-figure-plan`) register into the host's skill catalog when a skill registry is mounted; `skills.enabled: false` opts out, and project-level same-name skills override them.

--- a/README.zh.md
+++ b/README.zh.md
@@ -383,6 +383,12 @@ pnpm run typecheck   # tsc -b 两个包；需先构建（ui-mimir 引用生成�
 
 ## 更新日志
 
+### 0.8.1
+
+- 修复：没有论文目录的项目会导致整个项目列表加载失败（`paperDir` 以显式 `undefined` 输出，过不了网关的 JSON 边界校验）；`submitJob` 未关联实验时的 `experimentId` 是同款隐患。两处现在都在缺省时完全省略该键，附回归测试。
+- 论文页：窄窗格下头部按钮和保存徽标不再逐字换行（项目名/编译状态用省略号吸收挤压）。
+- 文献页：订阅新文献列表可折叠（默认折叠；手动检新成功后自动展开一次；状态持久化）。侧栏项目列表也可折叠，折叠后仍显示当前项目名。
+
 ### 0.8.0
 
 - 九个**内置科研 skills**（`research-pipeline`、`research-lit-review`、`research-novelty-check`、`research-experiment-plan`、`research-result-to-claim`、`research-paper-drafting`、`research-citation-audit`、`research-rebuttal`、`research-figure-plan`）在宿主挂载 skill registry 时注册进 agent 的 skill 目录；`skills.enabled: false` 可关闭，项目级同名 skill 可覆盖。

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release bump: dsh-mimir + dsh-client-ui-mimir → 0.8.1；README 更新日志补 0.8.1。合并后打 v0.8.1 tag。