### PR TITLE
feat(meeting): figure-by-figure decks + meeting_deck tool + direct group-meeting-skills integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ Contributing: branch off `main` (`feature/<name>` or `fix/<name>`), keep `pnpm r
 
 ## Changelog
 
+### 0.13.0
+
+- **Decks with real paper figures**: the Meetings pipeline now embeds figure-by-figure slides — drop a `meetings/.paper-figures/<arxivId>/manifest.json` (extracted from the paper PDF) next to the project and each selected paper's intro slide is followed by up to 3 per-figure slides with its extracted images.
+- **New `meeting_deck` agent tool**: the agent can generate the whole-project report deck itself (title/presenter/date, section switches, paper selection) — same renderer as the tab, so the result lands in 已生成的汇报 with download/delete.
+- **Direct integration of [academic-Group-meeting-skills](https://github.com/mlxbc12138/academic-Group-meeting-skills)**: the rewritten `research-meeting-deck` skill walks the agent through the original repo's pipeline end to end — clone the skill, run `paper_figures_to_ppt.py extract` against the project's cached arXiv PDFs (with a bundled single-file `pdftoppm` shim for hosts without poppler), let the agent polish manifest captions, `build` a figure-by-figure deck against the skill's reference style, then file the `.pptx` into `meetings/<project>/` where the tab manages it. Path B remains the built-in whole-project deck via `meeting_deck`.
+
 ### 0.12.0
 
 - **Group-meeting decks (组会)**: a new workbench tab turns the project's wiki into a presentation — deck title/presenter/date, four section switches (progress/experiments/figures/papers), paper multi-select with relevance chips (empty = top 12 by score), and a figure thumbnail multi-select. The host renders a real 16:9 `.pptx` via pptxgenjs (no agent session needed) into `meetings/<project>/`; generated decks list in the tab with download and delete.

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -18,6 +18,7 @@ import { researchWikiDomainSpec } from './store.ts'
 import { createArxivSearchTool, createPaperFetchTool } from './tools/arxiv.ts'
 import { createWikiNoteTool } from './tools/wiki.ts'
 import { createFigureOrganizeTool, createFigureSaveTool } from './tools/figure.ts'
+import { createMeetingDeckTool } from './tools/meeting.ts'
 import { createLatexCompileTool } from './tools/latex.ts'
 import { registerIdeaCommand } from './commands/idea.ts'
 import { registerPlanCommand } from './commands/plan.ts'
@@ -137,6 +138,7 @@ export { createZoteroClient } from './tools/zotero.ts'
 export type { ZoteroBibRequest, ZoteroClient, ZoteroClientConfig, ZoteroCollection, ZoteroFetch, ZoteroItem } from './tools/zotero.ts'
 export { createWikiNoteTool } from './tools/wiki.ts'
 export { createFigureOrganizeTool, createFigureSaveTool } from './tools/figure.ts'
+export { createMeetingDeckTool } from './tools/meeting.ts'
 export { buildWikiSnapshot } from './wiki-snapshot.ts'
 export type { WikiSnapshotSource } from './wiki-snapshot.ts'
 export {
@@ -717,6 +719,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   ctx.tools.register(createWikiNoteTool(domain))
   ctx.tools.register(createFigureSaveTool(deps.workspaceDir, domain))
   ctx.tools.register(createFigureOrganizeTool(deps.workspaceDir, domain))
+  ctx.tools.register(createMeetingDeckTool(deps.workspaceDir, domain))
   ctx.tools.register(createLatexCompileTool(resolved.latex))
 
   registerIdeaCommand(ctx, deps)

--- a/packages/mimir/src/services/meeting.ts
+++ b/packages/mimir/src/services/meeting.ts
@@ -10,7 +10,7 @@
  * @module dsh-mimir/src/services/meeting
  */
 
-import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
+import { mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
 import type {
   ExperimentRecord,
@@ -29,11 +29,15 @@ import type { WikiAdminDeps } from './wiki-admin.ts'
 
 /** Directory under the workspace root holding one subfolder per project. */
 export const MEETINGS_DIR_NAME = 'meetings'
+/** Directory under meetings/ holding per-paper extracted figure crops (the 逐图 assets). */
+export const PAPER_FIGURES_DIR_NAME = '.paper-figures'
 /** The deck font, per the group-meeting house style. */
 export const DECK_FONT = 'Microsoft YaHei'
 /** Caps keeping a deck presentable: papers and figures per deck. */
 export const DECK_MAX_PAPERS = 12
 export const DECK_MAX_FIGURES = 12
+/** Per-paper figure-crop cap inside the papers section (the 逐图 slides). */
+export const DECK_MAX_PAPER_FIGURES = 3
 
 const DEFAULT_INCLUDE: MeetingInclude = Object.freeze({
   progress: true, experiments: true, figures: true, papers: true,
@@ -46,6 +50,16 @@ export interface MeetingFigureInput {
   readonly imagePath: string
 }
 
+/** One figure crop extracted from a paper's PDF (the 逐图 slides of the papers section). */
+export interface PaperFigureAsset {
+  /** Absolute path of the extracted crop (png). */
+  readonly imagePath: string
+  /** Figure label as printed in the paper (`Figure 2`, `Fig. 3a`…). */
+  readonly label: string
+  /** Caption text — the takeaway sentence after the agent's polish pass. */
+  readonly caption: string
+}
+
 /** Everything {@link buildDeckModel} needs, already gathered. */
 export interface DeckModelInput {
   readonly project: ProjectRecord
@@ -55,6 +69,8 @@ export interface DeckModelInput {
   /** Total library papers associated with the project (the slide's count, uncapped). */
   readonly paperCount: number
   readonly papers: readonly PaperRecord[]
+  /** Extracted figure crops per paper, keyed by arXiv id (missing = text-only paper slide). */
+  readonly paperFigures: Readonly<Record<string, readonly PaperFigureAsset[]>>
   readonly experiments: readonly ExperimentRecord[]
   readonly figures: readonly MeetingFigureInput[]
   readonly include: MeetingInclude
@@ -165,6 +181,16 @@ export function buildDeckModel(input: DeckModelInput): readonly DeckSlide[] {
         heading: paper.title,
         bullets: bullets.length > 0 ? bullets : [{ text: paper.summary.slice(0, 200) }],
       })
+      // 逐图 slides: extracted figure crops follow the paper's intro slide,
+      // one figure per slide with its takeaway caption (the house layout).
+      for (const asset of input.paperFigures[paper.arxivId] ?? []) {
+        slides.push({
+          kind: 'figure',
+          heading: `${asset.label} · ${paper.title}`,
+          imagePath: asset.imagePath,
+          caption: asset.caption,
+        })
+      }
     }
   }
 
@@ -308,6 +334,52 @@ function slugOf(title: string, fallback: string): string {
 }
 
 /**
+ * Load one paper's extracted figure crops, when an extraction pass ran (the
+ * research-meeting-deck skill's script writes `manifest.json` plus png crops
+ * here). A missing/invalid manifest reads as none; entries whose file is
+ * gone are dropped. Capped at {@link DECK_MAX_PAPER_FIGURES}.
+ * @param workspaceDir - research workspace root.
+ * @param arxivId - the paper's bare arXiv id (the manifest folder name).
+ * @returns the paper's deck-ready figure assets, possibly empty.
+ */
+export async function loadPaperFigures(
+  workspaceDir: string,
+  arxivId: string,
+): Promise<readonly PaperFigureAsset[]> {
+  const dir = join(workspaceDir, MEETINGS_DIR_NAME, PAPER_FIGURES_DIR_NAME, arxivId)
+  let raw: string
+  try {
+    raw = await readFile(join(dir, 'manifest.json'), 'utf8')
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  const assets: PaperFigureAsset[] = []
+  for (const entry of parsed as readonly { file?: unknown; label?: unknown; caption?: unknown }[]) {
+    const file = basename(typeof entry?.file === 'string' ? entry.file : '')
+    if (file === '' || extname(file).toLowerCase() !== '.png') continue
+    const imagePath = join(dir, file)
+    const stats = await stat(imagePath).catch(() => undefined)
+    if (stats === undefined || !stats.isFile()) continue
+    assets.push({
+      imagePath,
+      label: typeof entry.label === 'string' && entry.label !== ''
+        ? entry.label
+        : file.replace(/\.png$/, ''),
+      caption: typeof entry.caption === 'string' ? entry.caption : '',
+    })
+    if (assets.length >= DECK_MAX_PAPER_FIGURES) break
+  }
+  return Object.freeze(assets)
+}
+
+/**
  * Generate one project's meeting deck. Gathers the selected (or default)
  * papers/experiments/figures, plans the slides, renders the pptx into
  * `meetings/<projectId>/`, and returns the file name plus the slide count.
@@ -379,8 +451,18 @@ export async function generateMeetingDeck(
 
   const date = request.date?.trim() || dateOnly(new Date().toISOString())
   const title = request.title?.trim() || `${project.title} · 组会汇报`
+
+  // 逐图 assets of the selected papers (extraction ran → crops + manifest).
+  const paperFigures: Record<string, readonly PaperFigureAsset[]> = {}
+  if (include.papers) {
+    for (const paper of papers) {
+      const assets = await loadPaperFigures(deps.workspaceDir, paper.arxivId)
+      if (assets.length > 0) paperFigures[paper.arxivId] = assets
+    }
+  }
+
   const slides = buildDeckModel({
-    project, title, date, presenter: request.presenter, paperCount: associated.length, papers, experiments, figures, include,
+    project, title, date, presenter: request.presenter, paperCount: associated.length, papers, paperFigures, experiments, figures, include,
   })
 
   const meetingsDir = join(deps.workspaceDir, MEETINGS_DIR_NAME, project.id)

--- a/packages/mimir/src/skills.ts
+++ b/packages/mimir/src/skills.ts
@@ -381,54 +381,103 @@ Design and produce the paper's figures so each one earns its column width.
   column width, referenced in the text, and captioned with its takeaway.
 ` + SHARED_RULES
 
