### PR TITLE
fix(meeting): validate projectId before joining meeting-deck paths

### DIFF
--- a/packages/mimir/src/project-id.ts
+++ b/packages/mimir/src/project-id.ts
@@ -1,0 +1,29 @@
+/**
+ * The shared project-id safety predicate. A project id keys the wiki's
+ * projects table AND joins filesystem paths (meeting decks under
+ * `meetings/<projectId>/`), so every write and every path join must reject
+ * ids that could escape the directory.
+ *
+ * Same shape and the same reasoning as {@link isValidArxivId}: a charset
+ * whitelist MINUS `..` anywhere and leading slashes (absolute paths), with
+ * backslashes and drive letters excluded by the charset so a Windows host
+ * gets the same answer as a POSIX one.
+ *
+ * A leaf module so `store.ts` (schema), the services, and the import path can
+ * share it without an import cycle.
+ * @module dsh-mimir/src/project-id
+ */
+
+/**
+ * Whether one string is safe to use as a project id in filesystem paths.
+ *
+ * `projectRecord.id` is an unconstrained `z.string()` in the durable schema,
+ * deliberately: a legacy bad row must not abort the domain open. So the
+ * checking happens where the value is used, not where it is stored, exactly
+ * as it does for arXiv ids.
+ */
+export function isValidProjectId(projectId: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(projectId)
+    && !projectId.includes('..')
+    && !projectId.startsWith('/')
+}

