### PR TITLE
feat(mimir): ship the workbench inside dsh-mimir (single-package install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,12 @@ Dark/light theme and 中/EN toggles live in the panel header. Keyboard-first: `1
 
 ## Quickstart
 
-Mimir is distributed as two npm packages:
+Mimir is a single npm package: `dsh-mimir` carries the research commands, tools, wiki, reviewer loop, server APIs, **and** the six-view Web workbench (shipped as the package's `dsh.client` bundle — installing the host plugin is all it takes; the Web roster row doubles as the browser row). The legacy `dsh-client-ui-mimir` package remains published for existing source integrations, but new installs do not need it.
 
-- `dsh-mimir` provides the research commands, tools, wiki, reviewer loop, and server APIs. This is the only package required for normal use.
-- `dsh-client-ui-mimir` provides the six-view Web workbench. It must be integrated into the dsh Web client and does not appear in the sidebar merely by installing the npm package.
-
-Check the currently published versions at any time:
+Check the currently published version at any time:
 
 ```sh
 npm view dsh-mimir version
-npm view dsh-client-ui-mimir version
 ```
 
 ### Prerequisites
@@ -163,23 +159,17 @@ dsh plugin --profile web add dsh-mimir@latest
 npm view dsh-mimir version
 ```
 
-For packages installed directly in a Node.js project, run:
+For packages installed directly in a Node.js project instead, run:
 
 ```sh
-npm install dsh-mimir@latest dsh-client-ui-mimir@latest
+npm install dsh-mimir@latest
 ```
 
 ### 5. Full Web workbench
 
-Install the Web workbench package with npm:
+Nothing extra to install: since v0.11.0 the six-view workbench ships inside `dsh-mimir` itself (the package declares `dsh.client` and serves its client bundle at `/plugins/dsh-mimir/client.js`). Restart `dsh web` after installing or upgrading, then click **Mimir** in the sidebar footer.
 
-```sh
-npm install dsh-client-ui-mimir@latest
-```
-
-The two packages version in lockstep: `dsh-client-ui-mimir` declares `dsh-mimir` as a peer dependency with a floor at the current release (npm installs it automatically when missing), because each workbench release may call Remote methods that only that host release serves. When upgrading, upgrade both together (`npm install dsh-mimir@latest dsh-client-ui-mimir@latest`); a newer UI against an older host silently lacks the newest panel features.
-
-One important limitation: the currently published dsh Web composition does not automatically discover standalone client plugins or mount the `research` Remote namespace. Installing `dsh-client-ui-mimir` alone therefore does not add the Mimir sidebar button. The complete six-view UI currently requires registering the client package in a dsh source checkout and applying the Remote assembly described in [Known limitations](#known-limitations). The host-side research commands, tools, wiki, automatic artifact saving, and `/research/*` APIs work without that UI integration.
+If you previously integrated the standalone `dsh-client-ui-mimir` package into a dsh source checkout, remove its roster row (`ui-mimir`) when you upgrade — keeping both mounts the panel twice. The legacy package stays published and versioned in lockstep for integrations that still reference it.
 
 ### 6. Develop from source (optional)
 
@@ -349,7 +339,7 @@ Full example with comments: [examples/mimir-agent/cordis.yml](examples/mimir-age
   disposers.push(await ctx.remote.$mount(researchRemote))
   ```
 
-  The client plugin (`dsh-client-ui-mimir`) must likewise be registered in the web composition. This is a dsh-side design constraint (the assembly is an explicit allowlist), not a Mimir defect — see [Quickstart §5](#5-the-web-workbench).
+  The Remote assembly line is the only wiring left: the client bundle itself ships inside `dsh-mimir` since v0.11.0, so no separate client package needs registering.
 - **Compile status is host process memory** — a host restart forgets the last result; the panel shows `idle` until the next compile even if a previously built `main.pdf` is still on disk.
 - **No live push** — the panel neither polls nor subscribes; compiles started elsewhere (`/paper-compile` or the tool) become visible on the next selection or compile.
 
@@ -359,6 +349,8 @@ Full example with comments: [examples/mimir-agent/cordis.yml](examples/mimir-age
 pnpm install
 pnpm run build       # ordered pipeline: mimir typecheck → mimir bundle (emits the
                      # typert artifacts ui-mimir typechecks against) → ui-mimir
+                     # typecheck+bundle → mimir client bundle (the workbench,
+                     # built from ui-mimir's compiled client entry)
 pnpm test            # vitest, both packages
 pnpm run typecheck   # tsc -b both packages; assumes a prior build (ui-mimir
                      # imports the generated dsh-mimir/remote declarations)
@@ -366,12 +358,12 @@ pnpm run typecheck   # tsc -b both packages; assumes a prior build (ui-mimir
 
 Layout:
 
-- `packages/mimir` — the host plugin (`dsh-mimir`): commands, tools, wiki domain, reviewer loop, LaTeX compile, BibTeX management, paper snapshots, arXiv keyword subscriptions with scheduled new-paper checks, the `research` Remote namespace (55 methods), and the `/research/pdf` / `/research/figure` / `/research/figure-upload` routes.
-- `packages/ui-mimir` — the browser workbench (`dsh-client-ui-mimir`): sidebar toggle + overlay panel.
+- `packages/mimir` — the host plugin (`dsh-mimir`): commands, tools, wiki domain, reviewer loop, LaTeX compile, BibTeX management, paper snapshots, arXiv keyword subscriptions with scheduled new-paper checks, venue templates, the `research` Remote namespace (55 methods), the `/research/pdf` / `/research/paper-pdf` / `/research/figure` / `/research/figure-upload` / `/research/template-upload` routes, **and the bundled Web workbench** (`lib/client.js`, built from ui-mimir's client entry, served under the package's own `dsh.client` declaration).
+- `packages/ui-mimir` — the browser workbench sources; also still published as the legacy standalone `dsh-client-ui-mimir` for existing integrations.
 - `packages/typert-protocol` — vendored, never-published source copy of the Typert protocol (see below).
 - `examples/mimir-agent` — the cordis patch used in the Quickstart.
 
-Build artifacts: `packages/mimir/lib/{index.js, invariant.js, typert.host.js, typert.remote-client.js, types/}` and `packages/ui-mimir/lib/{index.js, invariant.js, client.js, types/}`.
+Build artifacts: `packages/mimir/lib/{index.js, invariant.js, typert.host.js, typert.remote-client.js, client.js, types/}` and `packages/ui-mimir/lib/{index.js, invariant.js, client.js, types/}`.
 
 `packages/ui-mimir/scripts/screenshot.ts` is a QA harness (not part of the test suite): against a running `dsh web` instance with the plugin mounted, it captures one PNG per workbench tab into `/tmp/research-ui/`. It requires a local Playwright installation; adjust the import/`CHROMIUM` path at the top of the file.
 

--- a/build/client-preset/tsdown.client.ts
+++ b/build/client-preset/tsdown.client.ts
@@ -106,6 +106,23 @@ export function clientBundle(
   return [lib, client]
 }
 
+/**
+ * Browser bundle variant for a package whose client entry lives in ANOTHER
+ * workspace package (the single-package layout: the host package ships the
+ * workbench under its own name). The entry is spelled at the call site; the
+ * banner id stays the host package's name so the loader row matches.
+ * @param id - plugin id (the host package's name), stamped into the
+ * __ModuleLoader__.load handoff and onto the injected style tags.
+ * @param clientEntry - the compiled client entry, relative to this package.
+ * @returns the tsdown config of the browser bundle alone.
+ */
+export function clientBundleOnly(
+  id: string,
+  clientEntry: string,
+): UserConfig[] {
+  return [clientConfig(id, clientEntry)]
+}
+
 function clientLibraryConfig(
   id: string,
   libEntry: readonly string[],

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "mimir-monorepo",
   "private": true,
   "packageManager": "pnpm@11.18.0",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "type": "module",
   "scripts": {
-    "build": "tsc -b packages/mimir && pnpm --filter dsh-mimir run bundle && tsc -b packages/ui-mimir && pnpm --filter dsh-client-ui-mimir run bundle",
+    "build": "tsc -b packages/mimir && pnpm --filter dsh-mimir run bundle && tsc -b packages/ui-mimir && pnpm --filter dsh-client-ui-mimir run bundle && pnpm --filter dsh-mimir run bundle:client",
     "typecheck": "tsc -b packages/mimir packages/ui-mimir",
     "test": "vitest run",
     "test:e2e": "playwright test",

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -23,6 +23,7 @@
       "types": "./lib/types/invariant.d.ts",
       "default": "./lib/invariant.js"
     },
+    "./client": "./lib/client.js",
     "./types": {
       "types": "./lib/types/types.d.ts",
       "default": "./lib/types/types.js"
@@ -46,10 +47,13 @@
     "lib/typert.host.js",
     "lib/typert.host.d.ts",
     "lib/typert.remote-client.js",
-    "lib/typert.remote-client.d.ts"
+    "lib/typert.remote-client.d.ts",
+    "lib/client.js",
+    "lib/client.js.map"
   ],
   "scripts": {
-    "bundle": "tsdown"
+    "bundle": "tsdown",
+    "bundle:client": "tsdown -c tsdown.client.config.ts"
   },
   "license": "MIT",
   "peerDependencies": {
@@ -91,5 +95,18 @@
     "@deepseek-ai/dsh-subagent": "0.1.0-rc.8",
     "@deepseek-ai/dsh-tools": "0.1.0-rc.8",
     "@deepseek-ai/dsh-typert-protocol": "0.1.0-rc.8"
+  },
+  "dsh": {
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-runtime",
+        "@deepseek-ai/dsh-api-remotes",
+        "@deepseek-ai/dsh-client-locale",
+        "@deepseek-ai/dsh-client-ui-layout",
+        "@deepseek-ai/dsh-client-ui-sidebar",
+        "@deepseek-ai/dsh-client-ui-theme"
+      ],
+      "platform": "web"
+    }
   }
 }

--- a/packages/mimir/tsdown.client.config.ts
+++ b/packages/mimir/tsdown.client.config.ts
@@ -1,0 +1,9 @@
+import { clientBundleOnly } from '../../build/client-preset/tsdown.client.ts'
+
+// The single-package layout: dsh-mimir ships the research workbench under its
+// own name, bundling ui-mimir's compiled client entry (`tsc -b` of
+// packages/ui-mimir must run first — the root build script orders it). The
+// banner id stays `dsh-mimir` so the host roster row doubles as the browser
+// row (the ClientModuleRegistry scanner picks up this package's dsh.client
+// declaration and serves this bundle at /plugins/dsh-mimir/client.js).
+export default clientBundleOnly('dsh-mimir', '../ui-mimir/lib/types/client/index.js')


### PR DESCRIPTION
## What
`dsh-mimir` now declares `dsh.client` and bundles the ui-mimir workbench as `lib/client.js` under its own package name (banner id `dsh-mimir`). The ClientModuleRegistry scanner picks the declaration up from the roster row that `dsh plugin add` already inserts — **installing the host plugin alone now yields the full six-view UI**; no separate client package, no source integration.

- New preset helper `clientBundleOnly(id, entry)`; `packages/mimir/tsdown.client.config.ts` bundles `../ui-mimir/lib/types/client/index.js` after the ui-mimir build (root build script extended).
- `dsh-client-ui-mimir` keeps publishing in lockstep for existing integrations; README documents removing its roster row to avoid a double mount.
- Quickstart rewritten to the single-package story; the old "client plugin must be source-integrated" limitation is gone (only the Remote assembly line remains).

## Verified
- 577 tests green; full build green.
- Browser-verified in a dsh tree with the ui-mimir roster row removed: the panel loads from `/plugins/@deepseek-ai/dsh-mimir/client.js`, exactly one sidebar toggle, relevance chips and the venue picker work.