### PR TITLE
fix(venues): count calendar days, and resolve PT through the IANA zone

### DIFF
--- a/packages/mimir/src/venue-deadlines.ts
+++ b/packages/mimir/src/venue-deadlines.ts
@@ -58,11 +58,60 @@ export interface VenueNextDeadline {
   readonly atMs: number
 }
 
+/** The IANA zone the ccfddl `PT` label means. */
+const PACIFIC_ZONE = 'America/Los_Angeles'
+
+/**
+ * Pacific's UTC offset at one wall-clock date, in milliseconds.
+ *
+ * A fixed -8 is wrong for two thirds of the year, and wrong in the direction
+ * that costs a submission: during PDT it places the deadline an hour later
+ * than it is, so the countdown shows time that has already passed.
+ *
+ * Resolved by asking `Intl` what the zone's local time is for a UTC instant
+ * and taking the difference. The first pass uses a standard-time guess; the
+ * second re-resolves at that instant, which is what gets a date inside PDT
+ * right. `-7` is the fallback if `Intl` has no zone data, because erring
+ * toward the *earlier* instant is the safe half of the ambiguity.
+ */
+function pacificOffsetMs(wall: RegExpExecArray): number {
+  const asUtc = Date.UTC(
+    Number(wall[1]), Number(wall[2]) - 1, Number(wall[3]),
+    Number(wall[4]), Number(wall[5]), Number(wall[6] ?? '0'),
+  )
+  try {
+    const resolve = (instantMs: number): number => {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: PACIFIC_ZONE,
+        hourCycle: 'h23',
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+      }).formatToParts(new Date(instantMs))
+      const at = (type: string): number =>
+        Number(parts.find(part => part.type === type)?.value ?? '0')
+      const local = Date.UTC(
+        at('year'), at('month') - 1, at('day'), at('hour'), at('minute'), at('second'),
+      )
+      return local - instantMs
+    }
+    // Two passes: the first offset is measured at the wrong instant when the
+    // wall time is inside PDT, the second at the corrected one.
+    const first = resolve(asUtc)
+    return resolve(asUtc - first)
+  } catch {
+    return -7 * 3_600_000
+  }
+}
+
 /**
  * Parse one ccfddl instant: a `YYYY-MM-DD HH:mm:ss` wall time plus a zone
  * string. The upstream file uses `AoE` (= UTC-12, the common case), `UTC±H`,
- * plain `UTC`, and a handful of `PT` (approximated as UTC-8 — the deadline
- * hour is what matters, the DST wobble is within it).
+ * plain `UTC`, and a handful of `PT`.
+ *
+ * `PT` is resolved through the IANA zone rather than a fixed UTC-8. During
+ * PDT the fixed offset put the instant an hour later than it really is, which
+ * is the dangerous direction: the countdown said there was an hour left that
+ * had already gone.
  * @param value - the wall-time string.
  * @param timezone - the zone string.
  * @returns epoch milliseconds, or null for an unparseable pair.
@@ -73,7 +122,7 @@ export function parseCcfddlInstant(value: string, timezone: string): number | nu
   const zoneRaw = timezone.trim()
   let offsetMs: number
   if (/^aoe$/i.test(zoneRaw)) offsetMs = -12 * 3_600_000
-  else if (/^pt$/i.test(zoneRaw)) offsetMs = -8 * 3_600_000
+  else if (/^pt$/i.test(zoneRaw)) offsetMs = pacificOffsetMs(wall)
   else if (/^utc$/i.test(zoneRaw)) offsetMs = 0
   else {
     const zone = /^UTC([+-])(\d{1,2})(?::(\d{2}))?$/i.exec(zoneRaw)
@@ -87,9 +136,22 @@ export function parseCcfddlInstant(value: string, timezone: string): number | nu
   return utcMs - offsetMs
 }
 
-/** Whole days from `nowMs` to `atMs`, rounded up (a deadline today is 0). */
+/**
+ * Calendar days from `nowMs` to `atMs` in the host's local zone, so a
+ * deadline today is 0.
+ *
+ * `Math.ceil` on the millisecond gap does not answer that question: a
+ * deadline five minutes away is 0.003 days, which rounds up to "1 day left",
+ * and `withinDays=0` then matched nothing at all -- it excluded exactly the
+ * deadlines it most needed to show. Truncating both ends to a local date
+ * counts the boundaries a person actually reads.
+ */
 export function daysUntil(atMs: number, nowMs: number): number {
-  return Math.ceil((atMs - nowMs) / 86_400_000)
+  const startOfLocalDay = (ms: number): number => {
+    const date = new Date(ms)
+    return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  }
+  return Math.round((startOfLocalDay(atMs) - startOfLocalDay(nowMs)) / 86_400_000)
 }
 
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- the YAML is

