### PR TITLE
fix(ledger): guard an inverted moment window, and declare a truncated lookback

### DIFF
--- a/packages/mimir/src/services/ledger.ts
+++ b/packages/mimir/src/services/ledger.ts
@@ -118,7 +118,17 @@ function resolveWindow(
   spanDays: number,
 ): { readonly since: string; readonly until: string } {
   const untilIso = until ?? new Date().toISOString()
-  if (since !== undefined) return { since, until: untilIso }
+  if (since !== undefined) {
+    // An inverted window is not an empty window. Passed through, every read
+    // below returns nothing and the view reports that as "no activity" --
+    // indistinguishable from a genuinely quiet period, which is the one
+    // reading these organs must never get wrong. Swapping the bounds is the
+    // interpretation the caller can only have meant.
+    if (Date.parse(since) > Date.parse(untilIso)) {
+      return { since: untilIso, until: since }
+    }
+    return { since, until: untilIso }
+  }
   const parsed = Date.parse(untilIso)
   const anchor = Number.isNaN(parsed) ? Date.now() : parsed
   return { since: new Date(anchor - spanDays * MS_PER_DAY).toISOString(), until: untilIso }
@@ -1163,6 +1173,12 @@ export async function getMomentIndexRemote(
       since: prefixSince,
       until: window.until,
     }, 'moment index lookback')
+    // The lookback is what dormancy and lane-opening are judged against, and
+    // `loadLedgerWindow` keeps the NEWEST events when it caps. So a truncated
+    // prefix drops exactly the oldest history those judgements need, and a
+    // line that was dormant reads as one that was never seen. That has to be
+    // declared: a silence derived from a short prefix is a guess.
+    const lookbackTruncated = prefixFolded.truncated
     // Merge window + prefix (dedupe by id) — the fold sorts canonically.
     const seen = new Set(folded.events.map(event => event.id))
     const merged = [...folded.events, ...prefixFolded.events.filter(event => !seen.has(event.id))]
