### PR TITLE
fix: recover stale subscription locks and coalesce venue refreshes

### DIFF
--- a/packages/mimir/src/arxiv-subscriptions.ts
+++ b/packages/mimir/src/arxiv-subscriptions.ts
@@ -12,7 +12,7 @@
  * @module dsh-mimir/src/arxiv-subscriptions
  */
 
-import { readFile } from 'node:fs/promises'
+import { lstat, readFile, rename, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { writeFileAtomic, withFileLock } from '@deepseek-ai/dsh-atomic-write'
 import { isNotFound } from './paper-source.ts'
@@ -35,6 +35,42 @@ export const ARXIV_SUBSCRIPTION_FETCH_TIMEOUT_MS = 15_000
 export const ARXIV_SUBSCRIPTION_GAP_MS = 3_000
 /** How long after plugin start the FIRST scheduled check runs. */
 export const ARXIV_SUBSCRIPTION_FIRST_DELAY_MS = 120_000
+/** Age after which a lock left by a crashed writer may be quarantined. */
+export const ARXIV_SUBSCRIPTION_LOCK_STALE_MS = 5 * 60_000
+
+/** Remove one stale lock without deleting a lock a later writer may own. */
+async function recoverStaleArxivSubscriptionLock(filename: string): Promise<void> {
+  const lockPath = `${filename}.lock`
+  let stats
+  try {
+    stats = await lstat(lockPath)
+  } catch (error) {
+    if (isNotFound(error)) return
+    throw error
+  }
+  if (Date.now() - stats.mtimeMs < ARXIV_SUBSCRIPTION_LOCK_STALE_MS) return
+
+  // Rename first so a lock created after the rename remains visible at the
+  // canonical path; only the quarantined orphan is removed below.
+  const quarantinePath = `${lockPath}.stale-${process.pid}-${Date.now()}`
+  try {
+    await rename(lockPath, quarantinePath)
+  } catch (error) {
+    if (isNotFound(error)) return
+    throw error
+  }
+  await rm(quarantinePath, { force: true })
+}
+
+/** Run one subscription-file mutation behind stale-lock recovery. */
+export async function withArxivSubscriptionsFileLock<T>(
+  workspaceDir: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const filename = join(workspaceDir, ARXIV_SUBSCRIPTIONS_FILE)
+  await recoverStaleArxivSubscriptionLock(filename)
+  return withFileLock(filename, operation)
+}
 
 /**
  * One persisted arXiv subscription. `seenIds` is the diff memory (newest
@@ -257,7 +293,7 @@ async function runArxivSubscriptionCheckUnlocked(
     }
   }
   if (outcomes.some(outcome => outcome.error === null)) {
-    await withFileLock(join(workspaceDir, ARXIV_SUBSCRIPTIONS_FILE), async () => {
+    await withArxivSubscriptionsFileLock(workspaceDir, async () => {
       const updates = new Map(outcomes
         .filter((outcome): outcome is ArxivSubscriptionCheckOutcome & { readonly error: null } => outcome.error === null)
         .map(outcome => [outcome.record.id, outcome.record]))

--- a/packages/mimir/src/services/subscriptions.ts
+++ b/packages/mimir/src/services/subscriptions.ts
@@ -8,14 +8,12 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
-import { withFileLock } from '@deepseek-ai/dsh-atomic-write'
 import {
   ARXIV_SUBSCRIPTION_QUERY_MAX,
-  ARXIV_SUBSCRIPTIONS_FILE,
   loadArxivSubscriptions,
   runArxivSubscriptionCheck,
   saveArxivSubscriptions,
+  withArxivSubscriptionsFileLock,
 } from '../arxiv-subscriptions.ts'
 import type {
   ArxivSubscriptionRecord,
@@ -81,7 +79,7 @@ export async function saveArxivSubscription(
   // The same file lock the check's save path holds: a check settling between
   // our read and write would otherwise be overwritten whole. The duplicate
   // probe and the append both re-read inside the lock.
-  return await withFileLock(join(deps.workspaceDir, ARXIV_SUBSCRIPTIONS_FILE), async () => {
+  return await withArxivSubscriptionsFileLock(deps.workspaceDir, async () => {
     const subscriptions = await loadArxivSubscriptions(deps.workspaceDir)
     if (subscriptions.some(record => record.query.toLowerCase() === query.toLowerCase())) {
       return rejected({ code: 'invalid-input', message: `already subscribed: ${query}` })
@@ -113,7 +111,7 @@ export async function deleteArxivSubscription(
   // Same lock as the check's save path: re-read inside, then filter, so a
   // concurrently settling check can neither resurrect the deleted record nor
   // be lost itself.
-  return await withFileLock(join(deps.workspaceDir, ARXIV_SUBSCRIPTIONS_FILE), async () => {
+  return await withArxivSubscriptionsFileLock(deps.workspaceDir, async () => {
     const subscriptions = await loadArxivSubscriptions(deps.workspaceDir)
     if (!subscriptions.some(record => record.id === request.id)) {
       return rejected({ code: 'subscription-not-found', id: request.id })

--- a/packages/mimir/src/services/venue-deadlines.ts
+++ b/packages/mimir/src/services/venue-deadlines.ts
@@ -45,6 +45,9 @@ interface VenueCache {
   readonly venues: readonly VenueSeries[]
 }
 
+/** In-flight cache refreshes keyed by workspace, so timer and manual calls share one fetch. */
+const activeVenueRefreshes = new Map<string, Promise<VenueCache>>()
+
 /** Deps of the venue-deadline handlers: workspace root plus the wiki domain. */
 export type VenueDeadlineDeps = WikiAdminDeps & { readonly workspaceDir: string }
 
@@ -79,13 +82,26 @@ export async function loadVenueCache(workspaceDir: string): Promise<VenueCache |
  * @param fetchImpl - fetch seam (the real network outside tests).
  * @returns the fresh cache.
  */
-export async function refreshVenueCache(workspaceDir: string, fetchImpl: VenueFetch = defaultFetch): Promise<VenueCache> {
+async function refreshVenueCacheUnlocked(workspaceDir: string, fetchImpl: VenueFetch): Promise<VenueCache> {
   const text = await fetchImpl(CCFDDL_ALLCONF_URL, AbortSignal.timeout(VENUE_FETCH_TIMEOUT_MS))
   const venues = parseAllconfYaml(text)
   if (venues.length === 0) throw new Error('ccfddl payload parsed to an empty catalog')
   const cache: VenueCache = { fetchedAt: new Date().toISOString(), venues: Object.freeze(venues) }
   await writeFileAtomic(join(workspaceDir, VENUE_CACHE_FILE), JSON.stringify(cache), { mode: 0o666 })
   return cache
+}
+
+export async function refreshVenueCache(workspaceDir: string, fetchImpl: VenueFetch = defaultFetch): Promise<VenueCache> {
+  const active = activeVenueRefreshes.get(workspaceDir)
+  if (active !== undefined) return active
+
+  const refresh = refreshVenueCacheUnlocked(workspaceDir, fetchImpl)
+  activeVenueRefreshes.set(workspaceDir, refresh)
+  try {
+    return await refresh
+  } finally {
+    if (activeVenueRefreshes.get(workspaceDir) === refresh) activeVenueRefreshes.delete(workspaceDir)
+  }
 }
 
 /** Options for {@link startVenueDeadlineLoop}. */

--- a/packages/mimir/tests/arxiv-subscriptions.spec.ts
+++ b/packages/mimir/tests/arxiv-subscriptions.spec.ts
@@ -7,7 +7,7 @@
  * workspace.
  */
 
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -122,6 +122,24 @@ describe('saveArxivSubscription / deleteArxivSubscription', () => {
       .resolves.toMatchObject({ ok: false, error: { code: 'subscription-not-found', id } })
     const listed = await listArxivSubscriptions(deps)
     expect(listed.ok && listed.value.subscriptions.length).toBe(0)
+  })
+
+  it('recovers an orphaned stale lock before a CRUD write', async () => {
+    const dir = await workspace()
+    const lockPath = join(dir, `${ARXIV_SUBSCRIPTIONS_FILE}.lock`)
+    await writeFile(lockPath, 'orphaned\n')
+    const staleAt = new Date(Date.now() - 5 * 60_000 - 1)
+    await utimes(lockPath, staleAt, staleAt)
+
+    const result = await saveArxivSubscription(
+      { workspaceDir: dir },
+      { query: 'mesh reconstruction' },
+    )
+
+    expect(result).toMatchObject({ ok: true })
+    await expect(readFile(lockPath, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
   })
 })
 

--- a/packages/mimir/tests/venue-deadlines.spec.ts
+++ b/packages/mimir/tests/venue-deadlines.spec.ts
@@ -223,6 +223,33 @@ describe('venue cache shell', () => {
     expect(loaded?.venues.length).toBe(3)
   })
 
+  it('coalesces concurrent refreshes for the same workspace', async () => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-venue-cache-'))
+    const body = await readFile(FIXTURE, 'utf8')
+    let calls = 0
+    let resolveFetch!: (value: string) => void
+    const pendingFetch = new Promise<string>((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchImpl = async () => {
+      calls += 1
+      return pendingFetch
+    }
+
+    const first = refreshVenueCache(workspaceDir, fetchImpl)
+    await Promise.resolve()
+    const second = refreshVenueCache(workspaceDir, async () => {
+      calls += 1
+      return body
+    })
+
+    resolveFetch(body)
+    const [left, right] = await Promise.all([first, second])
+
+    expect(calls).toBe(1)
+    expect(left).toBe(right)
+  })
+
   it('rejects a payload that parses to an empty catalog', async () => {
     const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-venue-cache-'))
     await expect(refreshVenueCache(workspaceDir, async () => 'foo: bar')).rejects.toThrow('empty catalog')


### PR DESCRIPTION
## Summary

Harden subscription and venue-cache refreshes against stale locks and duplicate concurrent work.

## Problem

- A process crash can leave `arxiv-subscriptions.json.lock` behind, causing later writes to time out indefinitely.
- Manual venue refreshes and the scheduled refresh loop can overlap, issuing duplicate fetches and competing cache writes.

## Changes

- Added stale-lock detection and atomic quarantine for the arXiv subscription file lock.
- Routed subscription CRUD and check-result writes through the stale-lock-aware wrapper.
- Added a workspace-scoped in-flight refresh registry so concurrent venue refreshes share one promise and failure cleanup remains safe.
- Added regression tests for orphaned lock recovery and concurrent refresh coalescing.

## Tests

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build`
- `corepack pnpm run typecheck`
- `corepack pnpm exec vitest run packages/mimir/tests/arxiv-subscriptions.spec.ts packages/mimir/tests/venue-deadlines.spec.ts --reporter=dot` — 48 passed
- `corepack pnpm test -- --reporter=dot` — 1,064 passed, 1 skipped; 16 pre-existing Windows/environment failures and 2 unhandled `ECONNRESET` errors remain outside the changed modules.

## Compatibility / Known limitations

The implementation preserves the existing file format, cache format, public refresh signature, and two-second lock wait. Stale locks older than five minutes are quarantined before retrying. The full suite's remaining failures are Windows path, permission, remote SSH, GPU, and network-environment cases already present in the unmodified baseline; the changed modules pass their focused suite.

## Issue

Closes #141