--- a/packages/mimir/tests/venue-deadlines.spec.ts
+++ b/packages/mimir/tests/venue-deadlines.spec.ts
@@ -89,8 +89,24 @@ describe('parseCcfddlInstant', () => {
     expect(parseCcfddlInstant('2026-01-01 00:00:00', 'UTC')).toBe(Date.UTC(2026, 0, 1, 0, 0, 0))
   })
 
-  it('approximates PT as UTC-8', () => {
+  it('resolves PT through the IANA zone, so PST and PDT differ', () => {
+    // January is PST (UTC-8) -- unchanged from the old fixed offset.
     expect(parseCcfddlInstant('2026-01-01 00:00:00', 'PT')).toBe(Date.UTC(2026, 0, 1, 8, 0, 0))
+    // July is PDT (UTC-7). The fixed -8 put this an hour later than it is,
+    // which is the direction that costs a submission: the countdown showed
+    // an hour that had already gone.
+    expect(parseCcfddlInstant('2026-07-15 23:59:00', 'PT')).toBe(Date.UTC(2026, 6, 16, 6, 59, 0))
+  })
+
+  it('places a PT deadline on the correct side of a DST transition', () => {
+    // 2026-03-08 02:00 local is when PST becomes PDT.
+    expect(parseCcfddlInstant('2026-03-07 12:00:00', 'PT')).toBe(Date.UTC(2026, 2, 7, 20, 0, 0))
+    expect(parseCcfddlInstant('2026-03-09 12:00:00', 'PT')).toBe(Date.UTC(2026, 2, 9, 19, 0, 0))
+  })
+
+  it('leaves the other zones alone', () => {
+    expect(parseCcfddlInstant('2026-07-15 23:59:00', 'AoE')).toBe(Date.UTC(2026, 6, 16, 11, 59, 0))
+    expect(parseCcfddlInstant('2026-07-15 23:59:00', 'UTC+8')).toBe(Date.UTC(2026, 6, 15, 15, 59, 0))
   })
 
   it('accepts missing seconds and a T separator', () => {
@@ -105,11 +121,41 @@ describe('parseCcfddlInstant', () => {
 })
 
 describe('daysUntil', () => {
-  it('rounds up whole days; a deadline today is 0 and past is negative', () => {
-    expect(daysUntil(NOW, NOW)).toBe(0)
-    expect(daysUntil(NOW + 1, NOW)).toBe(1)
-    expect(daysUntil(NOW + 86_400_000, NOW)).toBe(1)
-    expect(daysUntil(NOW - 86_400_000, NOW)).toBe(-1)
+  /** Local midnight, so the calendar-day arithmetic is not zone-dependent. */
+  const localNoon = (year: number, month: number, day: number, hour = 12): number =>
+    new Date(year, month, day, hour).getTime()
+
+  it('counts calendar days: a deadline later today is 0', () => {
+    const now = localNoon(2026, 0, 1)
+    expect(daysUntil(now, now)).toBe(0)
+    // The case the old `Math.ceil` got wrong. A deadline a millisecond, five
+    // minutes or eleven hours away is still today, and `withinDays=0` has to
+    // match it -- that filter was excluding exactly the deadlines it most
+    // needed to show.
+    expect(daysUntil(now + 1, now)).toBe(0)
+    expect(daysUntil(now + 5 * 60_000, now)).toBe(0)
+    expect(daysUntil(localNoon(2026, 0, 1, 23), now)).toBe(0)
+  })
+
+  it('counts tomorrow as 1 however few hours away it is', () => {
+    const now = localNoon(2026, 0, 1, 23)
+    // One hour later, but the next calendar day.
+    expect(daysUntil(localNoon(2026, 0, 2, 0), now)).toBe(1)
+    expect(daysUntil(localNoon(2026, 0, 2, 23), now)).toBe(1)
+  })
+
+  it('counts whole days forward and negative days backward', () => {
+    const now = localNoon(2026, 0, 1)
+    expect(daysUntil(localNoon(2026, 0, 8), now)).toBe(7)
+    expect(daysUntil(localNoon(2025, 11, 31), now)).toBe(-1)
+    expect(daysUntil(localNoon(2025, 11, 25), now)).toBe(-7)
+  })
+
+  it('is not thrown off by a DST transition in between', () => {
+    // Truncating to a local date rather than dividing a millisecond gap: the
+    // 23-hour spring-forward day still counts as one day.
+    expect(daysUntil(localNoon(2026, 2, 9), localNoon(2026, 2, 8))).toBe(1)
+    expect(daysUntil(localNoon(2026, 10, 2), localNoon(2026, 10, 1))).toBe(1)
   })
 })
 


### PR DESCRIPTION
Items **1 and 2** of #142, taken together because they are the same failure: both make the countdown wrong in the direction that costs a submission. The other four items are independent and I'd rather they land separately.

### 1. `Math.ceil` on a millisecond gap is not a day count

A deadline five minutes away is `0.003` days, which rounds up to **"1 day left"**, and `withinDays=0` then matched nothing — the filter excluded exactly the deadlines it most needed to show.

The function's own docstring already said *"a deadline today is 0"*. It now truncates both ends to a local calendar date, which is the question a reader is actually asking, and is incidentally immune to the 23- and 25-hour days a millisecond division gets wrong.

### 2. `PT` was a fixed UTC-8

Right for four months a year, an hour late for the other eight — placing the deadline **later** than it is, so the countdown displayed time that had already gone.

It now resolves `America/Los_Angeles` through `Intl`. Two passes, because the first offset is measured at the wrong instant when the wall time is inside PDT and the second at the corrected one. The fallback when `Intl` carries no zone data is `-7`, since erring toward the *earlier* instant is the safe half of the ambiguity — the same reasoning the issue offers.

Verified against real dates:

```
2026-07-15 23:59 PT -> 2026-07-16T06:59:00Z   (PDT, UTC-7)
2026-01-15 23:59 PT -> 2026-01-16T07:59:00Z   (PST, UTC-8)
2026-07-15 23:59 AoE -> 2026-07-16T11:59:00Z  (unchanged)
```

### Two existing tests pinned the old behaviour — flagging that explicitly

Changing a test to match new behaviour is the thing worth scrutinising in this diff, so:

- **`'approximates PT as UTC-8'`** — its January assertion is *unchanged and still passes* (January really is UTC-8). It gains a July assertion and a pair either side of the 2026-03-08 transition, and the name now describes what it checks.
- **`daysUntil`** asserted `daysUntil(NOW + 1, NOW) === 1`. That is the bug written down as a requirement: one millisecond is not one day. It is now `0`, alongside five-minutes-away, later-today, tomorrow-however-close, whole days forward and backward, and both DST transitions.

Nothing was deleted; both grew.

AoE and `UTC±H` are untouched, with a test saying so.

`tsc -b packages/mimir` clean. `venue-deadlines.spec.ts`: 36 passed. Full suite: **22 failed / 1074 passed on `main`, 22 failed / 1079 passed here** — zero newly failing.
