### PR TITLE
fix(mimir): serialize arXiv subscription checks

### DIFF
--- a/packages/mimir/src/arxiv-subscriptions.ts
+++ b/packages/mimir/src/arxiv-subscriptions.ts
@@ -14,7 +14,7 @@
 
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { writeFileAtomic } from '@deepseek-ai/dsh-atomic-write'
+import { writeFileAtomic, withFileLock } from '@deepseek-ai/dsh-atomic-write'
 import { isNotFound } from './paper-source.ts'
 import { fetchArxivSearch } from './tools/arxiv.ts'
 import type { ArxivEntry } from './tools/arxiv.ts'
@@ -198,9 +198,28 @@ export interface ArxivSubscriptionCheckOptions {
  * @returns one outcome per selected subscription, in list order; undefined
  * when `id` selected an unknown subscription.
  */
+const activeChecks = new Map<string, Promise<readonly ArxivSubscriptionCheckOutcome[] | undefined>>()
+
+/** Serialize in-process checks for one workspace while the file lock covers other processes. */
 export async function runArxivSubscriptionCheck(
   workspaceDir: string,
   options: ArxivSubscriptionCheckOptions = {},
+): Promise<readonly ArxivSubscriptionCheckOutcome[] | undefined> {
+  const existing = activeChecks.get(workspaceDir)
+  if (existing !== undefined) return existing
+  const run = runArxivSubscriptionCheckUnlocked(workspaceDir, options)
+  activeChecks.set(workspaceDir, run)
+  try {
+    return await run
+  } finally {
+    if (activeChecks.get(workspaceDir) === run) activeChecks.delete(workspaceDir)
+  }
+}
+
+/** Execute one check after the workspace-level in-process gate is acquired. */
+async function runArxivSubscriptionCheckUnlocked(
+  workspaceDir: string,
+  options: ArxivSubscriptionCheckOptions,
 ): Promise<readonly ArxivSubscriptionCheckOutcome[] | undefined> {
   const fetchSearch = options.fetchSearch ?? fetchArxivSearch
   const sleep = options.sleep ?? (async (ms: number): Promise<void> => {
@@ -235,9 +254,34 @@ export async function runArxivSubscriptionCheck(
     }
   }
   if (outcomes.some(outcome => outcome.error === null)) {
-    await saveArxivSubscriptions(workspaceDir, subscriptions.map(record => byId.get(record.id) ?? record))
+    await withFileLock(join(workspaceDir, ARXIV_SUBSCRIPTIONS_FILE), async () => {
+      const updates = new Map(outcomes
+        .filter((outcome): outcome is ArxivSubscriptionCheckOutcome & { readonly error: null } => outcome.error === null)
+        .map(outcome => [outcome.record.id, outcome.record]))
+      const latest = await loadArxivSubscriptions(workspaceDir)
+      await saveArxivSubscriptions(workspaceDir, latest.map(record => {
+        const updated = updates.get(record.id)
+        return updated === undefined ? record : mergeSubscriptionRecord(record, updated)
+      }))
+    })
   }
   return Object.freeze(outcomes)
+}
+
+/** Merge two concurrent checks without discarding entries discovered by either. */
+function mergeSubscriptionRecord(current: ArxivSubscriptionRecord, updated: ArxivSubscriptionRecord): ArxivSubscriptionRecord {
+  const seenIds = [...new Set([...updated.seenIds, ...current.seenIds])].slice(0, ARXIV_SUBSCRIPTION_SEEN_LIMIT)
+  const newEntryIds = [...new Set([...updated.newEntryIds, ...current.newEntryIds])].slice(0, ARXIV_SUBSCRIPTION_NEW_LIMIT)
+  const newEntries = [...new Map([...updated.newEntries, ...current.newEntries].map(entry => [entry.id, entry])).values()]
+    .filter(entry => newEntryIds.includes(entry.id))
+    .slice(0, ARXIV_SUBSCRIPTION_NEW_LIMIT)
+  return {
+    ...current,
+    ...updated,
+    seenIds: Object.freeze(seenIds),
+    newEntryIds: Object.freeze(newEntryIds),
+    newEntries: Object.freeze(newEntries),
+  }
 }
 
 /** Options for {@link startArxivSubscriptionLoop}. */

--- a/packages/mimir/tests/arxiv-subscriptions.spec.ts
+++ b/packages/mimir/tests/arxiv-subscriptions.spec.ts
@@ -59,6 +59,13 @@ function record(id: string, query: string, seenIds: readonly string[] = ['2608.0
   }
 }
 
+/** A manually settled promise for coordinating concurrent check calls. */
+function deferred<T>(): { readonly promise: Promise<T>; readonly resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => { resolve = res })
+  return { promise, resolve }
+}
+
 describe('arXiv subscription storage', () => {
   it('round-trips the list through the JSON file', async () => {
     const dir = await workspace()
@@ -202,6 +209,26 @@ describe('runArxivSubscriptionCheck', () => {
     // The failed record is untouched; the clean one settled.
     expect(persisted[0]?.lastCheckedAt).toBe('2026-08-21T00:00:00.000Z')
     expect(persisted[1]?.seenIds).toEqual(['y', 'x'])
+  })
+
+  it('coalesces concurrent checks without losing the settled update', async () => {
+    const dir = await workspace()
+    await saveArxivSubscriptions(dir, [record('s1', 'mesh', ['base'])])
+    const first = deferred<ArxivEntry[]>()
+    let calls = 0
+    const fetchSearch = async (): Promise<ArxivEntry[]> => {
+      calls += 1
+      return calls === 1 ? first.promise : [entry('right'), entry('base')]
+    }
+    const left = runArxivSubscriptionCheck(dir, { gapMs: 0, fetchSearch })
+    await Promise.resolve()
+    const right = runArxivSubscriptionCheck(dir, { gapMs: 0, fetchSearch })
+    first.resolve([entry('left'), entry('base')])
+    await Promise.all([left, right])
+    expect(calls).toBe(1)
+    const [persisted] = await loadArxivSubscriptions(dir)
+    expect(persisted?.seenIds).toEqual(expect.arrayContaining(['left', 'base']))
+    expect(persisted?.newEntryIds).toEqual(expect.arrayContaining(['left']))
   })
 
   it('returns undefined for an unknown id and skips the fetch entirely', async () => {


### PR DESCRIPTION
## 改动内容

修复 arXiv subscription 检查的并发覆盖问题。

手动触发检查与定时检查可能同时读取旧订阅文件，后完成的检查会覆盖前一次检查写入的 seenIds/new entries。此次改动：

- 为同一 workspace 的无 ID 检查增加 single-flight，合并并发调用。
- 持久化时使用 `withFileLock`，并在锁内重新读取最新订阅文件。
- 合并并发检查产生的 `seenIds`、`newEntryIds` 和 `newEntries`，避免丢失更新。
- 增加并发回归测试。

关联 Issue：无

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿（交由 CI 验证）
- [x] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方（不涉及 UI）
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（不涉及 `@Remote`）
- [x] README.md / README.zh.md 保持逐节对齐（未涉及功能描述）
- [x] ROADMAP.md 已更新（未涉及队列条目）

## 验证

- `pnpm exec vitest run packages/mimir/tests/arxiv-subscriptions.spec.ts`：13 tests passed
- `pnpm run typecheck`：通过
- `pnpm --filter dsh-mimir bundle`：通过

## 截图

不涉及 UI 改动，未附截图。
