### PR TITLE
fix(mimir): harden upload route boundaries

### DIFF
--- a/packages/mimir/src/http-write-boundary.ts
+++ b/packages/mimir/src/http-write-boundary.ts
@@ -1,0 +1,25 @@
+/**
+ * Security boundaries shared by browser-originated write routes.
+ * @module dsh-mimir/src/http-write-boundary
+ */
+
+import type { IncomingHttpHeaders } from 'node:http'
+import { resolvePaperDir } from './paper-source.ts'
+
+/** Whether a browser write request originated from the same web-server origin. */
+export function isSameOriginWrite(headers: IncomingHttpHeaders): boolean {
+  const origin = headers.origin
+  const host = headers.host
+  if (typeof origin !== 'string' || typeof host !== 'string') return false
+  try {
+    const parsed = new URL(origin)
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.host === host
+  } catch {
+    return false
+  }
+}
+
+/** Resolve a write destination only from the target project's configured paper directory. */
+export function projectPaperDir(workspaceDir: string, paperDir: string | undefined): string | undefined {
+  return resolvePaperDir(workspaceDir, undefined, paperDir)
+}

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -29,6 +29,7 @@ import { registerReviewCommand } from './commands/review.ts'
 import { registerPaperCommands } from './commands/paper.ts'
 import type { ResearchCommandDeps } from './commands/common.ts'
 import { resolvePaperDir } from './paper-source.ts'
+import { isSameOriginWrite, projectPaperDir } from './http-write-boundary.ts'
 import type { ResearchServiceConfig } from './service.ts'
 import { isFigureFile } from './artifacts.ts'
 import { TEMPLATE_DIR_NAME } from './services/venue.ts'
