### PR TITLE
feat(mimir): expose the server.* remote namespace as model tools (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Mimir is a single npm package (`dsh-mimir`) that plugs into dsh and gives you:
 
 - **Nine-view web workbench** (sidebar toggle → overlay, dark/light, 中/EN):
   **Overview** pipeline & stats · **Paper** Overleaf-style LaTeX studio (edit → compile → PDF preview, one-click AI fix) · **Library** arXiv + web search, AI relevance scoring, fullscreen PDF reader · **Experiments** metric charts, one-click paper figures · **Figures** upload/organize/insert into the paper · **Meetings** one-click group-meeting PPT (real paper figures + optional AI illustrations) · **Servers** GPU fleet probes + remote jobs · **Ledger** humanized research journal — idea evolution auto-captured into a worktree, six-perspective digest capsules, one-click progress report · **Venues** CCF conference-deadline countdown (ccfddl catalog, per-project watchlist) + CCF-A journal directory
-- **Agent tools & slash commands**: `/research-idea` `/research-plan` `/research-review` `/paper-write` `/paper-compile`, plus `arxiv_search`, `web_search`, `wiki_note`, `figure_save`, `latex_compile`, `meeting_deck`, `venue_search`
+- **Agent tools & slash commands**: `/research-idea` `/research-plan` `/research-review` `/paper-write` `/paper-compile`, plus `arxiv_search`, `web_search`, `wiki_note`, `figure_save`, `latex_compile`, `meeting_deck`, `venue_search`, and the remote-compute quartet `server_list` / `server_check` / `server_submit_job` / `server_list_jobs` (same remembered servers and jobs as the Servers tab)
 - **Eleven bundled research skills** (literature review, novelty check, experiment planning, citation audit, bilingual de-AI polish, rebuttal…) that teach the agent the workflow — no setup needed
 
 | Overview | Paper | Library | Experiments |

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,7 +24,7 @@ Mimir 是单个 npm 包（`dsh-mimir`），装进 dsh 即可获得：
 
 - **九视图 Web 工作台**（侧栏开关呼出浮层，深色/浅色、中/EN）：
   **总览** 管线进度与统计 · **论文** Overleaf 式 LaTeX 工作室（编辑 → 编译 → PDF 预览，每条报错可一键让 AI 修） · **文献** arXiv + Web 搜索、AI 相关度评分、全屏 PDF 阅读 · **实验** 指标对比图、一键生成论文图 · **图表** 上传/归纳命名/插入论文 · **组会** 一键生成组会 PPT（论文原图 + 可选 AI 配图） · **服务器** GPU 集群探测 + 远程任务 · **记录** 人本化科研日志——想法演化自动收进 worktree、六视角摘要胶囊、一键进展报告 · **会议** CCF 会议截稿倒计时（ccfddl 目录，按项目关注列表）+ CCF-A 期刊目录
-- **Agent 工具与斜杠命令**：`/research-idea` `/research-plan` `/research-review` `/paper-write` `/paper-compile`，以及 `arxiv_search`、`web_search`、`wiki_note`、`figure_save`、`latex_compile`、`meeting_deck`、`venue_search`
+- **Agent 工具与斜杠命令**：`/research-idea` `/research-plan` `/research-review` `/paper-write` `/paper-compile`，以及 `arxiv_search`、`web_search`、`wiki_note`、`figure_save`、`latex_compile`、`meeting_deck`、`venue_search`，与远程计算四件套 `server_list` / `server_check` / `server_submit_job` / `server_list_jobs`（与服务器页共享同一批已登记服务器与任务）
 - **十一个内置科研技能**（文献综述、novelty 检查、实验规划、引用审计、中英双语去 AI 味润色、rebuttal……），直接教 agent 走流程，零配置
 
 | 总览 | 论文 | 文献 | 实验 |

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -102,6 +102,7 @@
     "@deepseek-ai/dsh-storage": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-storage-domain": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-subagent": "0.1.2-alpha.4",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-tools": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-typert-protocol": "0.1.2-alpha.4",
     "@deepseek-ai/dsh-util-values": "0.1.2-alpha.4",

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -23,6 +23,7 @@ import { createWikiNoteTool } from './tools/wiki.ts'
 import { createFigureOrganizeTool, createFigureSaveTool } from './tools/figure.ts'
 import { createMeetingDeckTool } from './tools/meeting.ts'
 import { createLatexCompileTool } from './tools/latex.ts'
+import { createServerCheckTool, createServerListJobsTool, createServerListTool, createServerSubmitJobTool } from './tools/server.ts'
 import { registerIdeaCommand } from './commands/idea.ts'
 import { registerPlanCommand } from './commands/plan.ts'
 import { registerReviewCommand } from './commands/review.ts'
@@ -423,6 +424,8 @@ export { createZoteroClient } from './tools/zotero.ts'
 export type { ZoteroBibRequest, ZoteroClient, ZoteroClientConfig, ZoteroCollection, ZoteroFetch, ZoteroItem } from './tools/zotero.ts'
 export { createWikiNoteTool } from './tools/wiki.ts'
 export { createFigureOrganizeTool, createFigureSaveTool } from './tools/figure.ts'
+export { createServerCheckTool, createServerListJobsTool, createServerListTool, createServerSubmitJobTool } from './tools/server.ts'
+export type { ResearchServiceResolver } from './tools/server.ts'
 export { createMeetingDeckTool } from './tools/meeting.ts'
 export { buildWikiSnapshot } from './wiki-snapshot.ts'
 export type { WikiSnapshotSource } from './wiki-snapshot.ts'
@@ -516,6 +519,18 @@ export interface Config {
      */
     dir?: string
   }
+  /**
+   * Register the model-callable `server_*` tools (list / check / submit /
+   * list jobs) that forward to the `server.*` Remote namespace (default
+   * true). These let the running agent drive remembered ssh runtimes the
+   * panel manages — a capability with real remote-execution reach, so
+   * compositions that want the panel's Servers view but no agent-driven
+   * compute can turn it off.
+   */
+  serverTools?: {
+    /** Master switch (default true); false skips registering the four server_* tools. */
+    enabled?: boolean
+  }
   /** Bundled research-skill registration knobs. */
   skills?: {
     /**
@@ -562,6 +577,9 @@ export const Config: z<Config> = z.object({
   skills: z.object({
     enabled: z.boolean().default(true),
   }).default({ enabled: true }),
+  serverTools: z.object({
+    enabled: z.boolean().default(true),
+  }).default({ enabled: true }),
 })
 
 /** Fully defaulted config view used by tools and commands. */
@@ -583,6 +601,7 @@ interface ResolvedConfig {
     readonly dir: string
   }
   readonly skills: { readonly enabled: boolean }
+  readonly serverTools: { readonly enabled: boolean }
 }
 
 /** Validate defaults even when a caller invokes apply() without Loader normalization. */
@@ -604,6 +623,7 @@ function resolveConfig(config: Config): ResolvedConfig {
     dir: config.backup?.dir ?? 'backups',
   }
   const skills = { enabled: config.skills?.enabled ?? true }
+  const serverTools = { enabled: config.serverTools?.enabled ?? true }
   if (workspaceDir.trim().length === 0) throw new TypeError('workspaceDir must be a non-empty path')
   if (reviewer.provider.trim().length === 0) throw new TypeError('reviewer.provider must be a non-empty provider name')
   if (!Number.isSafeInteger(reviewer.maxRounds) || reviewer.maxRounds < 1) throw new TypeError('reviewer.maxRounds must be a positive safe integer')
@@ -616,7 +636,7 @@ function resolveConfig(config: Config): ResolvedConfig {
   if (!Number.isSafeInteger(backup.intervalMinutes) || backup.intervalMinutes < 1) throw new TypeError('backup.intervalMinutes must be a positive safe integer')
   if (!Number.isSafeInteger(backup.keep) || backup.keep < 1) throw new TypeError('backup.keep must be a positive safe integer')
   if (backup.dir.trim().length === 0) throw new TypeError('backup.dir must be a non-empty path')
-  return { workspaceDir, reviewer, latex, arxiv, search, zotero, subscriptions, backup, skills }
+  return { workspaceDir, reviewer, latex, arxiv, search, zotero, subscriptions, backup, skills, serverTools }
 }
 
 /**
@@ -1111,6 +1131,20 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       timeoutMs: resolved.search.timeoutMs,
       maxResults: resolved.arxiv.maxResults,
     }))
+  }
+  // The panel's Servers view and the model-callable server_* tools share the
+  // same server/job state through ResearchService; the tools only forward, so
+  // registering them is a pure addition to the runtime the panel already
+  // drives. The controller tests and the ssh-jobs harness construct the
+  // service directly, so `ctx.research` may not be set in-process for the
+  // full apply() wiring — resolve it lazily at execution time instead of
+  // at registration time.
+  if (resolved.serverTools.enabled) {
+    const getResearch = () => ctx.get('research') as ResearchService | undefined
+    ctx.tools.register(createServerListTool(getResearch))
+    ctx.tools.register(createServerCheckTool(getResearch))
+    ctx.tools.register(createServerSubmitJobTool(getResearch))
+    ctx.tools.register(createServerListJobsTool(getResearch))
   }
   const serviceConfig: ResearchServiceConfig = {
     workspaceDir: deps.workspaceDir,

--- a/packages/mimir/src/skills.ts
+++ b/packages/mimir/src/skills.ts
@@ -219,9 +219,10 @@ to move one claim out of \`pending\`; a run that maps to no claim is cut.
    then ablations ordered by claim coverage per GPU-hour, then robustness
    (seeds, datasets). Baselines run before or alongside, never after.
 3. **Budget**: state the compute each run needs and where it runs — check
-   the 服务器 / Servers tab for registered machines and their GPU probe
-   results before promising a schedule. Jobs can be dispatched and tracked
-   from that tab; their ids belong in the experiment records.
+   \`server_list\` for registered machines and \`server_check\` for their GPU
+   probe results before promising a schedule (the 服务器 / Servers tab is the
+   same state). Jobs can be dispatched with \`server_submit_job\` and tracked
+   with \`server_list_jobs\`; their ids belong in the experiment records.
 4. **Register** every planned run:
    \`wiki_note { action: 'add_experiment', project_id, name, metrics }\`
    with the hypothesis in the name and the target metrics explicit.

--- a/packages/mimir/src/tools/server.ts
+++ b/packages/mimir/src/tools/server.ts
@@ -1,0 +1,160 @@
+/**
+ * Model-callable tools that forward to the live `server.*` Remote namespace
+ * (`ResearchService`): list remembered servers, probe one (TCP connect plus
+ * best-effort ssh `nvidia-smi` GPU readout), submit a job over batch-mode
+ * ssh, and list jobs. Thin forwarding only — the domain logic, its input
+ * validation, and its job state stay in `services/server.ts`, so a
+ * model-dispatched job shares the panel's `ServiceState` (the same job
+ * counter and SSH abort handles).
+ *
+ * Submitting is non-blocking: `server_submit_job` returns once the queued
+ * record is durable, and polling `server_list_jobs` for the status flips
+ * (`queued` → `running` → `succeeded`/`failed`/`cancelled`) is the caller's
+ * job — the same contract the Servers panel has. A rejected submit (unknown
+ * server, empty/overlong command, TCP-only server, unknown experiment) is
+ * returned as a business failure, not thrown, so the model can list servers
+ * and retry.
+ * @module dsh-mimir/src/tools/server
+ */
+
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
+import type { JsonValue } from '@deepseek-ai/dsh-util-values'
+import type { ResearchFailure, ServerRecord } from '../types.ts'
+import type { ResearchService } from '../service.ts'
+
+/**
+ * Resolve the live service lazily so a tool works whether it is registered
+ * before or after the plugin mounts `ResearchService` (execution always runs
+ * after `apply()` settles). Injectable so tests forward a direct instance.
+ */
+export type ResearchServiceResolver = () => ResearchService | undefined
+
+/** The mounted service, or a clear error when the plugin is not up. */
+function requireService(getResearch: ResearchServiceResolver): ResearchService {
+  const service = getResearch()
+  if (service === undefined) {
+    throw new Error('server_* tool: the mimir research service is not mounted')
+  }
+  return service
+}
+
+/**
+ * Unwrap one Remote result into the tool's flat value shape, matching the
+ * `figure_save` / `wiki_note` idiom: a success returns the payload directly
+ * (`{ servers }`, `{ job }`, `{ jobs }`, the probe view), a rejection keeps
+ * `{ ok: false, error }` so the model sees a business failure rather than a
+ * thrown error and can list servers and retry.
+ */
+async function forward<T>(call: () => Promise<{ ok: true; value: T } | { ok: false; error: ResearchFailure }>): Promise<T | { ok: false; error: ResearchFailure }> {
+  const result = await call()
+  return result.ok ? result.value : { ok: false, error: result.error }
+}
+
+/** Render one tool value as model-facing text: pretty JSON (a failed shape stays a clear `failed:` line). */
+function renderResult(value: JsonValue): string {
+  if (typeof value === 'object' && value !== null && (value as { ok?: unknown }).ok === false) {
+    return `failed: ${JSON.stringify(value)}`
+  }
+  return JSON.stringify(value, null, 2)
+}
+
+const render = (_args: unknown, value: JsonValue): { type: 'text'; text: string }[] => [
+  { type: 'text', text: renderResult(value) },
+]
+
+/** Cast a domain result (nested read-only records) to the tool's `JsonValue` canonical shape. */
+function asJson<T>(value: T): JsonValue {
+  return value as unknown as JsonValue
+}
+
+/**
+ * Build the `server_list` tool over one live research service.
+ * @param getResearch - Lazy access to the mounted `ResearchService`.
+ * @returns the registry-ready tool definition.
+ */
+export function createServerListTool(getResearch: ResearchServiceResolver): ToolDefinition {
+  return defineTool({
+    name: 'server_list',
+    description: 'List every remembered compute server, most recently updated first. Each entry carries the server id (server_id), host, port, ssh login user (empty for a TCP-only record), tags, and note. Call this before promising or submitting a run so you address a real registered machine.',
+    parameters: {
+      detail: { type: 'boolean', description: 'Default true; false returns only server ids and names, which keeps the tool call cheap when you only need an id.' },
+    },
+    output: { schema: { type: 'json' }, render },
+    async execute(args) {
+      const result = await forward(() => requireService(getResearch).listServers())
+      if (!('servers' in result)) return asJson(result)
+      if (args.detail === false) {
+        return asJson({
+          servers: (result as { servers: readonly ServerRecord[] }).servers.map(server => ({ server_id: server.id, name: server.name })),
+        })
+      }
+      return asJson(result)
+    },
+  })
+}
+
+/**
+ * Build the `server_check` tool over one live research service.
+ * @param getResearch - Lazy access to the mounted `ResearchService`.
+ * @returns the registry-ready tool definition.
+ */
+export function createServerCheckTool(getResearch: ResearchServiceResolver): ToolDefinition {
+  return defineTool({
+    name: 'server_check',
+    description: 'Probe one remembered server: a TCP connect (offline settles the view), then — when the record names an ssh login user — a best-effort ssh nvidia-smi GPU readout (its failure empties the GPU table without flipping the state). Returns the settled view: state, per-stage latencies, and the GPU table.',
+    parameters: {
+      server_id: { type: 'string', required: true, description: 'Id of a remembered server (see server_list).' },
+    },
+    output: { schema: { type: 'json' }, render },
+    async execute(args) {
+      return asJson(await forward(() => requireService(getResearch).checkServer({ id: args.server_id })))
+    },
+  })
+}
+
+/**
+ * Build the `server_submit_job` tool over one live research service.
+ * @param getResearch - Lazy access to the mounted `ResearchService`.
+ * @returns the registry-ready tool definition.
+ */
+export function createServerSubmitJobTool(getResearch: ResearchServiceResolver): ToolDefinition {
+  return defineTool({
+    name: 'server_submit_job',
+    description: 'Queue one batch-mode ssh command on a remembered server (its login shell runs the command). Non-blocking: returns the queued job record (id, server_id, command, status "queued") once durable; poll server_list_jobs for the flips to running, then succeeded/failed. A non-empty command up to 4000 characters is required; the server must name an ssh login user; an optional experiment_id links the run and flips that experiment record to running on submit, then to success/failed when the job settles. Rejections (server-not-found, invalid-input, experiment-not-found) return as a failure, not an error.',
+    parameters: {
+      server_id: { type: 'string', required: true, description: 'Id of a remembered ssh-capable server (see server_list).' },
+      command: { type: 'string', required: true, description: 'The remote command line, executed by the server\'s login shell; at most 4000 characters.' },
+      experiment_id: { type: 'string', description: 'Optional wiki experiment record to link and write the settle outcome back to.' },
+    },
+    output: { schema: { type: 'json' }, render },
+    async execute(args) {
+      return asJson(await forward(() => requireService(getResearch).submitJob({
+        serverId: args.server_id,
+        command: args.command,
+        ...(args.experiment_id === undefined ? {} : { experimentId: args.experiment_id }),
+      })))
+    },
+  })
+}
+
+/**
+ * Build the `server_list_jobs` tool over one live research service.
+ * @param getResearch - Lazy access to the mounted `ResearchService`.
+ * @returns the registry-ready tool definition.
+ */
+export function createServerListJobsTool(getResearch: ResearchServiceResolver): ToolDefinition {
+  return defineTool({
+    name: 'server_list_jobs',
+    description: 'List submitted remote jobs, most recently submitted first, each with its status (queued/running/succeeded/failed/cancelled/interrupted), output tails, and exit code once settled. Optionally filter to one server by server_id. Poll this after server_submit_job to learn when a run settles and whether it succeeded.',
+    parameters: {
+      server_id: { type: 'string', description: 'Only list jobs submitted to this server (see server_list).' },
+    },
+    output: { schema: { type: 'json' }, render },
+    async execute(args) {
+      return asJson(await forward(() => requireService(getResearch).listJobs({
+        ...(args.server_id === undefined ? {} : { serverId: args.server_id }),
+      })))
+    },
+  })
+}

--- a/packages/mimir/tests/server-tools-apply.spec.ts
+++ b/packages/mimir/tests/server-tools-apply.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Composition test for the `server_*` tools' real wiring: the full `apply()`
+ * entry is invoked over a composed context that mounts every service the
+ * plugin injects (`commands`, `tools`, `subagents`, `storageDomain`,
+ * `webServer`), and the four tools are then observed through the live tool
+ * registry — `ctx.tools.schemas()` proves they are model-visible, and
+ * `ctx.tools.execute()` drives a real submit whose queued record lands in the
+ * same domain the registered resolver reaches. This is the test that would
+ * fail if a future refactor stopped registering the tools in `apply()` or
+ * forwarded them to the wrong service instance.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import CommandRuntime from '@deepseek-ai/dsh-commands'
+import SystemPrompt from '@deepseek-ai/dsh-system-prompt'
+import { ToolRuntime } from '@deepseek-ai/dsh-tools'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import type { ServerRecord } from '../src/types.ts'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { apply, Config } from '../src/index.ts'
+import { ResearchService } from '../src/service.ts'
+
+/** Shim a fake `ssh` that echoes its command and settles. */
+async function stubFakeSsh(): Promise<void> {
+  const { chmod, mkdtemp: mkd, writeFile } = await import('node:fs/promises')
+  const binDir = await mkd(join(tmpdir(), 'mimir-fake-ssh-'))
+  const script = [
+    '#!/bin/bash',
+    'while [ $# -gt 1 ]; do shift; done',
+    'echo "fake-ssh stdout: $1"',
+    'exit 0',
+    '',
+  ].join('\n')
+  await writeFile(join(binDir, 'ssh'), script)
+  await chmod(join(binDir, 'ssh'), 0o755)
+  vi.stubEnv('PATH', `${binDir}:${process.env.PATH ?? ''}`)
+}
+
+afterEach(() => { vi.unstubAllEnvs() })
+
+/**
+ * Boot the full plugin over the services `apply()` touches. The plugin
+ * declares `['commands', 'tools', 'subagents', 'storageDomain', 'webServer']`
+ * as injects; of these, `webServer` is used only for route registration and
+ * `subagents`/`skills` only inside command bodies and the optional skill
+ * mount, so a context providing `commands`, `tools` (+ its `systemPrompt`
+ * dependency), `storageDomain`, and `webServer` covers every line `apply()`
+ * actually runs. `webServer` is satisfied by a minimal route-register stub
+ * rather than the real network carrier.
+ */
+async function bootComposition(): Promise<{ ctx: Context; service: ResearchService }> {
+  const ctx = new Context()
+  await ctx.plugin(CommandRuntime)
+  await ctx.plugin(SystemPrompt)
+  await ctx.plugin(ToolRuntime, { mode: 'native' })
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  ctx.provide('storageDomain', facility)
+  // The only `apply()` use of webServer is ctx.webServer.register(...) route
+  // effects; a stub that accepts and disposes routes is enough.
+  ctx.provide('webServer', { register: () => () => {} })
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-apply-'))
+  await apply(ctx, {
+    workspaceDir,
+    latex: { engine: 'auto', timeoutMs: 1000 },
+    backup: { enabled: false },
+    subscriptions: { enabled: false },
+  } satisfies Config)
+  // apply() fires ctx.plugin(ResearchService) without awaiting it, so the
+  // service mounts a beat after apply resolves; wait for it to appear. The
+  // registered tools resolve it lazily at execute time either way.
+  let service: ResearchService | undefined
+  for (let attempt = 0; attempt < 100 && service === undefined; attempt += 1) {
+    service = ctx.get('research') as ResearchService | undefined
+    if (service === undefined) await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  if (service === undefined) throw new Error('research service never mounted')
+  return { ctx, service }
+}
+
+describe('server_* tools registered by apply()', () => {
+  it('exposes all four tools to the model registry', async () => {
+    const { ctx } = await bootComposition()
+    const names = ctx.tools.schemas().map(tool => tool.name)
+    for (const expected of ['server_list', 'server_check', 'server_submit_job', 'server_list_jobs']) {
+      expect(names).toContain(expected)
+    }
+  })
+
+  it('dispatches a real submit through the registry to the shared domain', async () => {
+    const { ctx, service } = await bootComposition()
+    await stubFakeSsh()
+    const created = await service.saveServer({
+      server: { name: 'gpu01', host: '127.0.0.1', port: 22, username: 'ops', note: '' },
+    })
+    if (!created.ok) throw new Error('create failed')
+    const serverId = created.value.server.id
+
+    const submit = await ctx.tools.execute({
+      callId: 'server-tools-test:submit',
+      name: 'server_submit_job',
+      arguments: { server_id: serverId, command: 'hostname' },
+      signal: new AbortController().signal,
+    })
+    expect(submit.isError).toBe(false)
+    const text = submit.content.map(block => (block as { text?: string }).text ?? '').join('')
+    const jobId = (JSON.parse(text) as { job?: { id: string } }).job?.id
+    expect(jobId).toBeTruthy()
+
+    const listed = await service.listJobs({})
+    if (!listed.ok) throw new Error('list rejected')
+    expect(listed.value.jobs.find(job => job.id === jobId)).toMatchObject({ serverId })
+  })
+
+  it('server_list resolves the same servers the service holds', async () => {
+    const { ctx, service } = await bootComposition()
+    const created = await service.saveServer({
+      server: { name: 'gpu02', host: '10.0.0.2', port: 22, username: 'ops', note: '', tags: ['a'] },
+    })
+    if (!created.ok) throw new Error('create failed')
+    const list = await ctx.tools.execute({
+      callId: 'server-tools-test:list',
+      name: 'server_list',
+      arguments: {},
+      signal: new AbortController().signal,
+    })
+    expect(list.isError).toBe(false)
+    const text = list.content.map(block => (block as { text?: string }).text ?? '').join('')
+    const servers = (JSON.parse(text) as { servers: ServerRecord[] }).servers
+    expect(servers.map(server => server.name)).toEqual(['gpu02'])
+  })
+})

--- a/packages/mimir/tests/server-tools.spec.ts
+++ b/packages/mimir/tests/server-tools.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Behavior tests for the model-callable `server_*` tools: `server_list`,
+ * `server_check`, `server_submit_job`, and `server_list_jobs`. The tools are
+ * thin forwards to the live `ResearchService` (the same namespace the Servers
+ * panel drives), so the domain behavior itself is covered by the ssh-jobs and
+ * service suites; here we pin the tool surface — argument mapping (snake_case
+ * → camelCase), failure shaping (a rejected Remote call is returned as a
+ * business failure, not thrown), and that a job the tools submit is the very
+ * job `server_list_jobs` observes settling. The fake-`ssh` PATH shim is
+ * reused from the ssh-jobs harness so no real ssh runs.
+ */
+
+import { chmod, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import type { ToolRunContext } from '@deepseek-ai/dsh-tools'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import {
+  createServerCheckTool,
+  createServerListJobsTool,
+  createServerListTool,
+  createServerSubmitJobTool,
+} from '../src/tools/server.ts'
+import type { ResearchServiceResolver } from '../src/tools/server.ts'
+import { ResearchService } from '../src/service.ts'
+import type { JobRecord, ServerRecord } from '../src/types.ts'
+
+/** Boot a memory-backed domain plus a fresh temp workspace and the four tools. */
+async function harness() {
+  const ctx = new Context()
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  const domain = await facility.open(researchWikiDomainSpec)
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-server-tools-'))
+  const service = new ResearchService(ctx, {
+    workspaceDir,
+    domain,
+    latex: { engine: 'auto', timeoutMs: 1000 },
+  })
+  // In apply() the resolver reads ctx.research; a direct service is the unit
+  // under test here, so the resolver returns the constructed instance.
+  const getResearch: ResearchServiceResolver = () => service
+  return {
+    domain,
+    workspaceDir,
+    service,
+    serverList: createServerListTool(getResearch),
+    serverCheck: createServerCheckTool(getResearch),
+    serverSubmit: createServerSubmitJobTool(getResearch),
+    serverListJobs: createServerListJobsTool(getResearch),
+  }
+}
+
+/** The tool execute() needs a ToolRunContext it never reads in these paths. */
+const NO_EXEC = {} as ToolRunContext
+
+/** One saved ssh-capable server (the fake ssh answers it). */
+const SERVER_INPUT = { name: 'gpu01', host: '127.0.0.1', port: 22, username: 'ops', note: '' }
+
+/** Save one server and return its record. */
+async function saveServer(service: ResearchService, input = SERVER_INPUT): Promise<ServerRecord> {
+  const created = await service.saveServer({ server: input })
+  if (!created.ok) throw new Error('create failed')
+  return created.value.server
+}
+
+/**
+ * Shim a fake `ssh` onto PATH: echoes its remote command (its last argument)
+ * to stdout and settles; `mimir-slow` sleeps briefly, `mimir-fail` exits 3.
+ */
+async function stubFakeSsh(): Promise<void> {
+  const binDir = await mkdtemp(join(tmpdir(), 'mimir-fake-ssh-'))
+  const script = [
+    '#!/bin/bash',
+    'while [ $# -gt 1 ]; do shift; done',
+    'echo "fake-ssh stdout: $1"',
+    'echo "fake-ssh stderr line" >&2',
+    'case "$1" in *mimir-fail*) exit 3 ;; esac',
+    'case "$1" in *mimir-slow*) sleep 0.5 ;; esac',
+    'exit 0',
+    '',
+  ].join('\n')
+  await writeFile(join(binDir, 'ssh'), script)
+  await chmod(join(binDir, 'ssh'), 0o755)
+  vi.stubEnv('PATH', `${binDir}:${process.env.PATH ?? ''}`)
+}
+
+/** Poll server_list_jobs until one job reaches a terminal status. */
+async function settleJob(
+  tool: ReturnType<typeof createServerListJobsTool>,
+  id: string,
+): Promise<JobRecord> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const outcome = await tool.execute({}, NO_EXEC)
+    const value = (outcome as { jobs: JobRecord[] }).jobs
+    const job = value.find(record => record.id === id)
+    if (job !== undefined && (job.status === 'succeeded' || job.status === 'failed')) return job
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+  throw new Error(`job ${id} did not settle`)
+}
+
+afterEach(() => { vi.unstubAllEnvs() })
+
+describe('server_list', () => {
+  it('lists the saved servers, most recently updated first', async () => {
+    const { service, serverList } = await harness()
+    await saveServer(service, { ...SERVER_INPUT, name: 'gpu01' })
+    await new Promise(resolve => setTimeout(resolve, 2))
+    await saveServer(service, { ...SERVER_INPUT, name: 'gpu02' })
+    const value = await serverList.execute({}, NO_EXEC) as { servers: ServerRecord[] }
+    expect(value.servers.map(server => server.name)).toEqual(['gpu02', 'gpu01'])
+    expect(value.servers[0]).toMatchObject({ host: '127.0.0.1', port: 22, username: 'ops' })
+  })
+
+  it('detail=false returns only ids and names', async () => {
+    const { service, serverList } = await harness()
+    await saveServer(service)
+    const value = await serverList.execute({ detail: false }, NO_EXEC) as { servers: { server_id: string; name: string }[] }
+    expect(value.servers).toEqual([{ server_id: expect.any(String), name: 'gpu01' }])
+  })
+})
+
+describe('server_check', () => {
+  it('probes an offline server to an offline view', async () => {
+    const { service, serverCheck } = await harness()
+    const server = await saveServer(service, { ...SERVER_INPUT, host: '127.0.0.1', port: 19999 })
+    const outcome = await serverCheck.execute({ server_id: server.id }, NO_EXEC) as { state: string }
+    expect(outcome.state).toBe('offline')
+  }, 20_000)
+
+  it('reports an unknown server id as a failure, not a thrown error', async () => {
+    const { serverCheck } = await harness()
+    const value = await serverCheck.execute({ server_id: 'srv-missing' }, NO_EXEC)
+    expect(value).toEqual({ ok: false, error: { code: 'server-not-found', id: 'srv-missing' } })
+  })
+})
+
+describe('server_submit_job / server_list_jobs', () => {
+  it('maps snake_case args, returns the queued record, and the job settles to succeeded', async () => {
+    const { domain, service, serverSubmit, serverListJobs } = await harness()
+    await stubFakeSsh()
+    const server = await saveServer(service)
+
+    const submitted = await serverSubmit.execute(
+      { server_id: server.id, command: 'python train.py --epochs 1' },
+      NO_EXEC,
+    ) as { job: JobRecord }
+    expect(submitted.job).toMatchObject({ serverId: server.id, status: 'queued' })
+    // The job is durable in the shared domain, and listJobs observes it.
+    expect(domain.table('jobs').get(submitted.job.id)).toMatchObject({ command: 'python train.py --epochs 1' })
+
+    const settled = await settleJob(serverListJobs, submitted.job.id)
+    expect(settled.status).toBe('succeeded')
+    expect(settled.exitCode).toBe(0)
+    expect(settled.stdoutTail).toContain('fake-ssh stdout: python train.py --epochs 1')
+  })
+
+  it('returns submit rejections as failures and lists by server', async () => {
+    const { service, serverSubmit, serverListJobs } = await harness()
+    await stubFakeSsh()
+    const server = await saveServer(service)
+
+    await expect(serverSubmit.execute({ server_id: 'srv-missing', command: 'hostname' }, NO_EXEC))
+      .resolves.toEqual({ ok: false, error: { code: 'server-not-found', id: 'srv-missing' } })
+    await expect(serverSubmit.execute({ server_id: server.id, command: '   ' }, NO_EXEC))
+      .resolves.toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+    // A rejected submit queues nothing.
+    const listed = await serverListJobs.execute({}, NO_EXEC) as { jobs: JobRecord[] }
+    expect(listed.jobs).toEqual([])
+
+    const submitted = await serverSubmit.execute({ server_id: server.id, command: 'hostname' }, NO_EXEC) as { job: JobRecord }
+    const byServer = await serverListJobs.execute({ server_id: server.id }, NO_EXEC) as { jobs: JobRecord[] }
+    expect(byServer.jobs.map(job => job.id)).toEqual([submitted.job.id])
+    const byOther = await serverListJobs.execute({ server_id: 'srv-other' }, NO_EXEC)
+    expect(byOther).toEqual({ ok: false, error: { code: 'server-not-found', id: 'srv-other' } })
+  })
+
+  it('forwards a linked experiment_id through to the job record', async () => {
+    const { domain, service, serverSubmit } = await harness()
+    await stubFakeSsh()
+    const server = await saveServer(service)
+    await domain.table('experiments').put('exp-1', {
+      id: 'exp-1', projectId: 'p1', name: 'baseline', status: 'failed',
+      metrics: {}, updatedAt: '2026-08-20T00:00:00.000Z',
+    })
+
+    const submitted = await serverSubmit.execute(
+      { server_id: server.id, command: 'hostname', experiment_id: 'exp-1' },
+      NO_EXEC,
+    ) as { job: JobRecord }
+    expect(submitted.job.experimentId).toBe('exp-1')
+    expect(domain.table('experiments').get('exp-1')).toMatchObject({ status: 'running' })
+    await expect(serverSubmit.execute(
+      { server_id: server.id, command: 'hostname', experiment_id: 'exp-missing' },
+      NO_EXEC,
+    )).resolves.toEqual({ ok: false, error: { code: 'experiment-not-found', id: 'exp-missing' } })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@deepseek-ai/dsh-subagent':
         specifier: 0.1.2-alpha.4
         version: 0.1.2-alpha.4(ec536cb4625467f8b302e2caf382b4c9)
+      '@deepseek-ai/dsh-system-prompt':
+        specifier: 0.1.2-alpha.4
+        version: 0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-scope@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.4(@deepseek-ai/cordis@4.0.2)))
       '@deepseek-ai/dsh-tools':
         specifier: 0.1.2-alpha.4
         version: 0.1.2-alpha.4(6f17de9b01b7bb711bb9888e3e73adf0)


### PR DESCRIPTION
## 改动内容

Closes #135

把 `server.*` Remote namespace（Servers 面板驱动的同一批已登记服务器与 SSH 任务）暴露成 4 个模型可调用工具：`server_list`、`server_check`、`server_submit_job`、`server_list_jobs`。全部是薄转发——domain 逻辑、输入校验、任务状态仍在 `services/server.ts`，模型触发的任务与面板共享同一份 `ServiceState`（job 计数 + SSH abort 句柄）。

- `server_list` 带 `detail` 开关（默认 true），模型先低成本拿到 server_id 再承诺排期；`detail=false` 只返回 id + name。
- `server_check` 探测单台（TCP → 尽力而为 ssh `nvidia-smi`）。
- `server_submit_job` 非阻塞：落盘即返回 queued 记录，由调用方轮询 `server_list_jobs` 观察状态翻转——与面板契约一致。拒绝（`server-not-found` / `invalid-input` / `experiment-not-found`）以 `{ ok: false }` 返回而不是抛错。
- `server_list_jobs` 最新在前，可按 `server_id` 过滤。

转发经懒解析器指向已挂载的 `ResearchService`（工具执行恒在 `apply()` 之后），避免注册顺序问题。新增 `serverTools.enabled` 配置开关（默认 true）——该能力给了 agent 远程执行触及面，不需要的组合可关掉。

配套：`research-plan` 技能与 README/README.zh 把 agent 从“只看 Servers tab”指向这四个工具。

### 为什么缺查询入口必须补 `server_list`

Issue 原提议三件套，但模型要 `submitJob` 必须先知 `serverId`（`research-plan` 技能本就写明“先查 Servers 再承诺排期”），缺查询入口闭环无法自启动。经确认后范围定为四件套。

### 明确不在本 PR

Issue 后半段的“闭环接哪个 autoresearch（Path A/B/C）”按 issue 作者建议另开 issue，本 PR 只交付工具层。

## 检查清单

- [x] `pnpm run build && pnpm run typecheck && pnpm test` 本地全绿（1029 passed）
- [x] 新行为补了测试：`server-tools.spec.ts`（工具面：参数映射、失败成形、experiment 联动、detail 开关）+ `server-tools-apply.spec.ts`（真实 `apply()` 组合上下文：`ctx.tools.schemas()` 可见性 + 注册表分发落到同一 domain）
- [ ] 涉及 UI：无 UI 改动
- [x] 涉及 `@Remote` 新增：无新增 Remote（工具只调既有 `listServers/checkServer/submitJob/listJobs`），`pnpm run build` 已重建 host bundle 并确认工具名入包
- [x] README.md / README.zh.md 保持逐节对齐
- [ ] ROADMAP.md：无对应队列条目（已是最新产品能力描述，未单独加列）

## 截图

无 UI 改动。
