### PR TITLE
fix(mimir): prevent overlapping wiki backups

### DIFF
--- a/packages/mimir/src/backup.ts
+++ b/packages/mimir/src/backup.ts
@@ -95,6 +95,8 @@ export interface WikiBackupLoopOptions {
   readonly firstDelayMs?: number
   /** Failure sink: called with each pass's error; the loop keeps going. */
   readonly onError: (error: unknown) => void
+  /** Backup implementation (test injection; defaults to {@link runWikiBackup}). */
+  readonly runBackup?: typeof runWikiBackup
 }
 
 /**
@@ -105,8 +107,14 @@ export interface WikiBackupLoopOptions {
  * @returns dispose: clears the pending timers (an in-flight pass finishes).
  */
 export function startWikiBackupLoop(options: WikiBackupLoopOptions): () => void {
+  const runBackup = options.runBackup ?? runWikiBackup
+  let inFlight = false
   const run = (): void => {
-    runWikiBackup(options.domain, options.dir, options.keep).catch(options.onError)
+    if (inFlight) return
+    inFlight = true
+    runBackup(options.domain, options.dir, options.keep)
+      .catch(options.onError)
+      .finally(() => { inFlight = false })
   }
   let interval: NodeJS.Timeout | undefined
   const first = setTimeout(() => {

--- a/packages/mimir/tests/backup.spec.ts
+++ b/packages/mimir/tests/backup.spec.ts
@@ -155,6 +155,24 @@ describe('startWikiBackupLoop', () => {
     }
   })
 
+  it('does not overlap an in-flight pass', async () => {
+    const calls: Array<() => void> = []
+    const runBackup = vi.fn(() => new Promise<string>(resolve => { calls.push(() => resolve('done')) }))
+    const dir = await mkdtemp(join(tmpdir(), 'mimir-backup-loop-'))
+    const stop = startWikiBackupLoop({
+      domain: {} as never, dir, intervalMs: 5, keep: 24, firstDelayMs: 1, onError: () => {}, runBackup,
+    })
+    try {
+      await vi.waitFor(() => { expect(runBackup).toHaveBeenCalledTimes(1) }, { timeout: 5000, interval: 5 })
+      await new Promise(resolveTimer => setTimeout(resolveTimer, 30))
+      expect(runBackup).toHaveBeenCalledTimes(1)
+      calls[0]?.()
+      await vi.waitFor(() => { expect(runBackup).toHaveBeenCalledTimes(2) }, { timeout: 5000, interval: 5 })
+    } finally {
+      stop()
+      calls[1]?.()
+    }
+  })
   it('survives a failing pass and retries next cycle', async () => {
     const { domain, workspaceDir } = await openDomain()
     // A file where the directory should be: mkdir/readdir fail until removed.


### PR DESCRIPTION
## 改动内容

修复定时 wiki 备份在上一次 pass 尚未完成时再次触发的问题。

备份周期短于文件 I/O 或 snapshot 构建耗时时，旧实现会并发执行多个备份 pass，导致同秒备份互相覆盖，并发 prune 也会放大失败路径。此次改动：

- 为 backup loop 增加 in-flight guard，尚未结束的 pass 期间跳过新的 timer tick。
- 增加 `runBackup` 测试注入点，覆盖慢速备份期间不重入、完成后恢复下一轮的行为。
- 保留原有失败上报及下一周期重试语义。

关联 Issue：无

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿（交由 CI 验证）
- [x] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方（不涉及 UI）
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（不涉及 `@Remote`）
- [x] README.md / README.zh.md 保持逐节对齐（未涉及功能描述）
- [x] ROADMAP.md 已更新（未涉及队列条目）

## 验证

- `pnpm exec vitest run packages/mimir/tests/backup.spec.ts`：16 tests passed
- `pnpm run typecheck`：通过

## 截图

不涉及 UI 改动，未附截图。