-// The deck-style rules below (Chinese slide voice, one message per slide,
-// figure-left/caption-right, Fig.X takeaway captions) are adapted from the
-// academic-Group-meeting-skills project
-// (https://github.com/mlxbc12138/academic-Group-meeting-skills) — credit and
-// thanks; Mimir renders them deterministically via pptxgenjs instead of
-// per-slide HTML.
+// Path A below drives the academic-Group-meeting-skills pipeline directly
+// (https://github.com/mlxbc12138/academic-Group-meeting-skills) — cloned at
+// first use, never vendored (the upstream repo ships no license file, so we
+// reference rather than copy it). Its slide-voice rules (Microsoft YaHei,
+// image-left/caption-right, Fig.X Chinese takeaway captions) also govern the
+// Path-B renderer. Credit and thanks to the upstream authors.
 export const RESEARCH_MEETING_DECK = String.raw`
-# Meeting Deck — prepare a group-meeting report from the wiki
+# Meeting Deck — 组会 PPT：逐图精读 or 全项目汇报
 
-Prepare the material for a group-meeting (组会) deck, then let the workbench
-render it. The 组会 / Meetings tab generates the .pptx deterministically from
-the wiki — your job is to make sure what it reads is worth projecting.
+Two decks, two engines. Pick by what the user asked for:
 
-## Slide voice (the house style)
+- **Path A — 单篇文献逐图精读**: one paper, one slide per figure, reference
+  deck style. Drives the upstream academic-Group-meeting-skills script.
+- **Path B — 全项目组会汇报**: progress + experiments + figures + selected
+  papers, rendered deterministically by the \`meeting_deck\` tool.
 
-- Chinese, plain and direct: one slide carries one message, stated in the
-  heading — never "实验结果", always "方法 X 在 Y 上超过 baseline 2.1 个点".
-- Figures present as image-left / caption-right; the caption is the takeaway
-  sentence ("Fig.2 去掉检索模块后召回掉 8 个点"), not a description of axes.
-- Progress is stated against the project stage and the venue target, not as a
-  diary.
+Both land in \`<workspace>/meetings/<projectId>/\`, so the workbench's 组会 /
+Meetings tab lists and downloads them.
 
-## Prepare the material
+## Path A — figure-by-figure deck of ONE paper
 
-1. **Papers** — the deck pulls the project's library papers, relevance-sorted,
-   capped at 12. Re-read the project's paper notes: each kept paper needs a
-   one-paragraph \`notes\` (update with \`wiki_note { action: 'update_paper' }\`)
-   and a relevance score so the sort is honest. A paper without notes shows up
-   as its abstract — weak on a slide.
-2. **Figures** — every figure slide takes its caption from the wiki registry.
-   Walk the 图表 tab and give each figure its takeaway caption before
-   generating; an empty caption wastes the right column.
-3. **Experiments** — the deck lists up to 8 recent runs with their metrics.
-   Make sure the runs you want projected are logged via
-   \`wiki_note { action: 'add_experiment' }\` with real metric values.
-4. **Progress** — \`wiki_note { action: 'set_project' }\` must reflect the
-   true stage, and the venue target (venue tab) should be set if the project
-   is aiming at a conference.
+1. First use only, clone the upstream skill:
+   \`git clone --depth 1 https://github.com/mlxbc12138/academic-Group-meeting-skills ~/.dsh/skills-external/academic-Group-meeting-skills\`
+   The script is at
+   \`~/.dsh/skills-external/academic-Group-meeting-skills/academic-Group-meeting-skills/scripts/paper_figures_to_ppt.py\`
+   (call it SCRIPT below). Read
+   \`~/.dsh/skills-external/academic-Group-meeting-skills/academic-Group-meeting-skills/references/style-profile.md\`
+   before laying out slides.
+2. Renderer check: \`command -v pdftoppm\` (poppler). If missing, write the
+   shim at the bottom of this skill to \`<scratch>/bin/pdftoppm\`,
+   \`chmod +x\` it, and pass \`--pdftoppm <scratch>/bin/pdftoppm\` to extract.
+3. Extract (paper PDFs live under \`<workspace>/papers/<arxivId>.pdf\` after
+   \`paper_fetch\`):
+   \`uv run --with pdfplumber --with pillow --with python-pptx python SCRIPT extract --pdf <paper.pdf> --workdir <scratch>\`
+4. Polish \`<scratch>/manifest.json\` — this is where the quality comes from:
+   drop logos/decorations/tiny icons; fill \`paper.title_zh\`,
+   \`paper.journal_if\`, \`paper.author_school\`; turn every \`raw_caption\`
+   into a takeaway \`zh_caption\` ("Fig. 2 去掉检索模块召回掉 8 个点", not an
+   axis description) plus \`zh_panel_captions\` A/B/C/D lines when the figure
+   has panels; crop huge composite figures into \`subslides\`. Keep exact
+   values, units, gene/method names verbatim.
+5. Build:
+   \`uv run --with pdfplumber --with pillow --with python-pptx python SCRIPT build --manifest <scratch>/manifest.json --out <out.pptx> --reference-pptx ~/.dsh/skills-external/academic-Group-meeting-skills/academic-Group-meeting-skills/assets/reference-style.pptx\`
+6. Register: copy the pptx to
+   \`<workspace>/meetings/<projectId>/<slug>-<yyyymmdd>.pptx\` — it shows in
+   the 组会 tab immediately.
 
-## Generate, then polish
+## Path B — whole-project report (deterministic)
 
-- Tell the user to open the 组会 tab, pick the papers/figures to include,
-  and hit 生成 — the deck lands in \`meetings/<project>/\` and downloads from
-  the tab. If you are preparing a specific meeting, draft the deck title and
-  the 下一步计划 talking points for them.
-- After generation, ask for the one-slide feedback: which slide would the
-  advisor attack first? Strengthen that slide's evidence (a missing run, a
-  missing baseline) before the meeting, not during it.
+1. Curate what the deck renders — it projects exactly what the wiki holds:
+   one-paragraph \`notes\` per featured paper
+   (\`wiki_note { action: 'update_paper' }\`), takeaway captions on figures,
+   logged runs with real metrics, and an honest stage
+   (\`wiki_note { action: 'set_project' }\`).
+2. Optional 逐图 slides inside the report: after a Path-A extract, copy the
+   chosen crops into \`<workspace>/meetings/.paper-figures/<arxivId>/\` and
+   write \`manifest.json\` there as
+   \`[{"file": "fig-01.png", "label": "Figure 1", "caption": "Fig.1 中文 takeaway"}]\`
+   — at most 3 per paper make the deck.
+3. Call \`meeting_deck\` with \`project_id\` (plus optional \`title\`,
+   \`presenter\`, \`date\`, \`paper_ids\`, \`include_*\` switches). The tool
+   returns the deck path; the user downloads from the 组会 tab.
+
+## Slide voice (both paths)
+
+- Chinese, one message per slide, stated in the heading — never "实验结果",
+  always "方法 X 在 Y 上超过 baseline 2.1 个点".
+- Figures image-left / caption-right; the caption is the takeaway sentence.
+- Microsoft YaHei everywhere; fixed readable caption sizes over auto-shrink.
+
+## pdftoppm shim (Path A step 2)
+
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pypdfium2", "pillow"]
+# ///
+"""pdftoppm-compatible shim: -r <dpi> -png <input.pdf> <prefix> via pypdfium2."""
+import sys
+import pypdfium2 as pdfium
+
+args = sys.argv[1:]
+dpi = 150
+while args and args[0].startswith("-"):
+    flag = args.pop(0)
+    if flag == "-r":
+        dpi = int(args.pop(0))
+    elif flag == "-png":
+        pass
+    else:
+        raise SystemExit("shim: unsupported flag " + flag)
+doc = pdfium.PdfDocument(args[0])
+n = len(doc)
+width = max(2, len(str(n)))
+for i in range(n):
+    doc[i].render(scale=dpi / 72).to_pil().save(args[1] + "-" + str(i + 1).zfill(width) + ".png")
+doc.close()
 ` + SHARED_RULES
 
 
