### PR TITLE
fix(mimir): 取消时终止 web_search 子进程，避免僵尸进程泄漏

### DIFF
--- a/packages/mimir/src/tools/web-search.ts
+++ b/packages/mimir/src/tools/web-search.ts
@@ -21,6 +21,7 @@ export type WebSearchRunner = (
   command: string,
   args: readonly string[],
   timeoutMs: number,
+  signal?: AbortSignal,
 ) => Promise<string>
 
 /** Deployment knobs for the web search tool. */
@@ -56,14 +57,18 @@ interface RawSxngRow {
 }
 
 /** Real runner: resolve stdout or reject with a readable message. */
-const runOnPath: WebSearchRunner = (command, args, timeoutMs) => new Promise((resolve, reject) => {
+const runOnPath: WebSearchRunner = (command, args, timeoutMs, signal) => new Promise((resolve, reject) => {
   execFile(
     command,
     [...args],
-    { timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024, encoding: 'utf8' },
+    { timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024, encoding: 'utf8', ...(signal === undefined ? {} : { signal }) },
     (error: ExecFileException | null, stdout: string) => {
       if (error !== null && error.code === 'ENOENT') {
         reject(new Error(`Web search command '${command}' was not found on PATH. ${INSTALL_GUIDANCE}`, { cause: error }))
+        return
+      }
+      if (error !== null && signal !== undefined && signal.aborted) {
+        reject(new DOMException('The operation was aborted.', 'AbortError'))
         return
       }
       // The CLI reports its own failures in the JSON body with exit code 1;
@@ -98,6 +103,7 @@ interface WebSearchModifiers {
 export async function fetchWebSearch(
   query: string,
   options: WebSearchOptions & WebSearchModifiers,
+  signal?: AbortSignal,
 ): Promise<WebSearchEntry[]> {
   const args = ['-f', 'json']
   const maxResults = options.maxResults
@@ -109,7 +115,7 @@ export async function fetchWebSearch(
   // (commander would otherwise swallow it as an unknown flag).
   args.push('--', query)
   const run = options.run ?? runOnPath
-  const stdout = await run(options.command, args, options.timeoutMs)
+  const stdout = await run(options.command, args, options.timeoutMs, signal)
   let parsed: unknown
   try {
     parsed = JSON.parse(stdout)
@@ -202,7 +208,7 @@ export function createWebSearchTool(options: WebSearchOptions): ToolDefinition {
       },
       render: (_args, value) => [{ type: 'text', text: renderWebEntries(value.results) }],
     },
-    async execute(args: WebSearchArgs, _exec) {
+    async execute(args: WebSearchArgs, exec) {
       const query = args.query.trim()
       if (query.length === 0) throw new TypeError('query must be a non-empty string')
       if (args.limit !== undefined && (!Number.isSafeInteger(args.limit) || args.limit < 1)) {
@@ -217,7 +223,7 @@ export function createWebSearchTool(options: WebSearchOptions): ToolDefinition {
           lang: args.lang,
           timeRange: args.time_range,
           ...(options.run === undefined ? {} : { run: options.run }),
-        }),
+        }, exec.signal),
       }
     },
   })

--- a/packages/mimir/tests/web-search.spec.ts
+++ b/packages/mimir/tests/web-search.spec.ts
@@ -8,10 +8,10 @@ import { describe, expect, it } from 'vitest'
 import { createWebSearchTool, fetchWebSearch } from '../src/tools/web-search.ts'
 
 /** A runner capturing its argv and answering with one canned payload. */
-function runCapturing(stdout: string): { run: (command: string, args: readonly string[], timeoutMs: number) => Promise<string>; argv: () => readonly string[] } {
+function runCapturing(stdout: string): { run: (command: string, args: readonly string[], timeoutMs: number, _signal?: AbortSignal) => Promise<string>; argv: () => readonly string[] } {
   const seen: string[][] = []
   return {
-    run: (_command, args, _timeoutMs) => { seen.push([...args]); return Promise.resolve(stdout) },
+    run: (_command, args, _timeoutMs, _signal) => { seen.push([...args]); return Promise.resolve(stdout) },
     argv: () => seen[0] ?? [],
   }
 }
@@ -102,6 +102,16 @@ describe('fetchWebSearch', () => {
     })).rejects.toThrow(/sxng output was not valid JSON/)
   })
 
+  it('forwards the abort signal to the runner', async () => {
+    let seenSignal: AbortSignal | undefined
+    const controller = new AbortController()
+    await fetchWebSearch('q', {
+      command: 'sxng', timeoutMs: 1000, maxResults: 10,
+      run: (_command, _args, _timeoutMs, signal) => { seenSignal = signal; return Promise.resolve(SXNG_OK) },
+    }, controller.signal)
+    expect(seenSignal).toBe(controller.signal)
+  })
+
   it('rejects an unknown envelope shape', async () => {
     await expect(fetchWebSearch('q', {
       command: 'sxng', timeoutMs: 1000, maxResults: 10, run: () => Promise.resolve('{}'),
@@ -112,7 +122,7 @@ describe('fetchWebSearch', () => {
 describe('createWebSearchTool', () => {
   it('executes through the injected runner and renders entries as text', async () => {
     const tool = createWebSearchTool({ command: 'sxng', timeoutMs: 1000, maxResults: 10, run: runCapturing(SXNG_OK).run })
-    const value = await tool.execute({ query: 'attention', limit: 2 }, {} as never) as Record<string, unknown>
+    const value = await tool.execute({ query: 'attention', limit: 2 }, { signal: new AbortController().signal } as never) as Record<string, unknown>
     expect(value).toMatchObject({ results: [{ engine: 'arxiv' }, { engine: 'brave' }] })
     const rendered = tool.output?.render?.({}, value)
     expect(String(rendered?.[0]?.text)).toContain('Attention Is All You Need')
@@ -120,6 +130,6 @@ describe('createWebSearchTool', () => {
 
   it('rejects a non-positive limit', async () => {
     const tool = createWebSearchTool({ command: 'sxng', timeoutMs: 1000, maxResults: 10, run: runCapturing(SXNG_OK).run })
-    await expect(tool.execute({ query: 'q', limit: 0 }, {} as never)).rejects.toThrow('limit must be a positive integer')
+    await expect(tool.execute({ query: 'q', limit: 0 }, { signal: new AbortController().signal } as never)).rejects.toThrow('limit must be a positive integer')
   })
 })


### PR DESCRIPTION
## 背景

`web_search` 是唯一忽略 `exec.signal` 的工具：取消后 `sxng` 子进程仍会跑完整个搜索，每次取消都会泄漏一个后台进程。

## 修复

将 `AbortSignal` 透传给 `WebSearchRunner` 和 `runOnPath`，利用 `execFile` 原生的 `signal` 选项终止子进程，与 `latex.ts`、`arxiv.ts` 保持一致。

## 验证

- 新增回归测试，断言 signal 被正确转发给 runner
- `web-search.spec.ts` 9 个测试全部通过
- `tsc --noEmit` 类型检查无错误