### PR TITLE
fix(commands,panel): tolerant project args for /research-plan & /pape…

### DIFF
--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -12,7 +12,8 @@ test.beforeEach(async ({ page }) => {
 
 test('opens the workbench and renders all six views', async ({ page }, testInfo) => {
   const workbench = page.getByRole('dialog', { name: /Mimir/ })
-  const tabs = [/总览|Overview/, /^论文$|^Paper$/, /^文献$|^Library$/, /^实验$|^Experiments$/, /^图表$|^Figures$/, /^服务器$|^Servers$/]
+  // Tab names carry live count suffixes (e.g. "文献 48"), so match prefixes.
+  const tabs = [/总览|Overview/, /^论文|^Paper/, /^文献|^Library/, /^实验|^Experiments/, /^图表|^Figures/, /^服务器|^Servers/]
   for (const [index, label] of tabs.entries()) {
     await workbench.getByRole('tab', { name: label }).first().click()
     await expect(workbench).toBeVisible()
@@ -22,7 +23,7 @@ test('opens the workbench and renders all six views', async ({ page }, testInfo)
 
 test('literature search exposes an import outcome', async ({ page }) => {
   const workbench = page.getByRole('dialog', { name: /Mimir/ })
-  await workbench.getByRole('tab', { name: /^文献$|^Library$/ }).first().click()
+  await workbench.getByRole('tab', { name: /^文献|^Library/ }).first().click()
   await workbench.getByPlaceholder(/egocentric whole body/).fill('attention is all you need')
   await workbench.getByRole('button', { name: /^搜索$|^Search$/ }).click()
   await expect(workbench.getByText(/Attention Is All You Need/i).first()).toBeVisible({ timeout: 30_000 })

--- a/packages/mimir/README.md
+++ b/packages/mimir/README.md
@@ -39,9 +39,9 @@ The plugin also mounts the `research` Remote namespace (`ResearchService`) plus 
 ## Commands
 
 - `/research-idea <direction>` — registers a project, scaffolds `IDEA_REPORT.md`, and instructs the model to survey arXiv, check failed ideas first, and record the idea.
-- `/research-plan [project id]` — scaffolds `EXPERIMENT_PLAN.md` from the idea report; planned claims become pending wiki claims.
+- `/research-plan [project id | instructions]` — scaffolds `EXPERIMENT_PLAN.md` from the idea report; planned claims become pending wiki claims. An argument that is not an existing project id targets the most recent project and is handed to the model as plan direction.
 - `/research-review <scope> <paths...> [project id]` — one independent review round: a fresh reviewer subagent gets only absolute file paths (never the executor's summary) and returns a schema-validated PASS/WARN/FAIL verdict. WARN/FAIL is handed back to the agent as a revision follow-up.
-- `/paper-write [project id]` — scaffolds `paper/main.tex` + `references.bib` and instructs the model to draft and compile-fix until clean.
+- `/paper-write [project id | instructions]` — scaffolds `paper/main.tex` + `references.bib` and instructs the model to draft and compile-fix until clean. Non-id argument text is handed to the model as drafting direction.
 - `/paper-compile [dir]` — compiles once (default `<workspace>/paper`) and reports parsed diagnostics.
 
 ## Storage

--- a/packages/mimir/README.zh.md
+++ b/packages/mimir/README.zh.md
@@ -39,9 +39,9 @@ Mimir 是 DeepSeek Harness 的科研助手插件套件：arXiv 文献检索、�
 ## 命令
 
 - `/research-idea <方向>` —— 注册项目、脚手架 `IDEA_REPORT.md`，并指示模型先查失败想法、再调研 arXiv、记录想法。
-- `/research-plan [项目 id]` —— 从想法报告脚手架 `EXPERIMENT_PLAN.md`；计划中的论断会成为 pending 的 wiki claim。
+- `/research-plan [项目 id | 说明]` —— 从想法报告脚手架 `EXPERIMENT_PLAN.md`；计划中的论断会成为 pending 的 wiki claim。参数若不是已存在的项目 id，则作用于最近更新的项目，并作为计划方向一并交给模型。
 - `/research-review <范围> <路径...> [项目 id]` —— 一轮独立评审：全新的 reviewer subagent 只拿到绝对文件路径（永远拿不到执行者的总结），返回 schema 校验过的 PASS/WARN/FAIL 结论。WARN/FAIL 会作为修订后续交还给 agent。
-- `/paper-write [项目 id]` —— 脚手架 `paper/main.tex` + `references.bib`，并指示模型起草、编译修复直至干净。
+- `/paper-write [项目 id | 说明]` —— 脚手架 `paper/main.tex` + `references.bib`，并指示模型起草、编译修复直至干净。非 id 参数文本会作为起草方向一并交给模型。
 - `/paper-compile [目录]` —— 编译一次（默认 `<workspace>/paper`）并报告解析出的诊断。
 
 ## 存储

--- a/packages/mimir/src/commands/common.ts
+++ b/packages/mimir/src/commands/common.ts
@@ -67,6 +67,35 @@ export function resolveProject(domain: ResearchWikiDomain, id: string | undefine
   return latest
 }
 
+/** One command argument resolved into its target project plus leftover text. */
+export interface ProjectArgResolution {
+  /** The targeted project, or undefined when no project exists at all. */
+  readonly project: ProjectRecord | undefined
+  /** Free-form text that was not an existing project id; guidance for the model instruction. */
+  readonly guidance: string | undefined
+}
+
+/**
+ * Resolve a command's raw argument tolerantly: text exactly naming an
+ * existing project id selects that project; anything else (a natural-language
+ * request, a typo) targets the most recently updated project and rides along
+ * as guidance instead of failing the command outright.
+ * @param domain - Open research-wiki domain.
+ * @param raw - The invocation's raw input.
+ * @returns the target project and any non-id guidance text.
+ */
+export function resolveProjectArg(domain: ResearchWikiDomain, raw: string): ProjectArgResolution {
+  const input = raw.trim()
+  if (input.length > 0) {
+    const exact = domain.table('projects').get(input)
+    if (exact !== undefined) return { project: exact, guidance: undefined }
+  }
+  return {
+    project: resolveProject(domain, undefined),
+    guidance: input.length > 0 ? input : undefined,
+  }
+}
+
 /**
  * Create and register a new project at the `idea` stage.
  * @param domain - Open research-wiki domain.

--- a/packages/mimir/src/commands/paper.ts
+++ b/packages/mimir/src/commands/paper.ts
@@ -1,8 +1,9 @@
 /**
- * `/paper-write [projectId]` and `/paper-compile [dir]`: scaffold the paper
- * skeleton into `<workspace>/paper/`, hand the drafting instruction to the
- * model, and expose a direct compile-report command over the same engine the
- * `latex_compile` tool uses.
+ * `/paper-write [project id | instructions]` and `/paper-compile [dir]`:
+ * scaffold the paper skeleton into `<workspace>/paper/`, hand the drafting
+ * instruction to the model (non-id argument text rides along as drafting
+ * direction), and expose a direct compile-report command over the same
+ * engine the `latex_compile` tool uses.
  * @module dsh-mimir/src/commands/paper
  */
 
@@ -12,15 +13,16 @@ import type { Context } from '@deepseek-ai/cordis'
 import type { CommandResult } from '@deepseek-ai/dsh-commands'
 import { compileLatex, renderLatexResult } from '../tools/latex.ts'
 import { PAPER_MAIN_TEX, PAPER_REFERENCES_BIB } from '../templates.ts'
-import { ensureWorkspace, followupInstruction, resolveProject, writeIfAbsent } from './common.ts'
+import { ensureWorkspace, followupInstruction, resolveProjectArg, writeIfAbsent } from './common.ts'
 import type { ResearchCommandDeps } from './common.ts'
 
-const WRITE_USAGE = 'Usage: /paper-write [project id]'
+const WRITE_USAGE = 'Usage: /paper-write [project id | instructions]'
 
 /** Build the drafting instruction handed to the model. */
-function writeInstruction(deps: ResearchCommandDeps, paperDir: string, projectTitle: string): string {
+function writeInstruction(deps: ResearchCommandDeps, paperDir: string, projectTitle: string, guidance: string | undefined): string {
   return [
     `You are drafting the paper for research project "${projectTitle}".`,
+    ...guidance === undefined ? [] : [`The user adds this direction for the draft: ${guidance}`],
     `1. Read ${join(deps.workspaceDir, 'IDEA_REPORT.md')} and ${join(deps.workspaceDir, 'EXPERIMENT_PLAN.md')}, and list the wiki's claims (wiki_note action=list, table=claims) and papers (table=papers).`,
     `2. Fill ${join(paperDir, 'main.tex')}: replace every <placeholder> with real content grounded in those sources. Keep the article-class skeleton; do not introduce packages beyond what it already loads.`,
     `3. Put real references into ${join(paperDir, 'references.bib')} from the wiki's papers, and cite them from the text.`,
@@ -39,16 +41,13 @@ export function registerPaperCommands(ctx: Context, deps: ResearchCommandDeps): 
   ctx.commands.register({
     name: 'paper-write',
     description: 'scaffold and draft the LaTeX paper for a research project, compiling until clean',
-    input: { hint: '[project id]' },
+    input: { hint: '[project id | instructions]' },
     async handler(invocation): Promise<CommandResult> {
-      const id = invocation.rawInput.trim()
-      const project = resolveProject(deps.domain, id.length === 0 ? undefined : id)
+      const { project, guidance } = resolveProjectArg(deps.domain, invocation.rawInput)
       if (project === undefined) {
         return {
           kind: 'error',
-          text: id.length === 0
-            ? `No research project exists yet; run /research-idea first.\n${WRITE_USAGE}`
-            : `No research project with id '${id}'.\n${WRITE_USAGE}`,
+          text: `No research project exists yet; run /research-idea first.\n${WRITE_USAGE}`,
         }
       }
       await ensureWorkspace(deps)
@@ -62,10 +61,11 @@ export function registerPaperCommands(ctx: Context, deps: ResearchCommandDeps): 
         artifacts: [...new Set([...current.artifacts, 'paper/main.tex', 'paper/references.bib'])],
         updatedAt: new Date().toISOString(),
       }))
-      followupInstruction(invocation.agent, writeInstruction(deps, paperDir, project.title))
+      followupInstruction(invocation.agent, writeInstruction(deps, paperDir, project.title, guidance))
       return {
         kind: 'success',
-        text: `Paper drafting started for project ${project.id}. The skeleton lives in ${paperDir}; the agent will compile and fix it until clean.`,
+        text: `Paper drafting started for project ${project.id}. The skeleton lives in ${paperDir}; the agent will compile and fix it until clean.`
+          + (guidance === undefined ? '' : ` Direction: "${guidance}".`),
       }
     },
   })

--- a/packages/mimir/src/commands/plan.ts
+++ b/packages/mimir/src/commands/plan.ts
@@ -1,8 +1,9 @@
 /**
- * `/research-plan [projectId]`: scaffolds EXPERIMENT_PLAN.md from the recorded
- * idea and hands the model the planning instruction; every planned claim is
- * registered as a pending wiki claim so later experiments have something to
- * support or invalidate.
+ * `/research-plan [project id | instructions]`: scaffolds EXPERIMENT_PLAN.md
+ * from the recorded idea and hands the model the planning instruction
+ * (non-id argument text rides along as plan direction); every planned claim
+ * is registered as a pending wiki claim so later experiments have something
+ * to support or invalidate.
  * @module dsh-mimir/src/commands/plan
  */
 
@@ -10,15 +11,16 @@ import { join } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
 import type { CommandResult } from '@deepseek-ai/dsh-commands'
 import { EXPERIMENT_PLAN_MD } from '../templates.ts'
-import { ensureWorkspace, followupInstruction, resolveProject, writeIfAbsent } from './common.ts'
+import { ensureWorkspace, followupInstruction, resolveProjectArg, writeIfAbsent } from './common.ts'
 import type { ResearchCommandDeps } from './common.ts'
 
-const USAGE = 'Usage: /research-plan [project id]'
+const USAGE = 'Usage: /research-plan [project id | instructions]'
 
 /** Build the planning instruction handed to the model. */
-function planInstruction(deps: ResearchCommandDeps, projectTitle: string): string {
+function planInstruction(deps: ResearchCommandDeps, projectTitle: string, guidance: string | undefined): string {
   return [
     `You are writing the experiment plan for research project "${projectTitle}".`,
+    ...guidance === undefined ? [] : [`The user adds this direction for the plan: ${guidance}`],
     'Do these steps in order:',
     `1. Read ${join(deps.workspaceDir, 'IDEA_REPORT.md')}. If it is still an unfilled skeleton or missing, say so and stop.`,
     `2. Fill every section of the skeleton at ${join(deps.workspaceDir, 'EXPERIMENT_PLAN.md')}. Each experiment must name the claim(s) it supports or invalidates, and success criteria must be decided now, before any experiment runs.`,
@@ -37,16 +39,13 @@ export function registerPlanCommand(ctx: Context, deps: ResearchCommandDeps): vo
   ctx.commands.register({
     name: 'research-plan',
     description: 'turn the current idea report into an experiment plan with registered claims',
-    input: { hint: '[project id]' },
+    input: { hint: '[project id | instructions]' },
     async handler(invocation): Promise<CommandResult> {
-      const id = invocation.rawInput.trim()
-      const project = resolveProject(deps.domain, id.length === 0 ? undefined : id)
+      const { project, guidance } = resolveProjectArg(deps.domain, invocation.rawInput)
       if (project === undefined) {
         return {
           kind: 'error',
-          text: id.length === 0
-            ? `No research project exists yet; run /research-idea first.\n${USAGE}`
-            : `No research project with id '${id}'.\n${USAGE}`,
+          text: `No research project exists yet; run /research-idea first.\n${USAGE}`,
         }
       }
       await ensureWorkspace(deps)
@@ -59,10 +58,11 @@ export function registerPlanCommand(ctx: Context, deps: ResearchCommandDeps): vo
           : [...current.artifacts, 'EXPERIMENT_PLAN.md'],
         updatedAt: new Date().toISOString(),
       }))
-      followupInstruction(invocation.agent, planInstruction(deps, project.title))
+      followupInstruction(invocation.agent, planInstruction(deps, project.title, guidance))
       return {
         kind: 'success',
-        text: `Planning started for project ${project.id} ("${project.title}"). The plan lands in ${join(deps.workspaceDir, 'EXPERIMENT_PLAN.md')}.`,
+        text: `Planning started for project ${project.id} ("${project.title}"). The plan lands in ${join(deps.workspaceDir, 'EXPERIMENT_PLAN.md')}.`
+          + (guidance === undefined ? '' : ` Direction: "${guidance}".`),
       }
     },
   })

--- a/packages/mimir/tests/commands.spec.ts
+++ b/packages/mimir/tests/commands.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Behavior tests for the research slash commands' argument resolution: a
+ * natural-language argument (the way users actually type, e.g.
+ * `/research-plan 请你帮我做实验计划`) must not fail the command — it targets
+ * the most recently updated project and rides into the model instruction as
+ * guidance. Real memory-backed domain, real temp workspace, no mocks.
+ */
+
+import { mkdtemp, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import SessionStore, { SessionId } from '@deepseek-ai/dsh-session'
+import CommandRuntime from '@deepseek-ai/dsh-commands'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import type { UserMessage } from '@deepseek-ai/dsh-llm'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import type { ResearchWikiDomain } from '../src/store.ts'
+import { createProject } from '../src/commands/common.ts'
+import type { ResearchCommandDeps } from '../src/commands/common.ts'
+import { registerPlanCommand } from '../src/commands/plan.ts'
+import { registerPaperCommands } from '../src/commands/paper.ts'
+
+/** Boot the command registry over a memory-backed domain and a fresh temp workspace. */
+async function harness() {
+  const ctx = new Context()
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(CommandRuntime)
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  const domain = await facility.open(researchWikiDomainSpec)
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-commands-'))
+  const deps: ResearchCommandDeps = {
+    workspaceDir,
+    domain,
+    reviewer: { provider: 'spawn', maxRounds: 3 },
+    latex: { engine: 'auto', timeoutMs: 1000 },
+  }
+  return { ctx, domain, workspaceDir, deps }
+}
+
+/** A command-receiving agent on a real session, capturing follow-up instructions. */
+function fakeAgent(ctx: Context, name: string): { agent: Agent; followups: UserMessage[] } {
+  const session = ctx.sessions.create(SessionId(name))
+  const followups: UserMessage[] = []
+  const agent = {
+    id: session.id,
+    session,
+    followup: (message: UserMessage): void => { followups.push(message) },
+  } as unknown as Agent
+  return { agent, followups }
+}
+
+/** Extract the text of one captured follow-up instruction. */
+function followupText(message: UserMessage): string {
+  const block = message.content[0]
+  if (block === undefined || block.type !== 'text') throw new Error('expected a text follow-up')
+  return block.text
+}
+
+/** Register a fresh project with one of two controlled update orderings. */
+async function seedProject(domain: ResearchWikiDomain, title: string, updatedAt: string) {
+  const project = await createProject(domain, title, ['IDEA_REPORT.md'])
+  await domain.table('projects').update(project.id, current => ({ ...current, updatedAt }))
+  return project
+}
+
+describe('/research-plan argument resolution', () => {
+  it('targets the latest project and threads natural-language input into the instruction', async () => {
+    const { ctx, domain, deps } = await harness()
+    registerPlanCommand(ctx, deps)
+    const older = await seedProject(domain, 'older', '2026-08-20T00:00:00.000Z')
+    const latest = await seedProject(domain, 'latest', '2026-08-21T00:00:00.000Z')
+    const { agent, followups } = fakeAgent(ctx, 'plan-guidance')
+
+    const execution = await ctx.commands.execute(agent, '/research-plan 请你帮我做实验计划', [], new AbortController().signal)
+
+    expect(execution?.result.kind).toBe('success')
+    expect(execution?.result.text).toContain(latest.id)
+    expect(execution?.result.text).not.toContain(older.id)
+    expect(execution?.result.text).toContain('请你帮我做实验计划')
+    expect(followups).toHaveLength(1)
+    expect(followupText(followups[0]!)).toContain('The user adds this direction for the plan: 请你帮我做实验计划')
+    expect((await domain.table('projects').get(latest.id))?.stage).toBe('plan')
+  })
+
+  it('selects the exact project id with no guidance', async () => {
+    const { ctx, domain, deps } = await harness()
+    registerPlanCommand(ctx, deps)
+    const older = await seedProject(domain, 'older', '2026-08-20T00:00:00.000Z')
+    await seedProject(domain, 'latest', '2026-08-21T00:00:00.000Z')
+    const { agent, followups } = fakeAgent(ctx, 'plan-exact')
+
+    const execution = await ctx.commands.execute(agent, `/research-plan ${older.id}`, [], new AbortController().signal)
+
+    expect(execution?.result.kind).toBe('success')
+    expect(execution?.result.text).toContain(older.id)
+    expect(execution?.result.text).not.toContain('Direction:')
+    expect(followupText(followups[0]!)).not.toContain('The user adds this direction')
+  })
+
+  it('still fails loud when no project exists at all', async () => {
+    const { ctx, deps } = await harness()
+    registerPlanCommand(ctx, deps)
+    const { agent, followups } = fakeAgent(ctx, 'plan-empty')
+
+    const execution = await ctx.commands.execute(agent, '/research-plan anything', [], new AbortController().signal)
+
+    expect(execution?.result.kind).toBe('error')
+    expect(execution?.result.text).toContain('/research-idea')
+    expect(followups).toHaveLength(0)
+  })
+})
+
+describe('/paper-write argument resolution', () => {
+  it('targets the latest project, scaffolds the skeleton, and threads guidance', async () => {
+    const { ctx, domain, workspaceDir, deps } = await harness()
+    registerPaperCommands(ctx, deps)
+    const project = await seedProject(domain, 'only project', '2026-08-21T00:00:00.000Z')
+    const { agent, followups } = fakeAgent(ctx, 'paper-guidance')
+
+    const execution = await ctx.commands.execute(agent, '/paper-write 重点写实验部分', [], new AbortController().signal)
+
+    expect(execution?.result.kind).toBe('success')
+    expect(execution?.result.text).toContain(project.id)
+    expect(followupText(followups[0]!)).toContain('The user adds this direction for the draft: 重点写实验部分')
+    await stat(join(workspaceDir, 'paper', 'main.tex'))
+    expect((await domain.table('projects').get(project.id))?.stage).toBe('writing')
+  })
+})

--- a/packages/ui-mimir/src/client/PapersView.tsx
+++ b/packages/ui-mimir/src/client/PapersView.tsx
@@ -21,6 +21,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ArxivEntry, PaperRecord, ResearchProjectView, WebSearchEntry } from 'dsh-mimir/types'
 import type {
   ResearchArxivSearchView, ResearchFailureView, ResearchImportCounts, ResearchPapersView, ResearchWebSearchView,
@@ -56,7 +57,10 @@ const ADD_TO_BIB_RESET_MS = 2000
  * reader on the `/research/paper-pdf/<id>` route next to the reading-notes
  * side panel, plus a fullscreen button lifting the same reader into a
  * viewport-sized overlay (Esc or the header button exits). A successful fetch
- * bumps the cache-bust version and opens the reader.
+ * bumps the cache-bust version and opens the reader. The overlay is portaled
+ * to `document.body`: rendered inside the card, the card's `backdrop-filter`
+ * (and hover `transform`) would become its containing block and trap the
+ * `position: fixed` overlay inside the card's box.
  */
 function PaperPdfSection({ paper, fetchPaperPdf, updatePaper, onError, t }: {
   readonly paper: PaperRecord
@@ -129,7 +133,7 @@ function PaperPdfSection({ paper, fetchPaperPdf, updatePaper, onError, t }: {
           </button>
         )}
       </div>
-      {paper.pdfPath !== undefined && fullscreen && (
+      {paper.pdfPath !== undefined && fullscreen && createPortal(
         <div
           className={css.paperPdfOverlay}
           role="dialog"
@@ -163,7 +167,8 @@ function PaperPdfSection({ paper, fetchPaperPdf, updatePaper, onError, t }: {
             />
             <PaperNotesPanel paper={paper} updatePaper={updatePaper} onError={onError} t={t} />
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )


### PR DESCRIPTION
…r-write; portal the PDF fullscreen overlay

- commands: natural-language args fall back to the most-recent project and pass the remaining text to the model as guidance (resolveProjectArg), instead of hard-failing on a non-id argument
- panel: render the literature PDF fullscreen overlay via createPortal to document.body so the card's backdrop-filter containing block no longer traps it at card size
- e2e: fix tab selector drift (accessible names now carry count suffixes)

## 改动内容

<!-- 简述做了什么、为什么。关联 Issue：Closes #xx -->

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿
- [ ] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（本仓库 `pnpm run build` 会处理）
- [ ] README.md / README.zh.md 保持逐节对齐（如涉及功能描述）
- [ ] ROADMAP.md 已更新（如涉及队列条目）

## 截图

<!-- UI 改动必填 -->
