### PR TITLE
fix(zotero): a 429 with no Retry-After waits the default, not zero

### DIFF
--- a/packages/mimir/src/tools/zotero.ts
+++ b/packages/mimir/src/tools/zotero.ts
@@ -97,10 +97,21 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 
 /** Milliseconds to wait before the retry, from the response's Retry-After header. */
 function retryDelayMs(response: Response): number {
-  const seconds = Number(response.headers.get('retry-after'))
+  const header = response.headers.get('retry-after')
+  // `Number(null)` is 0 and `Number('')` is 0, and both pass a `>= 0` check,
+  // so casting first made a 429 with no Retry-After retry immediately and
+  // skip the default backoff entirely. Absence has to be decided before the
+  // cast, not after it.
+  if (header === null || header.trim() === '') {
+    return ZOTERO_RETRY_DEFAULT_MS
+  }
+  const seconds = Number(header)
   if (Number.isFinite(seconds) && seconds >= 0) {
     return Math.min(seconds * 1000, ZOTERO_RETRY_MAX_MS)
   }
+  // A non-numeric value is malformed rather than absent -- RFC 9110 also
+  // allows an HTTP-date here, which this does not parse -- so it falls back
+  // to the default too rather than being treated as zero.
   return ZOTERO_RETRY_DEFAULT_MS
 }
 

--- a/packages/mimir/tests/zotero.spec.ts
+++ b/packages/mimir/tests/zotero.spec.ts
@@ -184,6 +184,81 @@ describe('createZoteroClient', () => {
     expect(stubborn).toBe(2)
   })
 
+  it('waits the default backoff when a 429 carries no Retry-After', async () => {
+    // `Number(null)` is 0 and passes a `>= 0` check, so the header's absence
+    // used to compute a 0ms wait and retry immediately -- the opposite of
+    // backing off, against a server that just said it was rate limited.
+    vi.useFakeTimers()
+    try {
+      let attempts = 0
+      const client = createZoteroClient(CONFIG, async () => {
+        attempts += 1
+        return attempts === 1 ? new Response('slow down', { status: 429 }) : json([])
+      })
+
+      const pending = client.listCollections(SIGNAL)
+      await vi.advanceTimersByTimeAsync(999)
+      expect(attempts).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(pending).resolves.toEqual([])
+      expect(attempts).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('lets the Retry-After header win when it is present', async () => {
+    vi.useFakeTimers()
+    try {
+      let attempts = 0
+      const client = createZoteroClient(CONFIG, async () => {
+        attempts += 1
+        return attempts === 1
+          ? new Response('slow down', { status: 429, headers: { 'Retry-After': '2' } })
+          : json([])
+      })
+
+      const pending = client.listCollections(SIGNAL)
+      // Still waiting past the default, so the header is what is being honoured.
+      await vi.advanceTimersByTimeAsync(1999)
+      expect(attempts).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(pending).resolves.toEqual([])
+      expect(attempts).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('falls back to the default for an empty or unparseable Retry-After', async () => {
+    // `Number('')` is also 0, and an HTTP-date -- which RFC 9110 permits and
+    // this client does not parse -- is NaN. Neither is a reason to retry
+    // instantly, so both take the default.
+    for (const value of ['', '   ', 'Wed, 21 Oct 2026 07:28:00 GMT']) {
+      vi.useFakeTimers()
+      try {
+        let attempts = 0
+        const client = createZoteroClient(CONFIG, async () => {
+          attempts += 1
+          return attempts === 1
+            ? new Response('slow down', { status: 429, headers: { 'Retry-After': value } })
+            : json([])
+        })
+
+        const pending = client.listCollections(SIGNAL)
+        await vi.advanceTimersByTimeAsync(999)
+        expect(attempts, `Retry-After: ${JSON.stringify(value)} retried too early`).toBe(1)
+
+        await vi.advanceTimersByTimeAsync(1)
+        await expect(pending).resolves.toEqual([])
+      } finally {
+        vi.useRealTimers()
+      }
+    }
+  })
+
   it('rejects HTTP failures with status and URL, never the API key', async () => {
     const client = createZoteroClient(CONFIG, async () => new Response('forbidden', { status: 403 }))
     await expect(client.testConnection(SIGNAL)).rejects.toThrow('HTTP 403')


### PR DESCRIPTION
Closes #139. Exactly the diagnosis in the issue: `Number(null) === 0`, `Number.isFinite(0) && 0 >= 0` passes, so a 429 with no `Retry-After` retried immediately.

Absence is now decided **before** the cast rather than after it.

### Two cases beyond the report

`Number('')` is also `0`, so an empty or whitespace-only header had the identical effect — same bug, different input. Both take the default now.

A non-numeric value keeps falling through to the default, which also covers the **HTTP-date** form RFC 9110 permits for `Retry-After` and this client does not parse. `Number('Wed, 21 Oct 2026 07:28:00 GMT')` is `NaN`, so that already fell through — but it is worth a test, because "malformed" and "absent" now both mean "wait the default" and that should stay true if someone later adds date parsing.

### Done when

**A 429 without the header waits ≥1000ms.** Asserted on fake timers rather than by sleeping: the retry has not fired at 999ms and has at 1000ms.

**With the header, the header wins.** `Retry-After: 2` is still waiting at 1999ms and fires at 2000ms — which shows it is honouring the header rather than merely not-zero.

**Regression test for both**, plus the empty/whitespace/HTTP-date cases.

### Verification

```
# on the unfixed zotero.ts
× waits the default backoff when a 429 carries no Retry-After
× falls back to the default for an empty or unparseable Retry-After
Tests  2 failed | 22 passed (24)

# with the fix
Tests  24 passed (24)
```

Full suite: **22 failed / 1074 passed on `main`, 22 failed / 1077 passed here** — the three new tests, zero newly failing.

`tsc -b packages/mimir` is clean. `pnpm typecheck` reports two errors in `packages/ui-mimir/src/client/index.ts`, but it does so on unmodified `main` too, so they are pre-existing and in a package this change does not touch.
