### PR TITLE
chore: bump versions to 0.11.0 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ Contributing: branch off `main` (`feature/<name>` or `fix/<name>`), keep `pnpm r
 
 ## Changelog
 
+### 0.11.0
+
+- **Single-package install**: the six-view Web workbench now ships inside `dsh-mimir` itself (a `dsh.client` declaration plus the bundled `lib/client.js`). `dsh plugin --profile web add dsh-mimir@latest` alone yields the full UI — the separate `dsh-client-ui-mimir` install and the source-integration requirement are gone. The legacy package stays published in lockstep; remove its roster row when upgrading to avoid a double mount.
+- `dsh-client-ui-mimir`'s `dsh-mimir` peer floor now tracks the current release (>= 0.11.0), so a new workbench cannot pair with an older host that lacks its Remote methods.
+
 ### 0.10.0
 
 - **Venue templates**: pick a target venue in the paper header — 11 built-in formats (CVPR/ICCV/ECCV, NeurIPS/ICML/ICLR/AAAI, ACL, IEEE conference/journal, ACM acmart) with official kit URLs and formatting checklists. Applying writes `template/TEMPLATE.md` (the re-layout brief) into the paper directory and records the venue on the project; "Format to venue" hands the re-layout task to the agent (content untouched, compile-verified).

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publishConfig": {
     "access": "public"
   },
@@ -57,7 +57,7 @@
     "@deepseek-ai/dsh-client-ui-theme": ">=0.0.1-rc.1",
     "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-typert-protocol": ">=0.1.0-rc.8",
-    "dsh-mimir": ">=0.10.0"
+    "dsh-mimir": ">=0.11.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",


### PR DESCRIPTION
Version bump 0.10.0 → 0.11.0 (both packages, ui peer floor >=0.11.0) + README changelog. Tag v0.11.0 after merge.