--- a/packages/mimir/src/services/meeting.ts
+++ b/packages/mimir/src/services/meeting.ts
@@ -25,6 +25,7 @@ import type {
 import { resolvePaperDir } from '../paper-source.ts'
 import { listPaperFigures, type FigureFile } from '../artifacts.ts'
 import { isValidArxivId } from '../arxiv-id.ts'
+import { isValidProjectId } from '../project-id.ts'
 import { extractPaperFigures, resolvePaperPdf } from './paper-figures.ts'
 import { fetchPaperPdf } from './library.ts'
 import {
@@ -478,6 +479,12 @@ export async function generateMeetingDeck(
 ): Promise<ResearchGenerateMeetingResult> {
   const project = deps.domain.table('projects').get(request.projectId)
   if (project === undefined) return rejected({ code: 'project-not-found', projectId: request.projectId })
+  // Checked before any work: this is the site that *creates*
+  // `meetings/<projectId>/`, so an unsafe id here would mkdir outside the
+  // workspace rather than merely read outside it.
+  if (!isValidProjectId(project.id)) {
+    return rejected({ code: 'invalid-path', path: project.id })
+  }
   const include: MeetingInclude = { ...DEFAULT_INCLUDE, ...(request.include ?? {}) }
 
   const allPapers = [...deps.domain.table('papers').entries()].map(([, record]) => record)
@@ -606,6 +613,12 @@ export async function listMeetingDecks(
 ): Promise<ResearchMeetingDecksResult> {
   const project = deps.domain.table('projects').get(request.projectId)
   if (project === undefined) return rejected({ code: 'project-not-found', projectId: request.projectId })
+  // The stored id is unconstrained `z.string()`, so it is checked here rather
+  // than trusted: an imported snapshot predating the import guard could still
+  // hold `../../x`, and this joins it into a filesystem path.
+  if (!isValidProjectId(project.id)) {
+    return rejected({ code: 'invalid-path', path: project.id })
+  }
   const meetingsDir = join(deps.workspaceDir, MEETINGS_DIR_NAME, project.id)
   let names: string[]
   try {
@@ -636,6 +649,9 @@ export async function deleteMeetingDeck(
   if (file === '' || extname(file).toLowerCase() !== '.pptx') {
     return rejected({ code: 'invalid-input', message: 'file must name a .pptx deck' })
   }
+  if (!isValidProjectId(project.id)) {
+    return rejected({ code: 'invalid-path', path: project.id })
+  }
   try {
     await unlink(join(deps.workspaceDir, MEETINGS_DIR_NAME, project.id, file))
   } catch {
@@ -650,6 +666,9 @@ export function meetingDeckPath(
   projectId: string,
   file: string,
 ): string | undefined {
+  // `file` is already reduced to a basename below; `projectId` was not
+  // checked at all, and it is the other half of the same path.
+  if (!isValidProjectId(projectId)) return undefined
   const name = basename(file)
   if (name === '' || extname(name).toLowerCase() !== '.pptx') return undefined
   return join(workspaceDir, MEETINGS_DIR_NAME, projectId, name)

--- a/packages/mimir/src/services/wiki-admin.ts
+++ b/packages/mimir/src/services/wiki-admin.ts
@@ -8,6 +8,7 @@
 
 import { readdir } from 'node:fs/promises'
 import { isValidArxivId } from '../arxiv-id.ts'
+import { isValidProjectId } from '../project-id.ts'
 import { isBackupFileName } from '../backup.ts'
 import {
   buildWikiSnapshot,
@@ -171,6 +172,13 @@ export async function importWiki(
       // explicitly: a snapshot paper with a path-unsafe id is skipped, not
       // written.
       if (name === 'papers' && !isValidArxivId(key)) {
+        skipped[name] += 1
+        continue
+      }
+      // Same rule for projects: the id joins `meetings/<projectId>/`, so a
+      // snapshot row carrying `../../x` would let a later deck request escape
+      // the workspace. Skipped rather than written, as above.
+      if (name === 'projects' && !isValidProjectId(key)) {
         skipped[name] += 1
         continue
       }

--- a/packages/mimir/tests/project-id.spec.ts
+++ b/packages/mimir/tests/project-id.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Behavior tests for the shared project-id path-safety predicate and its
+ * enforcement points (#140).
+ *
+ * `projectRecord.id` is an unconstrained `z.string()` and joins filesystem
+ * paths as `meetings/<projectId>/`, so an imported wiki snapshot carrying
+ * `projectId: "../../x"` could take a later deck request outside the
+ * workspace. The id is now checked at import and at every path join, the same
+ * split `isValidArxivId` already uses.
+ *
+ * Mirrors `arxiv-id.spec.ts`: the predicate, then each place that must apply
+ * it.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { isValidProjectId } from '../src/project-id.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import { ResearchService } from '../src/service.ts'
+import { meetingDeckPath } from '../src/services/meeting.ts'
+import type { ProjectRecord } from '../src/types.ts'
+
+/** The traversal id from the issue, plus its neighbours. */
+const TRAVERSAL = '../../x'
+
+describe('isValidProjectId', () => {
+  it('accepts the ids this codebase actually generates', () => {
+    // `createProject` uses randomUUID; `import-project` uses `slugify`, which
+    // emits [a-z0-9-]. Both must keep passing.
+    expect(isValidProjectId('3f1c9d0e-2b7a-4c55-9a11-8de0f6b21c34')).toBe(true)
+    expect(isValidProjectId('my-imported-paper')).toBe(true)
+    expect(isValidProjectId('project')).toBe(true)
+    expect(isValidProjectId('p1')).toBe(true)
+    expect(isValidProjectId('v1.2_final')).toBe(true)
+  })
+
+  it('rejects traversal, absolute paths, separators, and empty input', () => {
+    expect(isValidProjectId(TRAVERSAL)).toBe(false)
+    expect(isValidProjectId('..')).toBe(false)
+    expect(isValidProjectId('a/../b')).toBe(false)
+    expect(isValidProjectId('/etc/passwd')).toBe(false)
+    expect(isValidProjectId('..\\windows')).toBe(false)
+    expect(isValidProjectId('C:/temp')).toBe(false)
+    expect(isValidProjectId('')).toBe(false)
+    expect(isValidProjectId('some id')).toBe(false)
+  })
+
+  it('rejects a plain separator even without traversal', () => {
+    // Unlike an arXiv id, a project id is one directory name. A slash is not
+    // an escape on its own, but it takes the deck out of the directory the
+    // caller named, so it is not a valid id either.
+    expect(isValidProjectId('a/b')).toBe(false)
+  })
+})
+
+/** Boot a service over a memory-backed domain and a fresh temp workspace. */
+async function harness() {
+  const ctx = new Context()
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  const domain = await facility.open(researchWikiDomainSpec)
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-project-id-'))
+  const service = new ResearchService(ctx, {
+    workspaceDir,
+    domain,
+    latex: { engine: 'auto', timeoutMs: 1000 },
+    meetings: { fetchPdf: async () => undefined },
+  })
+  return { ctx, domain, workspaceDir, service }
+}
+
+const UNSAFE_PROJECT: ProjectRecord = {
+  id: TRAVERSAL,
+  title: 'escaped',
+  stage: 'idea',
+  artifacts: [],
+  reviewRounds: 0,
+  updatedAt: '2026-08-20T00:00:00.000Z',
+}
+
+describe('project-id enforcement', () => {
+  it('meetingDeckPath resolves nothing for a traversal id', () => {
+    // The download route's resolver. `file` was already reduced to a
+    // basename; the project id was the unchecked half of the same path.
+    expect(meetingDeckPath('/workspace', TRAVERSAL, 'deck.pptx')).toBeUndefined()
+    expect(meetingDeckPath('/workspace', 'p1', 'deck.pptx')).toBeDefined()
+  })
+
+  it('meetingDeckPath stays inside the meetings directory for a valid id', () => {
+    const resolved = meetingDeckPath('/workspace', 'p1', 'deck.pptx')
+    expect(resolved).toBe(join('/workspace', 'meetings', 'p1', 'deck.pptx'))
+  })
+
+  it('generating a deck for a traversal id is refused, not mkdir-ed', async () => {
+    const { domain, service } = await harness()
+    // Written straight to the table, as a pre-existing bad row would be.
+    await domain.table('projects').put(UNSAFE_PROJECT.id, UNSAFE_PROJECT)
+
+    const result = await service.generateMeetingDeck({ projectId: TRAVERSAL, title: 'x' })
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'invalid-path' } })
+  })
+
+  it('listing decks for a traversal id is refused', async () => {
+    const { domain, service } = await harness()
+    await domain.table('projects').put(UNSAFE_PROJECT.id, UNSAFE_PROJECT)
+
+    const result = await service.listMeetingDecks({ projectId: TRAVERSAL })
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'invalid-path' } })
+  })
+
+  it('deleting a deck under a traversal id is refused', async () => {
+    const { domain, service } = await harness()
+    await domain.table('projects').put(UNSAFE_PROJECT.id, UNSAFE_PROJECT)
+
+    const result = await service.deleteMeetingDeck({ projectId: TRAVERSAL, file: 'a.pptx' })
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'invalid-path' } })
+  })
+
+  it('importWiki skips a project row with a path-unsafe id', async () => {
+    // The route in the issue: an untrusted snapshot is the thing that can
+    // introduce such an id in the first place.
+    const { domain, service } = await harness()
+    const result = await service.importWiki({
+      mode: 'merge',
+      snapshot: {
+        format: 'mimir-wiki',
+        version: 2,
+        exportedAt: '2026-08-20T00:00:00.000Z',
+        tables: {
+          papers: [], ideas: [], claims: [], experiments: [], servers: [], figures: [], events: [],
+          projects: [UNSAFE_PROJECT, { ...UNSAFE_PROJECT, id: 'good-project', title: 'fine' }],
+        },
+      } as never,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.skipped.projects).toBe(1)
+    expect(result.value.imported.projects).toBe(1)
+    // The unsafe row is not in the table at all, so nothing downstream can
+    // reach it even if a later caller forgets to check.
+    expect(domain.table('projects').get(TRAVERSAL)).toBeUndefined()
+    expect(domain.table('projects').get('good-project')).toBeDefined()
+  })
+
+  it('a normal project still generates and lists decks', async () => {
+    // The guard must not fire on the ordinary path.
+    const { domain, service, workspaceDir } = await harness()
+    await domain.table('projects').put('p1', { ...UNSAFE_PROJECT, id: 'p1', title: 'fine' })
+
+    const generated = await service.generateMeetingDeck({ projectId: 'p1', title: 'Weekly' })
+    expect(generated.ok).toBe(true)
+    if (!generated.ok) return
+
+    const listed = await service.listMeetingDecks({ projectId: 'p1' })
+    expect(listed.ok).toBe(true)
+    expect(meetingDeckPath(workspaceDir, 'p1', generated.value.file)).toBeDefined()
+  })
+})


### PR DESCRIPTION
Closes #140. Follows the `isValidArxivId` pattern the issue points at, including its split: the durable schema stays unconstrained (a legacy bad row must not abort the domain open) and the checking happens where the value is used.

### One character stricter than the arXiv predicate

`isValidProjectId` excludes `/`. An arXiv id legitimately contains one — `hep-th/9901001` — but a project id is a single directory name, so a slash is not an escape on its own yet still takes the deck out of the directory the caller named.

I checked that against both generators before narrowing it: `createProject` uses `randomUUID()`, and `import-project` uses `slugify()`, which emits `[a-z0-9-]`. Every id this codebase produces passes, and there is a test asserting exactly that so the charset cannot be tightened into rejecting real data later.

### A fourth call site the issue did not list

The issue names `meeting.ts:609/640/655`. There is also **line 592**, in `generateMeetingDeck`, and it is the more serious one: it is the site that `mkdir`s `meetings/<projectId>/`, so an unsafe id there would *create* a directory outside the workspace rather than only read outside it. Guarded too, before any deck work starts.

So: import + four joins, not import + three.

### Tests — 10, mirroring `arxiv-id.spec.ts`

The predicate (ids this codebase really generates; traversal, absolute paths, backslashes, drive letters, spaces, empty, and a bare separator), then each enforcement point refused `../../x`: `meetingDeckPath`, generate, list, delete. Plus `importWiki` skipping the bad row **while importing its good sibling in the same snapshot** — so the guard is shown to be selective, not just refusing — and a control that a normal project still generates and lists decks.

Verified the tests bite: with both source files reverted, **4 failed / 6 passed**. With the fix, 10 passed.

`tsc -b packages/mimir` clean. Full suite: **22 failed / 1074 passed on `main`, 22 failed / 1084 passed here** — the ten new tests, zero newly failing. The 22 are pre-existing on my machine.
