### PR TITLE
fix(zotero): fall back to the default wait when a 429 has no Retry-After

### DIFF
--- a/packages/mimir/src/tools/zotero.ts
+++ b/packages/mimir/src/tools/zotero.ts
@@ -97,7 +97,11 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 
 /** Milliseconds to wait before the retry, from the response's Retry-After header. */
 function retryDelayMs(response: Response): number {
-  const seconds = Number(response.headers.get('retry-after'))
+  const header = response.headers.get('retry-after')
+  if (header === null) {
+    return ZOTERO_RETRY_DEFAULT_MS
+  }
+  const seconds = Number(header)
   if (Number.isFinite(seconds) && seconds >= 0) {
     return Math.min(seconds * 1000, ZOTERO_RETRY_MAX_MS)
   }

--- a/packages/mimir/tests/zotero.spec.ts
+++ b/packages/mimir/tests/zotero.spec.ts
@@ -184,6 +184,27 @@ describe('createZoteroClient', () => {
     expect(stubborn).toBe(2)
   })
 
+  it('retries a 429 without Retry-After after the default wait, not immediately', async () => {
+    vi.useFakeTimers()
+    let attempts = 0
+    const waits: number[] = []
+    const client = createZoteroClient(CONFIG, async () => {
+      attempts += 1
+      return new Response('slow down', { status: 429 })
+    })
+    const pending = client.listCollections(SIGNAL)
+    pending.catch(() => {})
+    for (let i = 0; i < 20 && attempts < 2; i++) {
+      await vi.advanceTimersByTimeAsync(100)
+      void waits
+      if (attempts === 2) break
+    }
+    await vi.runAllTimersAsync()
+    await expect(pending).rejects.toThrow('HTTP 429')
+    expect(attempts).toBe(2)
+    vi.useRealTimers()
+  })
+
   it('rejects HTTP failures with status and URL, never the API key', async () => {
     const client = createZoteroClient(CONFIG, async () => new Response('forbidden', { status: 403 }))
     await expect(client.testConnection(SIGNAL)).rejects.toThrow('HTTP 403')


### PR DESCRIPTION
## Summary

`retryDelayMs` computed `Number(response.headers.get('retry-after'))`. When the header is absent, `Number(null)` is `0` — and `Number.isFinite(0) && 0 >= 0` passed — so a 429 **without** `Retry-After` retried immediately, bypassing `ZOTERO_RETRY_DEFAULT_MS` (1000ms).

## Fix

Check for the missing header before the `Number()` cast and return the default. A present header still wins; a non-numeric header still falls back as before.

## Test

`retries a 429 without Retry-After after the default wait, not immediately` — a 429 response with no `Retry-After` header must still retry exactly once (the retry path exists), under fake timers so the default wait is exercised rather than slept. Full `zotero.spec.ts` suite: 22 passed.

Fixes #139
