### PR TITLE
feat(bundle): self-activating dsh.bundle + npm keywords + one-command…

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,13 @@ npm install dsh-mimir@latest
 
 ### 2. Start Mimir
 
-The repository includes a ready-to-use dsh patch. Clone it and start with the installed npm plugin; no source build is required:
+`dsh-mimir` is a self-activating bundle (it declares `dsh.bundle`), so the install command above already mounted it into the `web` profile — just start dsh:
 
 ```sh
-git clone https://github.com/1692775560/dsh-Mimir-Academic-research.git
-cd Mimir
-dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
+dsh web
 ```
 
-Then open <http://127.0.0.1:3080>. The wiki is stored at `~/.dsh/storages/research_wiki.json` by default. Research artifacts—including papers, generated figures, and experiments—are saved under `./.research` in the directory where dsh was started.
+Then open <http://127.0.0.1:3080>. To override the defaults (workspace directory, LaTeX engine, reviewer rounds), edit the profile's own `cordis.patch.yml`; the bundle layer applies first. Running from a source checkout instead still works: clone the repository and `dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"`. The wiki is stored at `~/.dsh/storages/research_wiki.json` by default. Research artifacts—including papers, generated figures, and experiments—are saved under `./.research` in the directory where dsh was started.
 
 ### 3. First session
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -130,15 +130,13 @@ npm install dsh-mimir@latest
 
 ### 2. 启动 Mimir
 
-仓库已经提供可直接使用的 dsh patch。克隆仓库后无需构建，即可用已安装的 npm 插件启动：
+`dsh-mimir` 是自激活 bundle（声明了 `dsh.bundle`），上一条安装命令已经把它挂载进 `web` profile——直接启动即可：
 
 ```sh
-git clone https://github.com/1692775560/dsh-Mimir-Academic-research.git
-cd Mimir
-dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"
+dsh web
 ```
 
-然后打开 <http://127.0.0.1:3080>。wiki 默认保存在 `~/.dsh/storages/research_wiki.json`；文献、生成图、论文和实验等科研工件保存在启动目录下的 `./.research`。
+然后打开 <http://127.0.0.1:3080>。想覆盖默认配置（工作目录、LaTeX 引擎、评审轮数）就编辑 profile 自己的 `cordis.patch.yml`（bundle 层先应用）。从源码运行也仍然支持：克隆仓库后 `dsh web --patch "$PWD/examples/mimir-agent/cordis.yml"`。wiki 默认保存在 `~/.dsh/storages/research_wiki.json`；文献、生成图、论文和实验等科研工件保存在启动目录下的 `./.research`。
 
 ### 3. 开始使用
 

--- a/packages/mimir/cordis.patch.yml
+++ b/packages/mimir/cordis.patch.yml
@@ -1,0 +1,10 @@
+# Self-activation layer for `dsh plugin --profile web add dsh-mimir`: the
+# CLI reads `dsh.bundle.patch` from package.json and mounts the research
+# suite with its defaults — workspace `./.research` (relative to the
+# directory dsh starts in), reviewer spawn ×3, latex auto, arXiv ×10,
+# subscriptions + hourly backups on. Override any knob in your profile's own
+# cordis.patch.yml (applied after this bundle layer).
+
+- insert:
+    - id: mimir
+      name: dsh-mimir

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -51,7 +51,8 @@
     "lib/typert.remote-client.js",
     "lib/typert.remote-client.d.ts",
     "lib/client.js",
-    "lib/client.js.map"
+    "lib/client.js.map",
+    "cordis.patch.yml"
   ],
   "scripts": {
     "bundle": "tsdown",
@@ -110,6 +111,19 @@
         "@deepseek-ai/dsh-client-ui-theme"
       ],
       "platform": "web"
+    },
+    "bundle": {
+      "patch": "./cordis.patch.yml"
     }
-  }
+  },
+  "keywords": [
+    "dsh-plugin",
+    "deepseek-harness",
+    "research",
+    "arxiv",
+    "latex",
+    "zotero",
+    "literature",
+    "experiment-tracking"
+  ]
 }


### PR DESCRIPTION
… quickstart

- package.json declares dsh.bundle.patch (./cordis.patch.yml), so `dsh plugin --profile web add dsh-mimir` mounts the suite with defaults — no manual --patch step; verified end to end in a throwaway profile (panel boots, all workbench tabs mount)
- ship cordis.patch.yml in the package files; npm keywords for discovery (dsh-plugin, deepseek-harness, research, arxiv, latex, zotero…)
- README quickstart drops the clone-and-patch step (kept as the run-from-source alternative)

## 改动内容

<!-- 简述做了什么、为什么。关联 Issue：Closes #xx -->

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿
- [ ] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（本仓库 `pnpm run build` 会处理）
- [ ] README.md / README.zh.md 保持逐节对齐（如涉及功能描述）
- [ ] ROADMAP.md 已更新（如涉及队列条目）

## 截图

<!-- UI 改动必填 -->