@@ -866,9 +867,10 @@ const FIGURE_UPLOAD_LIMIT_BYTES = 50 * 1024 * 1024
 /**
  * Receive one uploaded figure for a wiki project's paper directory. The query
  * carries `?project=` (an unknown id is a 404), `?name=` (reduced to its
- * basename, so no traversal is expressible; a non-figure extension is a 400),
- * and an optional `?dir=` override resolved like the PDF route. The raw body
- * lands at `figures/<name>` under the paper directory (created on demand,
+ * basename, so no traversal is expressible; a non-figure extension is a 400).
+ * The route requires an exact same-origin `Origin` header and always resolves
+ * the destination from the project record's `paperDir`; callers cannot select
+ * a different workspace directory. The raw body lands at `figures/<name>` under the paper directory (created on demand,
  * same-name overwrite); a body over {@link FIGURE_UPLOAD_LIMIT_BYTES} is a
  * 413, any method but POST a 405.
  * @param deps - Shared command dependencies (workspace root and open domain).
@@ -881,6 +883,10 @@ function createFigureUploadHandler(
   return async (req, res) => {
     if (req.method !== 'POST') {
       res.writeHead(405).end()
+      return
+    }
+    if (!isSameOriginWrite(req.headers)) {
+      res.writeHead(403).end('cross-origin uploads are not allowed')
       return
     }
     const url = new URL(req.url ?? '/', 'http://research.local')
@@ -899,7 +905,7 @@ function createFigureUploadHandler(
       res.writeHead(400).end('name must name a figure file (.png/.jpg/.jpeg/.svg/.pdf)')
       return
     }
-    const dir = resolvePaperDir(root, url.searchParams.get('dir') ?? undefined, record.paperDir)
+    const dir = projectPaperDir(root, record.paperDir)
     if (dir === undefined) {
       res.writeHead(400).end('dir must be a relative path inside the research workspace')
       return
@@ -933,8 +939,10 @@ const TEMPLATE_UPLOAD_EXTENSIONS = new Set(['.cls', '.sty', '.tex', '.bst', '.bb
  * Receive one uploaded venue-kit file for a wiki project's paper directory.
  * The query carries `?project=` (an unknown id is a 404) and `?name=`
  * (reduced to its basename; an extension outside
- * {@link TEMPLATE_UPLOAD_EXTENSIONS} is a 400), plus an optional `?dir=`
- * override resolved like the figure route. The raw body lands at
+ * {@link TEMPLATE_UPLOAD_EXTENSIONS} is a 400). The route requires an exact
+ * same-origin `Origin` header and always resolves the destination from the
+ * project record's `paperDir`; callers cannot select a different workspace
+ * directory. The raw body lands at
  * `template/<name>` under the paper directory (created on demand, same-name
  * overwrite); a body over {@link TEMPLATE_UPLOAD_LIMIT_BYTES} is a 413, any
  * method but POST a 405.
@@ -948,6 +956,10 @@ function createTemplateUploadHandler(
   return async (req, res) => {
     if (req.method !== 'POST') {
       res.writeHead(405).end()
+      return
+    }
+    if (!isSameOriginWrite(req.headers)) {
+      res.writeHead(403).end('cross-origin uploads are not allowed')
       return
     }
     const url = new URL(req.url ?? '/', 'http://research.local')
@@ -966,7 +978,7 @@ function createTemplateUploadHandler(
       res.writeHead(400).end('name must name a LaTeX kit file (.cls/.sty/.tex/.bst/...)')
       return
     }
-    const dir = resolvePaperDir(root, url.searchParams.get('dir') ?? undefined, record.paperDir)
+    const dir = projectPaperDir(root, record.paperDir)
     if (dir === undefined) {
       res.writeHead(400).end('dir must be a relative path inside the research workspace')
       return

--- a/packages/mimir/tests/http-write-boundary.spec.ts
+++ b/packages/mimir/tests/http-write-boundary.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isSameOriginWrite, projectPaperDir } from '../src/http-write-boundary.ts'
+
+describe('isSameOriginWrite', () => {
+  it('accepts an exact HTTP or HTTPS origin-host match', () => {
+    expect(isSameOriginWrite({ origin: 'http://127.0.0.1:3080', host: '127.0.0.1:3080' })).toBe(true)
+    expect(isSameOriginWrite({ origin: 'https://research.example.test', host: 'research.example.test' })).toBe(true)
+  })
+
+  it('rejects absent, malformed, cross-origin, and non-web origins', () => {
+    expect(isSameOriginWrite({ host: '127.0.0.1:3080' })).toBe(false)
+    expect(isSameOriginWrite({ origin: 'not a URL', host: '127.0.0.1:3080' })).toBe(false)
+    expect(isSameOriginWrite({ origin: 'http://attacker.test', host: '127.0.0.1:3080' })).toBe(false)
+    expect(isSameOriginWrite({ origin: 'file://', host: '127.0.0.1:3080' })).toBe(false)
+  })
+})
+
+describe('projectPaperDir', () => {
+  it('uses the project directory and never accepts a request-selected override', () => {
+    expect(projectPaperDir('/research', 'projects/p1')).toBe('/research/projects/p1')
+    expect(projectPaperDir('/research', undefined)).toBe('/research/paper')
+  })
+
+  it('rejects invalid project paper directories', () => {
+    expect(projectPaperDir('/research', '../other-project')).toBeUndefined()
+    expect(projectPaperDir('/research', '/tmp/paper')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 改动内容

收紧 figure/template upload route 的写入边界，修复审查项 HTTP-01 与 HTTP-04。

- 仅接受严格同源的 `Origin` 与 `Host` 匹配请求；缺失、畸形或跨源 Origin 返回 `403`。
- 不再接受 `?dir=` 覆盖，上传目录固定由目标 project 的 `paperDir`（或默认 `paper`）决定，避免跨项目写入 workspace 内其他目录。
- 提取共享安全边界到 `packages/mimir/src/http-write-boundary.ts`。
- 增加同源校验、目录绑定和非法路径的回归测试。

当前 DSH `dsh-host-webserver` 路由 API 仅提供原始 `IncomingMessage`/`ServerResponse`，没有可复用的 session/auth middleware；本 PR 未伪造 session 认证机制，而是落实当前 API 可可靠表达的同源写保护和项目目录授权。

关联 Issue：无

## 检查清单

- [ ] `pnpm run build && pnpm test` 本地全绿（交由 CI 验证）
- [x] 新行为补了测试
- [ ] 涉及 UI：已跑截图 QA 并逐张目检，截图附在下方（不涉及 UI）
- [ ] 涉及 `@Remote` 新增：已确认生成 face 重建（不涉及 `@Remote`）
- [x] README.md / README.zh.md 保持逐节对齐（未涉及功能描述）
- [x] ROADMAP.md 已更新（未涉及队列条目）

## 验证

- `pnpm exec vitest run packages/mimir/tests/http-write-boundary.spec.ts`：4 tests passed
- `pnpm run typecheck`：通过

## 截图

无 UI 改动，未附截图。