### PR TITLE
chore: bump versions to 0.12.0 for release

### DIFF
--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mimir",
   "description": "Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publishConfig": {
     "access": "public"
   },
@@ -11,7 +11,9 @@
     "directory": "packages/mimir"
   },
   "type": "module",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
   "exports": {

--- a/packages/ui-mimir/package.json
+++ b/packages/ui-mimir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-client-ui-mimir",
   "description": "Mimir research workbench for the web surface: a sidebar-footer toggle plus a frame-level overlay listing wiki projects, the paper outline, and the latexmk/tectonic compile/PDF preview, backed by the research Host Remote",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publishConfig": {
     "access": "public"
   },
@@ -11,7 +11,9 @@
     "directory": "packages/ui-mimir"
   },
   "type": "module",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
   "exports": {
@@ -57,7 +59,7 @@
     "@deepseek-ai/dsh-client-ui-theme": ">=0.0.1-rc.1",
     "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.8",
     "@deepseek-ai/dsh-typert-protocol": ">=0.1.0-rc.8",
-    "dsh-mimir": ">=0.11.0"
+    "dsh-mimir": ">=0.12.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",


### PR DESCRIPTION
Version-only release bump: both packages 0.11.0 → 0.12.0, ui peer floor >= 0.12.0. Content already on main via #109.