@@ -490,8 +539,8 @@ export const BUNDLED_SKILLS: readonly BundledSkill[] = [
   },
   {
     name: 'research-meeting-deck',
-    description: 'Prepare group-meeting (组会) material — paper notes, figure takeaway captions, logged runs, honest stage — so the Meetings tab renders a deck worth projecting. Use when the user says "组会", "组会汇报", "meeting deck", "group meeting slides", or a lab meeting is coming.',
-    whenToUse: 'A group meeting is coming and the deck should be generated from curated wiki material.',
+    description: 'Generate a group-meeting (组会) deck that actually shows paper figures: either run the bundled academic-Group-meeting-skills pipeline (pdftoppm shim + paper_figures_to_ppt.py) for a figure-by-figure paper walkthrough, or call the meeting_deck tool for a whole-project report with per-figure slides. Use when the user says "组会", "组会汇报", "meeting deck", "group meeting slides", or a lab meeting is coming.',
+    whenToUse: 'A group meeting is coming and the user wants a slide deck with real paper figures, generated end-to-end.',
     content: RESEARCH_MEETING_DECK,
   },
 ]

--- a/packages/mimir/src/tools/meeting.ts
+++ b/packages/mimir/src/tools/meeting.ts
@@ -1,0 +1,82 @@
+/**
+ * The `meeting_deck` tool: render one project's group-meeting pptx from the
+ * wiki (progress, experiments, paper-directory figures, library papers with
+ * extracted 逐图 crops) into `meetings/<projectId>/`, so the deck lists in the
+ * workbench's 组会 / Meetings tab immediately. This is the deterministic
+ * render path — the agent curates the material (paper notes, figure captions,
+ * extraction manifests) and calls this tool; no manual UI step is needed.
+ * @module dsh-mimir/src/tools/meeting
+ */
+
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
+import type { JsonValue } from '@deepseek-ai/dsh-session'
+import { generateMeetingDeck } from '../services/meeting.ts'
+import type { ResearchWikiDomain } from '../store.ts'
+
+interface MeetingDeckArgs {
+  readonly project_id?: string
+  readonly title?: string
+  readonly presenter?: string
+  readonly date?: string
+  readonly paper_ids?: readonly string[]
+  readonly include_progress?: boolean
+  readonly include_experiments?: boolean
+  readonly include_figures?: boolean
+  readonly include_papers?: boolean
+}
+
+/**
+ * Build the `meeting_deck` tool over one opened research-wiki domain.
+ * @param workspaceDir - the resolved research workspace root.
+ * @param domain - the plugin-owned open domain handle.
+ * @returns the registry-ready tool definition.
+ */
+export function createMeetingDeckTool(workspaceDir: string, domain: ResearchWikiDomain): ToolDefinition {
+  return defineTool({
+    name: 'meeting_deck',
+    description: 'Generate a group-meeting (组会) pptx for a research project from the wiki: progress, experiments, paper figures, and the selected library papers (with extracted per-figure slides when an extraction manifest exists). The deck lands in meetings/<projectId>/ and lists in the workbench\'s Meetings tab with download. Call this AFTER curating the material — paper notes, figure captions, honest project stage — because the slides render exactly what the wiki holds.',
+    parameters: {
+      project_id: { type: 'string', required: true, description: 'Wiki project id (see wiki_note action=list, table=projects).' },
+      title: { type: 'string', description: 'Deck title (defaults to "<project> · 组会汇报").' },
+      presenter: { type: 'string', description: 'Presenter name shown on the title slide (optional).' },
+      date: { type: 'string', description: 'Meeting date YYYY-MM-DD (defaults to today).' },
+      paper_ids: { type: 'array', items: { type: 'string' }, description: 'arXiv ids to feature, in slide order (omit for the project\'s papers, relevance-sorted, top 12).' },
+      include_progress: { type: 'boolean', description: 'Include the project-progress slide (default true).' },
+      include_experiments: { type: 'boolean', description: 'Include the experiments slide (default true).' },
+      include_figures: { type: 'boolean', description: 'Include paper-directory figure slides (default true).' },
+      include_papers: { type: 'boolean', description: 'Include the paper-sharing slides (default true).' },
+    },
+    output: {
+      schema: { type: 'json' },
+      render: (_args, value) => [{ type: 'text', text: JSON.stringify(value) }],
+    },
+    execute: async (args: MeetingDeckArgs): Promise<JsonValue> => {
+      if (args.project_id === undefined || args.project_id.trim().length === 0) {
+        throw new Error('meeting_deck requires a non-empty \'project_id\'')
+      }
+      const result = await generateMeetingDeck({ workspaceDir, domain }, {
+        projectId: args.project_id,
+        title: args.title,
+        presenter: args.presenter,
+        date: args.date,
+        paperIds: args.paper_ids,
+        include: {
+          progress: args.include_progress ?? true,
+          experiments: args.include_experiments ?? true,
+          figures: args.include_figures ?? true,
+          papers: args.include_papers ?? true,
+        },
+      })
+      if (!result.ok) {
+        const detail = 'message' in result.error ? ` — ${result.error.message}` : ` (${JSON.stringify(result.error)})`
+        throw new Error(`meeting_deck: ${result.error.code}${detail}`)
+      }
+      return {
+        file: result.value.file,
+        slides: result.value.slides,
+        path: `meetings/${args.project_id}/${result.value.file}`,
+      }
+    },
+  })
+}