@@ -1198,10 +1214,15 @@ export async function getMomentIndexRemote(
       retrieval: Object.freeze({
         eventsHit: folded.events.length,
         eventsTotal: folded.total,
-        truncated: folded.truncated,
-        silences: Object.freeze(folded.truncated
-          ? [`events truncated: window matched ${folded.total}, fold cap ${LIST_EVENTS_MAX_LIMIT}, folded newest ${folded.events.length}`]
-          : []),
+        truncated: folded.truncated || lookbackTruncated,
+        silences: Object.freeze([
+          ...(folded.truncated
+            ? [`events truncated: window matched ${folded.total}, fold cap ${LIST_EVENTS_MAX_LIMIT}, folded newest ${folded.events.length}`]
+            : []),
+          ...(lookbackTruncated
+            ? [`lookback truncated: prefix matched ${prefixFolded.total}, fold cap ${LIST_EVENTS_MAX_LIMIT}, folded newest ${prefixFolded.events.length} — dormancy and lane-opening judgements may be missing older history`]
+            : []),
+        ]),
       }),
       speaks,
       moments: Object.freeze(moments),

--- a/packages/mimir/tests/moment-index-window.spec.ts
+++ b/packages/mimir/tests/moment-index-window.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Two moment-index follow-ups from #127, tracked as item 3 of #143.
+ *
+ *  - `resolveWindow` accepted `since > until`. An inverted window reads as an
+ *    empty one, and "no events" is rendered as a quiet period -- which is the
+ *    one thing these organs must not confuse, since dormancy is a signal here
+ *    rather than an absence of signal.
+ *  - `getMomentIndex`'s lookback prefix could be truncated without saying so.
+ *    `loadLedgerWindow` keeps the NEWEST events when it caps, so a truncated
+ *    prefix drops exactly the oldest history that dormancy and lane-opening
+ *    are judged against.
+ *
+ * @module dsh-mimir/tests/moment-index-window
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
+import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
+import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
+import { researchWikiDomainSpec } from '../src/store.ts'
+import { ResearchService } from '../src/service.ts'
+import { LIST_EVENTS_MAX_LIMIT } from '../src/ledger.ts'
+import type { EventRecord, LedgerActor } from '../src/types.ts'
+
+const USER: LedgerActor = { kind: 'user', id: 'panel' }
+
+/** Boot a service over a memory-backed domain and a fresh temp workspace. */
+async function serviceHarness() {
+  const ctx = new Context()
+  await ctx.plugin(Storage)
+  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  ctx.storage.backend.register('memory', backend)
+  ctx.provide(storageBackendServiceKey('memory'), backend)
+  const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
+  ctx.storage.mount('domain', facility)
+  const domain = await facility.open(researchWikiDomainSpec)
+  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-moment-window-'))
+  const service = new ResearchService(ctx, {
+    workspaceDir,
+    domain,
+    latex: { engine: 'auto', timeoutMs: 1000 },
+  })
+  return { domain, service }
+}
+
+function eventAt(index: number, ts: string): EventRecord {
+  return Object.freeze({
+    id: `ev-${String(index).padStart(5, '0')}`,
+    ts,
+    actor: USER,
+    action: 'knowledge.idea.added',
+    refs: Object.freeze({}),
+    payload: Object.freeze({}),
+  }) as EventRecord
+}
+
+describe('moment index window bounds', () => {
+  it('an inverted since/until is normalised rather than read as empty', async () => {
+    const { domain, service } = await serviceHarness()
+    for (let index = 0; index < 5; index += 1) {
+      const ts = `2026-08-${String(10 + index).padStart(2, '0')}T00:00:00.000Z`
+      await domain.table('events').put(`ev-${String(index)}`, eventAt(index, ts))
+    }
+
+    // Bounds the wrong way round. Before the guard this returned a window
+    // that matched nothing, and the view reported it as a quiet period.
+    const inverted = await service.getMomentIndex({
+      since: '2026-08-20T00:00:00.000Z',
+      until: '2026-08-01T00:00:00.000Z',
+    })
+
+    expect(inverted.ok).toBe(true)
+    if (!inverted.ok) return
+    expect(new Date(inverted.value.window.since).getTime()).toBeLessThanOrEqual(
+      new Date(inverted.value.window.until).getTime(),
+    )
+    expect(inverted.value.window.since).toBe('2026-08-01T00:00:00.000Z')
+    expect(inverted.value.window.until).toBe('2026-08-20T00:00:00.000Z')
+    // And it now sees the events that fall inside the corrected span.
+    expect(inverted.value.retrieval.eventsTotal).toBeGreaterThan(0)
+  })
+
+  it('an inverted window returns the same view as the corrected one', async () => {
+    const { domain, service } = await serviceHarness()
+    for (let index = 0; index < 5; index += 1) {
+      const ts = `2026-08-${String(10 + index).padStart(2, '0')}T00:00:00.000Z`
+      await domain.table('events').put(`ev-${String(index)}`, eventAt(index, ts))
+    }
+
+    const inverted = await service.getMomentIndex({
+      since: '2026-08-20T00:00:00.000Z',
+      until: '2026-08-01T00:00:00.000Z',
+    })
+    const correct = await service.getMomentIndex({
+      since: '2026-08-01T00:00:00.000Z',
+      until: '2026-08-20T00:00:00.000Z',
+    })
+
+    expect(inverted.ok && correct.ok).toBe(true)
+    if (!inverted.ok || !correct.ok) return
+    expect(inverted.value.window).toEqual(correct.value.window)
+    expect(inverted.value.retrieval.eventsTotal).toBe(correct.value.retrieval.eventsTotal)
+  })
+
+  it('an ordinary window is untouched', async () => {
+    const { service } = await serviceHarness()
+    const result = await service.getMomentIndex({
+      since: '2026-08-01T00:00:00.000Z',
+      until: '2026-08-20T00:00:00.000Z',
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.window.since).toBe('2026-08-01T00:00:00.000Z')
+    expect(result.value.window.until).toBe('2026-08-20T00:00:00.000Z')
+  })
+
+  it('equal bounds stay equal rather than being swapped', async () => {
+    const { service } = await serviceHarness()
+    const at = '2026-08-10T00:00:00.000Z'
+    const result = await service.getMomentIndex({ since: at, until: at })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.window).toEqual({ since: at, until: at })
+  })
+
+  it('a malformed bound is still rejected, not swapped', async () => {
+    const { service } = await serviceHarness()
+    const result = await service.getMomentIndex({ since: 'not-a-date' })
+    expect(result).toMatchObject({ ok: false, error: { code: 'invalid-input' } })
+  })
+})
+
+describe('moment index lookback truncation', () => {
+  it('declares a truncated lookback as a silence', async () => {
+    // The lookback prefix reaches further back than the window, so it is the
+    // first of the two to hit the cap. Filling only the prefix span proves
+    // the new silence comes from the prefix rather than the window.
+    const { domain, service } = await serviceHarness()
+
+    const total = LIST_EVENTS_MAX_LIMIT + 50
+    const base = Date.parse('2026-08-20T00:00:00.000Z')
+    for (let index = 0; index < total; index += 1) {
+      // Spread across the prefix span, all before the window's `since`.
+      const ts = new Date(base - (index + 1) * 60_000).toISOString()
+      await domain.table('events').put(`ev-${String(index)}`, eventAt(index, ts))
+    }
+
+    const result = await service.getMomentIndex({
+      since: '2026-08-20T00:00:00.000Z',
+      until: '2026-08-21T00:00:00.000Z',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.retrieval.truncated).toBe(true)
+    const silences = result.value.retrieval.silences.join(' ')
+    expect(silences).toContain('lookback truncated')
+    // The message has to say *what it costs*, not merely that it happened.
+    expect(silences).toMatch(/dormancy/i)
+  })
+
+  it('reports no silence when nothing was truncated', async () => {
+    const { domain, service } = await serviceHarness()
+    for (let index = 0; index < 5; index += 1) {
+      const ts = `2026-08-${String(10 + index).padStart(2, '0')}T00:00:00.000Z`
+      await domain.table('events').put(`ev-${String(index)}`, eventAt(index, ts))
+    }
+
+    const result = await service.getMomentIndex({
+      since: '2026-08-01T00:00:00.000Z',
+      until: '2026-08-20T00:00:00.000Z',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.retrieval.truncated).toBe(false)
+    expect(result.value.retrieval.silences).toEqual([])
+  })
+})


### PR DESCRIPTION
Item 3 of #143 — the two moment-candidate follow-ups from #127. Scoped to that item only; items 1, 2 and 4 are separate pieces of work and I'd rather they land with their own gates than get bundled here.

### `resolveWindow` accepted `since > until`

Passed straight through, so every read below matched nothing and the view rendered it as a **quiet period**. That is the one reading these organs must not get wrong: dormancy is a signal here, not an absence of one, so "the caller inverted their bounds" and "nothing happened" were indistinguishable in the output.

The bounds are now swapped, which is the only thing the caller can have meant. Two boundaries kept deliberately: **equal bounds stay equal** rather than being churned through the swap, and a **malformed bound is still rejected** by the existing `Date.parse` guard rather than silently reordered.

### The lookback prefix could be truncated in silence

`loadLedgerWindow` keeps the **newest** events when it hits `LIST_EVENTS_MAX_LIMIT`. The lookback prefix reaches further back than the window precisely so dormancy and lane-opening can be judged — so a truncated prefix drops *exactly the oldest history those judgements need*, and a line that went quiet reads as a line that was never there.

`prefixFolded.truncated` was computed and discarded. It now feeds `retrieval.truncated` and adds its own line to `silences`. The message names the **consequence**, not just the fact:

```
lookback truncated: prefix matched 1050, fold cap 1000, folded newest 1000 —
dormancy and lane-opening judgements may be missing older history
```

A reader who is told "truncated" and not told what it cost them cannot act on it.

### Tests — 7

Inverted bounds normalised; inverted call returns the *same view* as the corrected one (which is the property that matters, not just that the bounds got reordered); ordinary bounds untouched; equal bounds untouched; malformed bound still rejected; a truncated lookback declared **with** its consequence; and no silence when nothing was truncated.

The truncation test fills only the prefix span, all events before the window's `since`, so the new silence is provably coming from the prefix rather than the window.

**Verified 3 of the 7 fail with `ledger.ts` reverted** — two for the window guard, one for the lookback.

`tsc -b packages/mimir` clean. Full suite: **22 failed / 1074 passed on `main`, 22 failed / 1081 passed here** — the seven new tests, zero newly failing.
