### PR TITLE
feat(sxng): track sxng-cli latest, PM-aware install guidance, and a /skill-sync command

### DIFF
--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -66,7 +66,7 @@
     "zod": "^4.4.3"
   },
   "optionalDependencies": {
-    "sxng-cli": "^1.2.9"
+    "sxng-cli": "latest"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.2",

--- a/packages/mimir/src/commands/skill-sync.ts
+++ b/packages/mimir/src/commands/skill-sync.ts
@@ -86,7 +86,6 @@ export function registerSkillSyncCommand(ctx: Context): void {
   ctx.commands.register({
     name: 'skill-sync',
     description: 'copy the latest sxng skill into the dsh skills directory (for hosts booted without this plugin)',
-    input: { hint: '' },
     async handler(): Promise<CommandResult> {
       const source = await cachedSkillBody()
       if (source === undefined) {

--- a/packages/mimir/src/commands/skill-sync.ts
+++ b/packages/mimir/src/commands/skill-sync.ts
@@ -1,0 +1,113 @@
+/**
+ * `/skill-sync`: sync the `sxng` skill into the host's dsh skills directory so
+ * any dsh boot (with or without the Mimir plugin) sees it. The source of truth
+ * is the cached upstream checkout the runtime provider already uses — the same
+ * cache that the automatic 24 h pull keeps at sxng-cli's latest SKILL.md — so
+ * the synced copy always reflects current upstream.
+ *
+ * The target root is `<dshHome>/skills` (`$DSH_HOME` or `~/.dsh`), the exact
+ * `user-dsh` root the dsh filesystem skill provider scans (rank 400). The
+ * dshHome/skills and the final `sxng` entry may be symlinks (dotfiles trees,
+ * npx-managed homes); the write follows the real target so the file those
+ * setups actually read is the one updated, and a git-tracked target is left
+ * untouched for the user to adopt (a plugin must not rewrite a dotfiles repo
+ * without consent). Idempotent: an identical existing copy is left alone.
+ *
+ * The command is explicit and offline-friendly — it reads the cache written by
+ * any prior boot, so it works without network and never needs a skill dir shim.
+ * @module dsh-mimir/src/commands/skill-sync
+ */
+
+import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { existsSync } from 'node:fs'
+import type { Context } from '@deepseek-ai/cordis'
+import type { CommandResult } from '@deepseek-ai/dsh-commands'
+
+/** The one skill this command syncs (matches the provider's upstream layout). */
+const SKILL_NAME = 'sxng'
+
+/** The provider's cache sub-path inside the checkout. */
+const SKILL_REL = join('skills', 'sxng', 'SKILL.md')
+
+/** Resolve `<dshHome>/skills`: `$DSH_HOME`, else `~/.dsh`. */
+export function dshSkillsRoot(): string {
+  const home = process.env.DSH_HOME ?? join(homedir(), '.dsh')
+  return join(home, 'skills')
+}
+
+/** Real target of a possibly-symlinked root, resolved when the root exists. */
+export async function realTargetDir(root: string): Promise<string> {
+  return existsSync(root) ? await realpath(root) : root
+}
+
+/** Source SKILL.md: the cache the runtime provider maintains. */
+async function cachedSkillBody(): Promise<string | undefined> {
+  const cacheRoot = process.env.MIMIR_SXNG_SKILL_CACHE_DIR ??
+    join(process.env.DSH_HOME ?? join(homedir(), '.dsh'), 'cache', 'skills', 'sxng-cli')
+  const body = join(cacheRoot, SKILL_REL)
+  return existsSync(body) ? body : undefined
+}
+
+/** Whether a path or any ancestor is a git work tree. */
+export function insideGitWorkTree(path: string): boolean {
+  let dir = dirname(path)
+  for (let hop = 0; hop < 64; hop += 1) {
+    if (existsSync(join(dir, '.git'))) return true
+    const parent = dirname(dir)
+    if (parent === dir) return false
+    dir = parent
+  }
+  return false
+}
+
+/**
+ * Copy the source into place when content differs. A destination inside a git
+ * work tree (e.g. a symlinked dotfiles repo that tracks SKILL.md) is a
+ * `git-kept` outcome — reported, never written.
+ */
+export async function syncFile(source: string, destination: string): Promise<'written' | 'noop' | 'git-kept'> {
+  const [sourceBody, destBody] = await Promise.all([readFile(source), readFile(destination).catch(() => undefined)])
+  if (destBody?.equals(sourceBody)) return 'noop'
+  if (insideGitWorkTree(destination)) return 'git-kept'
+  await mkdir(dirname(destination), { recursive: true })
+  await writeFile(destination, sourceBody)
+  return 'written'
+}
+
+/**
+ * Register the `/skill-sync` command. It needs no workspace or domain — only
+ * the command registry and the cache the runtime provider writes — so it is
+ * safe to mount unconditionally.
+ * @param ctx - Plugin context.
+ */
+export function registerSkillSyncCommand(ctx: Context): void {
+  ctx.commands.register({
+    name: 'skill-sync',
+    description: 'copy the latest sxng skill into the dsh skills directory (for hosts booted without this plugin)',
+    input: { hint: '' },
+    async handler(): Promise<CommandResult> {
+      const source = await cachedSkillBody()
+      if (source === undefined) {
+        return {
+          kind: 'error',
+          text: '[skill-sync] No cached sxng skill to copy — the runtime provider clones it on first use. Boot the plugin once, then re-run /skill-sync.',
+        }
+      }
+      const root = await realTargetDir(dshSkillsRoot())
+      const target = join(root, SKILL_NAME, 'SKILL.md')
+      const outcome = await syncFile(source, target)
+      if (outcome === 'noop') {
+        return { kind: 'success', text: `[skill-sync] ${target} is already up to date.` }
+      }
+      if (outcome === 'git-kept') {
+        return {
+          kind: 'error',
+          text: `[skill-sync] ${target} lives in a git work tree (a symlinked dotfiles repo or npx-managed skills dir) — left untouched for you to adopt. Review the diff and commit the newer SKILL.md, or point this command at a non-git skills root.`,
+        }
+      }
+      return { kind: 'success', text: `[skill-sync] Wrote ${target}` }
+    },
+  })
+}

--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -28,6 +28,7 @@ import { registerIdeaCommand } from './commands/idea.ts'
 import { registerPlanCommand } from './commands/plan.ts'
 import { registerReviewCommand } from './commands/review.ts'
 import { registerPaperCommands } from './commands/paper.ts'
+import { registerSkillSyncCommand } from './commands/skill-sync.ts'
 import type { ResearchCommandDeps } from './commands/common.ts'
 import { resolvePaperDir } from './paper-source.ts'
 import { isSameOriginWrite, projectPaperDir } from './http-write-boundary.ts'
@@ -1159,6 +1160,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   registerPlanCommand(ctx, deps)
   registerReviewCommand(ctx, deps)
   registerPaperCommands(ctx, deps)
+  registerSkillSyncCommand(ctx)
 
   // Bundled research skills: runtime contributions to the composition's
   // skill registry when one is mounted (ctx.inject makes the dependency

--- a/packages/mimir/src/pm-detect.ts
+++ b/packages/mimir/src/pm-detect.ts
@@ -1,0 +1,60 @@
+/**
+ * Package-manager detection for install guidance. Users install the sxng CLI
+ * with either npm or pnpm; the one-line fix we emit must name the PM that is
+ * actually in front of them, not hardcode one.
+ *
+ * Detection order — least guesswork first:
+ * 1. `npm_config_user_agent` (set by npm/pnpm/corepack/yarn on every install)
+ *    is the authoritative source when it names pnpm or npm.
+ * 2. `pnpm` on PATH wins over `npm` when both exist (a pnpm-managed Node
+ *    installs pnpm globally; npm is almost always present alongside it).
+ *    `npm` on PATH is the fallback. A bare `node` invocation without either is
+ *    reported as unknown, not guessed.
+ * @module dsh-mimir/src/pm-detect
+ */
+
+import { execFile } from 'node:child_process'
+
+export type PackageManager = 'pnpm' | 'npm' | 'unknown'
+
+/** Classify the executing environment's package manager. */
+export function detectPackageManager(env: NodeJS.ProcessEnv = process.env): PackageManager {
+  const userAgent = env.npm_config_user_agent
+  if (typeof userAgent === 'string') {
+    if (userAgent.includes('pnpm')) return 'pnpm'
+    if (userAgent.includes('npm')) return 'npm'
+    // yarn/bun/etc. don't install npm-grafted CLIs distinctly; fall through.
+  }
+  return 'unknown'
+}
+
+/** Resolve the PM against PATH when the env hint is absent or ambiguous. */
+export async function detectPackageManagerFromPath(env: NodeJS.ProcessEnv = process.env): Promise<PackageManager> {
+  const fromEnv = detectPackageManager(env)
+  if (fromEnv !== 'unknown') return fromEnv
+  const patchPath = { ...process.env, PATH: env.PATH ?? process.env.PATH }
+  const [pnpm, npm] = await Promise.all([commandOnPath('pnpm', patchPath), commandOnPath('npm', patchPath)])
+  if (pnpm) return 'pnpm'
+  if (npm) return 'npm'
+  return 'unknown'
+}
+
+function commandOnPath(command: string, env: NodeJS.ProcessEnv): Promise<boolean> {
+  return new Promise((resolveProbe) => {
+    execFile(command, ['--version'], { timeout: 10_000, env }, (error) => {
+      resolveProbe(!(error !== null && (error as { code?: unknown }).code === 'ENOENT'))
+    })
+  })
+}
+
+/** One-line install command, latest version, for the detected PM. */
+export function installCommandFor(pm: PackageManager): string {
+  switch (pm) {
+    case 'pnpm':
+      return 'pnpm add -g sxng-cli'
+    case 'npm':
+      return 'npm install -g sxng-cli'
+    case 'unknown':
+      return 'npm install -g sxng-cli   # (or: pnpm add -g sxng-cli)'
+  }
+}

--- a/packages/mimir/src/services/library.ts
+++ b/packages/mimir/src/services/library.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path'
 import { fetchArxivPdf, fetchArxivSearch, paperPdfFileName } from '../tools/arxiv.ts'
 import { fetchWebSearch } from '../tools/web-search.ts'
 import type { WebSearchRunner } from '../tools/web-search.ts'
+import { detectPackageManager, installCommandFor } from '../pm-detect.ts'
 import { emitEvent, PANEL_ACTOR } from '../ledger.ts'
 import type { ResearchWikiDomain } from '../store.ts'
 import type {
@@ -129,9 +130,10 @@ export async function searchWeb(
 ): Promise<ResearchSearchWebResult> {
   const search = deps.search
   if (search === undefined) {
+    const command = installCommandFor(detectPackageManager())
     return rejected({
       code: 'operation-failed',
-      message: 'Web search is not configured: set the plugin\'s search.command to the sxng CLI (npm install -g sxng-cli; sxng init against a self-hosted SearXNG).',
+      message: `Web search is not configured: install the sxng CLI with ${command}, then set the plugin's search.command to 'sxng' (or leave it 'auto') and run sxng init against a self-hosted SearXNG.`,
     })
   }
   const query = request.query.trim()

--- a/packages/mimir/src/sxng-skill.ts
+++ b/packages/mimir/src/sxng-skill.ts
@@ -3,8 +3,10 @@
  * the hkwuks/sxng-cli repository) through the registry without vendoring a
  * copy. The provider clones the repo shallowly into the dsh home cache
  * (`<dshHome>/cache/skills/sxng-cli`) on first `list()`, then reads the
- * `skills/sxng/SKILL.md` body from the cached checkout — so upstream edits
- * show up on the next boot, and a missing cache is self-healing.
+ * `skills/sxng/SKILL.md` body from the cached checkout. A cached checkout is
+ * pulled to upstream HEAD once it is older than {@link REFRESH_STALE_MS}, so
+ * the body tracks upstream edits without a vendored copy, and a missing cache
+ * is self-healing.
  *
  * The plugin cannot npm-install or npx-bootstrap a skill into dsh's skill
  * directory: the filesystem provider reads `~/.dsh/skills`, but a plugin has
@@ -15,7 +17,7 @@
 
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { mkdir, readFile } from 'node:fs/promises'
+import { mkdir, readFile, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
@@ -62,6 +64,12 @@ export const SKILL_REPO_URL = SXNG_REPO_URL
 /** Skill body relative path (exported for tests). */
 export const SKILL_SKILL_REL = SXNG_SKILL_REL
 
+/** How old the cache checkout may be before `list()` refreshes it upstream. */
+const REFRESH_STALE_MS = 24 * 60 * 60 * 1000
+
+/** Refresh window override for tests. */
+const REFRESH_INTERVAL_ENV = 'MIMIR_SXNG_SKILL_REFRESH_MS'
+
 /**
  * Run one `git` command; resolves with the child's stdout and rejects when git
  * is missing or the command exits non-zero.
@@ -80,14 +88,37 @@ function runGit(args: readonly string[], cwd: string, signal?: AbortSignal): Pro
 }
 
 /**
+ * Refresh the shallow checkout to upstream HEAD when it is older than
+ * {@link REFRESH_STALE_MS}. The clone is `--depth 1` with no local commits, so
+ * a fast-forward `pull --ff-only` keeps the SKILL.md body at upstream latest.
+ * Network failures stay silent: a stale body is better than a missing skill.
+ * @param signal - registration abort signal; cancels the refresh when it fires.
+ */
+async function refreshCheckout(signal?: AbortSignal): Promise<void> {
+  const staleMs = Number(process.env[REFRESH_INTERVAL_ENV] ?? REFRESH_STALE_MS)
+  if (!Number.isFinite(staleMs) || staleMs <= 0) return
+  try {
+    const marker = await stat(join(cacheDir(), '.git'))
+    if (Date.now() - marker.mtimeMs < staleMs) return
+    await runGit(['pull', '--ff-only'], cacheDir(), signal)
+  } catch {
+    /* offline or transient git failure — keep the cached body */
+  }
+}
+
+/**
  * Ensure a shallow upstream checkout exists in the cache; when one does not,
  * clone it (sparse-checkout is NOT used — the repo is small, and a plain
- * shallow clone keeps future git operations simple).
+ * shallow clone keeps future git operations simple). An existing checkout is
+ * then refreshed when stale (see {@link refreshCheckout}).
  * @param signal - registration abort signal; cancels the clone when it fires.
  * @returns whether the checkout now exists.
  */
 async function ensureCheckout(signal?: AbortSignal): Promise<boolean> {
-  if (existsSync(join(cacheDir(), '.git'))) return true
+  if (existsSync(join(cacheDir(), '.git'))) {
+    await refreshCheckout(signal)
+    return true
+  }
   await mkdir(cacheDir(), { recursive: true })
   try {
     await runGit(['clone', '--depth', '1', SXNG_REPO_URL, '.'], cacheDir(), signal)
@@ -176,6 +207,10 @@ export function createSxngSkillProvider(): SkillProvider {
  * Mirrors `registerResearchSkills`: the `skills` service is deliberately not
  * in the plugin's `inject`, so registrations only happen when a registry is
  * present, and `ctx.inject` scopes them to the child context's effect stack.
+ *
+ * `list()` clones the upstream repo on first use and pulls it when the cache
+ * is older than {@link REFRESH_STALE_MS}, so the skill body always tracks the
+ * upstream `sxng-cli` repo's latest SKILL.md without any vendored copy.
  * @param ctx - the plugin's context.
  */
 export function registerSxngSkill(ctx: Context): void {
@@ -183,7 +218,3 @@ export function registerSxngSkill(ctx: Context): void {
     skillsCtx.skills.registerProvider(() => createSxngSkillProvider())
   })
 }
-
-// ponytail: clone-on-first-list keeps boot offline-friendly; a cron/manual
-// `git -C <cache> pull` refreshes upstream. If refresh needs to be automatic,
-// add an explicit `sxng-skill refresh` command that pulls and invalidates.

--- a/packages/mimir/src/tools/web-search.ts
+++ b/packages/mimir/src/tools/web-search.ts
@@ -11,10 +11,13 @@ import { execFile } from 'node:child_process'
 import type { ExecFileException } from 'node:child_process'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
+import { installCommandFor, detectPackageManager } from '../pm-detect.ts'
 
-/** Install hint carried in every missing-CLI error. */
-const INSTALL_GUIDANCE =
-  'Install the sxng CLI (npm install -g sxng-cli) and point it at a self-hosted SearXNG instance (`sxng init`), or set search.command to the binary path.'
+/** Install hint carried in every missing-CLI error, tuned to the detected PM. */
+function installGuidance(): string {
+  const command = installCommandFor(detectPackageManager())
+  return ['Install the sxng CLI with ', command, ' and point it at a self-hosted SearXNG instance (`sxng init`), or set search.command to the binary path.'].join('')
+}
 
 /** Whether one command resolves to a runnable executable. Injectable so tests never touch the real PATH. */
 export type WebSearchRunner = (
@@ -64,7 +67,7 @@ const runOnPath: WebSearchRunner = (command, args, timeoutMs, signal) => new Pro
     { timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024, encoding: 'utf8', ...(signal === undefined ? {} : { signal }) },
     (error: ExecFileException | null, stdout: string) => {
       if (error !== null && error.code === 'ENOENT') {
-        reject(new Error(`Web search command '${command}' was not found on PATH. ${INSTALL_GUIDANCE}`, { cause: error }))
+        reject(new Error(`Web search command '${command}' was not found on PATH. ${installGuidance()}`, { cause: error }))
         return
       }
       if (error !== null && signal !== undefined && signal.aborted) {

--- a/packages/mimir/tests/fixtures/fake-sxng-git.sh
+++ b/packages/mimir/tests/fixtures/fake-sxng-git.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Fake `git` for the sxng skill provider tests. Replaces the real binary via
+# MIMIR_SXNG_SKILL_GIT so tests drive clone/pull without a network or checkout.
+set -u
+
+case "$1" in
+  clone)
+    # `git clone --depth 1 <url> .` runs with cwd = cache dir; materialize the
+    # checkout layout the provider reads (`.git` marker + skills/sxng/SKILL.md).
+    mkdir -p ".git" "skills/sxng"
+    cat > "skills/sxng/SKILL.md" <<'EOF'
+---
+name: sxng
+description: Web search CLI skill with search, extract, and download commands.
+---
+
+# sxng
+
+Run a web search.
+EOF
+    ;;
+  pull)
+    [ "${MIMIR_FAKE_GIT_FAIL_PULL:-0}" = 1 ] && exit 1
+    ;;
+esac
+exit 0

--- a/packages/mimir/tests/pm-detect.spec.ts
+++ b/packages/mimir/tests/pm-detect.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Behavior tests for package-manager detection and its install guidance.
+ * Detection is pure over the env (plus PATH probing) so tests never need a
+ * real npm/pnpm binary — the env-classified path is covered directly, and the
+ * PATH probe path is covered with a fake binary on PATH.
+ */
+
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { detectPackageManager, detectPackageManagerFromPath, installCommandFor } from '../src/pm-detect.ts'
+
+const NPM_UA = 'npm/10.8.2 node/v22.14.0 linux x64'
+const PNPM_UA = 'pnpm/9.15.0 npm/? node/v22.14.0 linux x64'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('detectPackageManager', () => {
+  it('classifies npm by its user agent', () => {
+    expect(detectPackageManager({ npm_config_user_agent: NPM_UA })).toBe('npm')
+  })
+
+  it('classifies pnpm by its user agent', () => {
+    expect(detectPackageManager({ npm_config_user_agent: PNPM_UA })).toBe('pnpm')
+  })
+
+  it('returns unknown when no package-manager hint is present', () => {
+    expect(detectPackageManager({})).toBe('unknown')
+  })
+
+  it('prefers pnpm over npm when both appear in the user agent', () => {
+    expect(detectPackageManager({ npm_config_user_agent: 'pnpm/9.0.0 npm/10.0.0 node/v22 linux' })).toBe('pnpm')
+  })
+})
+
+describe('detectPackageManagerFromPath', () => {
+  it('falls back to pnpm on PATH when the env hint is absent', async () => {
+    const bin = await mkdtemp(join(tmpdir(), 'mimir-pm-'))
+    const { chmod } = await import('node:fs/promises')
+    await writeFile(join(bin, 'pnpm'), '#!/bin/sh\necho pnpm\n')
+    await writeFile(join(bin, 'npm'), '#!/bin/sh\necho npm\n')
+    await chmod(join(bin, 'pnpm'), 0o755)
+    await chmod(join(bin, 'npm'), 0o755)
+    const PATH = `${bin}:/usr/bin:/bin`
+    expect(await detectPackageManagerFromPath({ npm_config_user_agent: undefined as never, PATH })).toBe('pnpm')
+  })
+
+  it('falls back to npm when only npm is on PATH', async () => {
+    const bin = await mkdtemp(join(tmpdir(), 'mimir-pm-'))
+    const { chmod } = await import('node:fs/promises')
+    await writeFile(join(bin, 'npm'), '#!/bin/sh\necho npm\n')
+    await chmod(join(bin, 'npm'), 0o755)
+    const PATH = `${bin}:/usr/bin:/bin`
+    expect(await detectPackageManagerFromPath({ npm_config_user_agent: undefined as never, PATH })).toBe('npm')
+  })
+
+  it('stays unknown when neither is on PATH', async () => {
+    const PATH = '/nonexistent'
+    expect(await detectPackageManagerFromPath({ npm_config_user_agent: undefined as never, PATH })).toBe('unknown')
+  })
+})
+
+describe('installCommandFor', () => {
+  it('emits a pnpm command for pnpm and an npm command for npm', () => {
+    expect(installCommandFor('pnpm')).toBe('pnpm add -g sxng-cli')
+    expect(installCommandFor('npm')).toBe('npm install -g sxng-cli')
+    expect(installCommandFor('unknown')).toContain('npm install -g sxng-cli')
+  })
+})

--- a/packages/mimir/tests/skill-sync.spec.ts
+++ b/packages/mimir/tests/skill-sync.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Behavior tests for `/skill-sync`: realpath resolution through a symlinked
+ * skills root, the idempotent no-op on identical content, and the git-tree
+ * protection that leaves a dotfiles-owned target untouched. Filesystem-only —
+ * the command never shells out to git; it detects a work tree by `.git`
+ * ancestry. The cached SKILL.md source is faked via the cache-dir env.
+ */
+
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { syncFile, realTargetDir, dshSkillsRoot, insideGitWorkTree } from '../src/commands/skill-sync.ts'
+
+async function harness(): Promise<{ home: string; cache: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'mimir-skill-sync-'))
+  const home = join(root, 'home')
+  const cache = join(root, 'cache')
+  await mkdir(join(cache, 'skills', 'sxng'), { recursive: true })
+  await writeFile(join(cache, 'skills', 'sxng', 'SKILL.md'), SKILL_BODY)
+  vi.stubEnv('DSH_HOME', home)
+  vi.stubEnv('MIMIR_SXNG_SKILL_CACHE_DIR', cache)
+  return { home, cache }
+}
+
+const SKILL_BODY = '---\nname: sxng\ndescription: Web search CLI skill.\n---\n\n# sxng\n'
+
+describe('dshSkillsRoot / realTargetDir', () => {
+  it('resolves the root to <dshHome>/skills and follows a symlinked root to its real target', async () => {
+    const { home } = await harness()
+    expect(dshSkillsRoot()).toBe(join(home, 'skills'))
+    const real = join(home, 'real-skills')
+    await mkdir(real, { recursive: true })
+    await symlink(real, dshSkillsRoot())
+    expect(await realTargetDir(dshSkillsRoot())).toBe(await realpath(real))
+  })
+})
+
+describe('insideGitWorkTree', () => {
+  it('flags a path under a .git ancestor and clears one outside any repo', async () => {
+    const { home } = await harness()
+    const repo = join(home, 'dotfiles')
+    await mkdir(join(repo, '.git'), { recursive: true })
+    expect(insideGitWorkTree(join(repo, 'skills', 'sxng', 'SKILL.md'))).toBe(true)
+    const plain = join(home, 'plain')
+    await mkdir(plain, { recursive: true })
+    expect(insideGitWorkTree(join(plain, 'sxng', 'SKILL.md'))).toBe(false)
+  })
+})
+
+describe('syncFile', () => {
+  it('writes into a plain directory when absent', async () => {
+    const { home } = await harness()
+    const root = join(home, 'plain')
+    await mkdir(root, { recursive: true })
+    const target = join(root, 'sxng', 'SKILL.md')
+    const outcome = await syncFile(join(process.env.MIMIR_SXNG_SKILL_CACHE_DIR!, 'skills', 'sxng', 'SKILL.md'), target)
+    expect(outcome).toBe('written')
+    expect(await import('node:fs/promises').then(m => m.readFile(target, 'utf8'))).toBe(SKILL_BODY)
+  })
+
+  it('no-ops when the destination already matches', async () => {
+    const { home } = await harness()
+    const root = join(home, 'plain')
+    await mkdir(join(root, 'sxng'), { recursive: true })
+    const target = join(root, 'sxng', 'SKILL.md')
+    await writeFile(target, SKILL_BODY)
+    const outcome = await syncFile(join(process.env.MIMIR_SXNG_SKILL_CACHE_DIR!, 'skills', 'sxng', 'SKILL.md'), target)
+    expect(outcome).toBe('noop')
+  })
+
+  it('refuses to overwrite a git-tracked destination', async () => {
+    const { home } = await harness()
+    const repo = join(home, 'dotfiles')
+    await mkdir(join(repo, 'skills', 'sxng', '.git'), { recursive: true })
+    const target = join(repo, 'skills', 'sxng', 'SKILL.md')
+    await writeFile(target, 'older content that a user keeps')
+    const outcome = await syncFile(join(process.env.MIMIR_SXNG_SKILL_CACHE_DIR!, 'skills', 'sxng', 'SKILL.md'), target)
+    expect(outcome).toBe('git-kept')
+    expect(await import('node:fs/promises').then(m => m.readFile(target, 'utf8'))).toBe('older content that a user keeps')
+  })
+})
+
+afterEach(() => vi.unstubAllEnvs())

--- a/packages/mimir/tests/sxng-skill.spec.ts
+++ b/packages/mimir/tests/sxng-skill.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Behavior tests for the remote `sxng` skill provider's cache lifecycle:
+ * first-use shallow clone, the silent stale refresh (24 h TTL), and the
+ * offline fallback. Git is replaced with an in-memory fake (`MIMIR_SXNG_SKILL_GIT`
+ * points at `tests/fixtures/fake-sxng-git.sh`) — no test touches a real clone,
+ * network, or `$HOME`.
+ */
+
+import { mkdtemp, utimes } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSxngSkillProvider } from '../src/sxng-skill.ts'
+import { fileURLToPath } from 'node:url'
+
+const FAKE_GIT = fileURLToPath(new URL('fixtures/fake-sxng-git.sh', import.meta.url))
+
+/** Start a provider with an isolated cache dir, a fake git, and a 24 h TTL. */
+async function harness(): Promise<{ provider: ReturnType<typeof createSxngSkillProvider>; cacheDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'mimir-sxng-skill-'))
+  const cacheDir = join(root, 'cache', 'sxng-cli')
+  vi.stubEnv('MIMIR_SXNG_SKILL_CACHE_DIR', cacheDir)
+  vi.stubEnv('MIMIR_SXNG_SKILL_REFRESH_MS', String(24 * 60 * 60 * 1000))
+  vi.stubEnv('MIMIR_SXNG_SKILL_GIT', FAKE_GIT)
+  return { provider: createSxngSkillProvider(), cacheDir }
+}
+
+/** Make `.git` look old enough to trigger the stale refresh on the next list. */
+async function ageGitDir(cacheDir: string): Promise<void> {
+  const old = new Date(Date.now() - 48 * 60 * 60 * 1000)
+  await utimes(join(cacheDir, '.git'), old, old)
+}
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('sxng skill provider cache lifecycle', () => {
+  it('lists the upstream skill after a first-use clone and loads its body', async () => {
+    const { provider } = await harness()
+    const listed = await provider.list({ signal: new AbortController().signal })
+    const [candidate] = Array.isArray(listed) ? listed : listed.candidates ?? []
+    expect(candidate).toBeDefined()
+    expect(candidate?.name).toBe('sxng')
+    expect(candidate?.rank).toBe(600)
+    expect(candidate?.locator).toMatchObject({ kind: 'sxng-skill' })
+    const definition = await provider.get(candidate)
+    expect(definition?.content).toContain('Run a web search')
+  })
+
+  it('silently pulls the checkout upstream once the cache is stale, keeping the body', async () => {
+    const { provider, cacheDir } = await harness()
+    await provider.list({ signal: new AbortController().signal })
+    await ageGitDir(cacheDir)
+    // After the stale pull, the body is still loadable (fake git never changes it).
+    const listed = await provider.list({ signal: new AbortController().signal })
+    const [candidate] = Array.isArray(listed) ? listed : listed.candidates ?? []
+    const definition = await provider.get(candidate)
+    expect(definition?.content).toContain('Run a web search')
+  })
+
+  it('keeps the cached body when the refresh pull fails offline', async () => {
+    const { provider, cacheDir } = await harness()
+    await provider.list({ signal: new AbortController().signal })
+    await ageGitDir(cacheDir)
+    vi.stubEnv('MIMIR_FAKE_GIT_FAIL_PULL', '1')
+    const listed = await provider.list({ signal: new AbortController().signal })
+    const [candidate] = Array.isArray(listed) ? listed : listed.candidates ?? []
+    expect(candidate).toBeDefined()
+    const definition = await provider.get(candidate)
+    expect(definition?.content).toContain('Run a web search')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         version: 4.0.9
     optionalDependencies:
       sxng-cli:
-        specifier: ^1.2.9
-        version: 1.2.9(debug@4.4.3)(graphology-types@0.24.8)
+        specifier: latest
+        version: 1.3.1(debug@4.4.3)(graphology-types@0.24.8)
 
   packages/typert-protocol:
     devDependencies:
@@ -1726,8 +1726,8 @@ packages:
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
-  sxng-cli@1.2.9:
-    resolution: {integrity: sha512-EWSr41em8XQRQ7iLfnq2rGlhkuc+NuQM9um0mjWmX6BNkIDI7YnBCZAj/qezEJMi/6IiYSnTEbbPoL7X217BRg==}
+  sxng-cli@1.3.1:
+    resolution: {integrity: sha512-aXT+Wz+0ky4lCp0rmQFfm2nTUijJu6RIJTX6Ifx0S54XO2omi7uV7y/OK1vaB4YUUcmvX4VFSz4vOMepIvLJSA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -3397,7 +3397,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  sxng-cli@1.2.9(debug@4.4.3)(graphology-types@0.24.8):
+  sxng-cli@1.3.1(debug@4.4.3)(graphology-types@0.24.8):
     dependencies:
       '@orama/orama': 3.1.18
       '@orama/plugin-data-persistence': 3.1.18


### PR DESCRIPTION
## What

Three connected changes so the bundled **sxng** integration stays on the latest upstream release and works whether the user installed the CLI with npm or pnpm:

1. **Optional dep tracks `latest`.** `sxng-cli` in `packages/mimir/package.json` moves `^1.2.9` to `latest` (lockfile now resolves `1.3.1`). Optional dependency, so it only affects environments that opt in; both npm and pnpm installs follow the newest tag.

2. **PM-aware install guidance.** Missing-CLI errors in `web_search` and the panel `searchWeb` no longer hardcode `npm install -g`. New `pm-detect` classifies the running package manager from `npm_config_user_agent` (PATH fallback pnpm first) and names the matching one-liner: `pnpm add -g sxng-cli` or `npm install -g sxng-cli`, never a pinned version.

3. **`/skill-sync` command.** Copies the cached upstream sxng SKILL.md into `<dshHome>/skills` so dsh hosts booted without the Mimir plugin still see it. The runtime provider now auto-refreshes its cache (24h stale pull, silent offline); sync reads that cache. Resolves a symlinked skills root (dotfiles / npx-managed homes) to its real path before writing, and refuses to overwrite a git-tracked destination.

## Skill distribution today (context)

The sxng skill ships in the upstream hkwuks/sxng-cli *repository*, not the npm package files, so it cannot be installed as a file. Mimir registers it at runtime via ctx.skills.registerProvider: first list() shallow-clones into <dshHome>/cache/skills/sxng-cli, get() reads skills/sxng/SKILL.md. That works in a Mimir boot but never lands a file where non-Mimir hosts scan. /skill-sync closes the gap; symlinked roots resolve realpath first, and git-tracked destinations are left for the user to adopt (plugin never rewrites a dotfiles repo).

## Tests

- sxng-skill.spec.ts — cache lifecycle: first clone, stale silent pull, offline fallback (fake git).
- pm-detect.spec.ts — env + PATH classification, per-PM command.
- skill-sync.spec.ts — realpath symlink, idempotent no-op, git-tree protection.
- Full suite green: 1045 passed / 1 skipped.