--- a/packages/mimir/tests/meeting.spec.ts
+++ b/packages/mimir/tests/meeting.spec.ts
@@ -96,6 +96,7 @@ describe('buildDeckModel', () => {
       date: '2026-08-24',
       paperCount: 3,
       papers: [paperOf('2103.00020', 9)],
+      paperFigures: {},
       experiments: [experimentOf('e1')],
       figures: [{
         record: {
@@ -121,6 +122,7 @@ describe('buildDeckModel', () => {
       date: '2026-08-24',
       paperCount: 0,
       papers: [],
+      paperFigures: {},
       experiments: [],
       figures: [],
       include: { progress: true, experiments: true, figures: true, papers: true },
@@ -138,6 +140,7 @@ describe('buildDeckModel', () => {
       date: '2026-08-24',
       paperCount: 1,
       papers: [paperOf('2103.00020', 9)],
+      paperFigures: {},
       experiments: [],
       figures: [],
       include: { progress: false, experiments: false, figures: false, papers: true },
@@ -156,6 +159,7 @@ describe('buildDeckModel', () => {
       date: '2026-08-24',
       paperCount: 0,
       papers: [],
+      paperFigures: {},
       experiments,
       figures: [],
       include: { progress: false, experiments: true, figures: false, papers: false },
@@ -164,6 +168,32 @@ describe('buildDeckModel', () => {
     if (slide?.kind !== 'bullets') throw new Error('expected an experiments slide')
     expect(slide.bullets.length).toBe(9)
     expect(slide.bullets.at(-1)?.text).toContain('另外 2 次实验')
+  })
+
+  it('appends one 逐图 slide per extracted paper figure after the intro', () => {
+    const slides = buildDeckModel({
+      project: PROJECT,
+      title: '组会汇报',
+      date: '2026-08-24',
+      paperCount: 1,
+      papers: [paperOf('2103.00020', 9)],
+      paperFigures: {
+        '2103.00020': [
+          { imagePath: '/tmp/fig-01.png', label: 'Figure 1', caption: 'Fig.1 方法总览：检索模块是核心' },
+          { imagePath: '/tmp/fig-02.png', label: 'Figure 2', caption: 'Fig.2 去掉检索召回掉 8 个点' },
+        ],
+      },
+      experiments: [],
+      figures: [],
+      include: { progress: false, experiments: false, figures: false, papers: true },
+    })
+    const figureSlides = slides.filter(slide => slide.kind === 'figure')
+    expect(figureSlides.length).toBe(2)
+    expect(figureSlides[0]?.kind === 'figure' ? figureSlides[0].heading : '').toContain('Figure 1')
+    expect(figureSlides[1]?.kind === 'figure' ? figureSlides[1].caption : '').toContain('召回掉 8 个点')
+    // The intro slide still precedes the figure slides.
+    const introIndex = slides.findIndex(slide => slide.kind === 'bullets' && slide.heading.startsWith('Paper'))
+    expect(slides.indexOf(figureSlides[0] as never)).toBeGreaterThan(introIndex)
   })
 })
 
@@ -243,6 +273,29 @@ describe('generateMeetingDeck', () => {
     if (!picked.ok) return
     // title + agenda + two paper slides + closing
     expect(picked.value.slides).toBe(5)
+  })
+
+  it('embeds extracted paper figures when an extraction manifest exists', async () => {
+    const { domain, workspaceDir, service } = await harness()
+    await domain.table('projects').put(PROJECT.id, PROJECT)
+    await domain.table('papers').put('2103.00020', paperOf('2103.00020', 9))
+    const assetsDir = join(workspaceDir, 'meetings', '.paper-figures', '2103.00020')
+    await mkdir(assetsDir, { recursive: true })
+    await writeFile(join(assetsDir, 'fig-01.png'), PNG_BYTES)
+    await writeFile(join(assetsDir, 'manifest.json'), JSON.stringify([
+      { file: 'fig-01.png', label: 'Figure 1', caption: 'Fig.1 方法总览' },
+      // A manifest row whose crop file is gone is dropped, not fatal.
+      { file: 'gone.png', label: 'Figure 2', caption: 'missing' },
+    ]))
+    const result = await service.generateMeetingDeck({
+      projectId: 'p1',
+      date: '2026-08-24',
+      include: { progress: false, experiments: false, figures: false },
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // title + agenda + paper intro + one 逐图 slide + closing
+    expect(result.value.slides).toBe(5)
   })
 })
 

--- a/packages/mimir/tests/skills.spec.ts
+++ b/packages/mimir/tests/skills.spec.ts
@@ -13,7 +13,7 @@ import { BUNDLED_SKILLS, registerResearchSkills } from '../src/skills.ts'
 
 /** Tool, command, and artifact names the plugin itself registers/ships. */
 const REAL_SURFACES = [
-  'arxiv_search', 'paper_fetch', 'wiki_note', 'figure_save', 'latex_compile',
+  'arxiv_search', 'paper_fetch', 'wiki_note', 'figure_save', 'latex_compile', 'meeting_deck',
   'research-idea', 'research-plan', 'research-review', 'paper-write', 'paper-compile',
   'IDEA_REPORT.md', 'EXPERIMENT_PLAN.md', 'EXPERIMENT_LOG.md', 'NARRATIVE_REPORT.md',
 ]


### PR DESCRIPTION
## What

- **逐图 slides**: Meetings pipeline reads `meetings/.paper-figures/<arxivId>/manifest.json` and appends up to 3 per-figure slides (image + label + caption) after each selected paper's intro slide.
- **`meeting_deck` agent tool**: the agent can generate the whole-project deck itself; result lands in the tab's 已生成的汇报 list.
- **`research-meeting-deck` skill rewritten** to directly drive the original [academic-Group-meeting-skills](https://github.com/mlxbc12138/academic-Group-meeting-skills) pipeline: clone the repo, extract figures from cached arXiv PDFs via `paper_figures_to_ppt.py` (bundled single-file pdftoppm shim for hosts without poppler), polish manifest captions, build against the skill's reference style, file the .pptx into `meetings/<project>/`.

## Tests

- 588 tests green in Mimir; 15/15 green after syncing into the dsh tree.
- End-to-end verified against a real arXiv PDF: extract → 21 candidate figures, build → 22-slide deck with figures, listed and downloadable in the Meetings tab.