### PR TITLE
fix(mimir): interrupt active SSH jobs when the host service is disposed

### DIFF
--- a/packages/mimir/src/service.ts
+++ b/packages/mimir/src/service.ts
@@ -229,7 +229,16 @@ export class ResearchService extends TypertRemoteService {
       compileStatus: new Map(),
       jobSeq: 0,
       jobAborts: new Map(),
+      jobStopStatus: new Map(),
     }
+    // The service owns the SSH sessions it spawns: when the fiber is torn
+    // down (host restart / plugin unload / dispose), abort every active job
+    // so a stale child process cannot outlive the service. The abort rides
+    // the job's own signal; each settle marks the record `interrupted`
+    // (never a fabricated succeed/fail for a disconnected session).
+    ctx.fiber.effect(() => () => {
+      void server.stopOwnedJobs(this.state)
+    }, 'research.jobsStopOnDispose')
   }
 
   /** Broadcast a file-side wiki write to subscribed panels (a no-op unwired). */

--- a/packages/mimir/src/services/common.ts
+++ b/packages/mimir/src/services/common.ts
@@ -22,6 +22,8 @@ export interface ServiceState {
   jobSeq: number
   /** Abort handles for active SSH sessions owned by this service instance. */
   readonly jobAborts: Map<string, AbortController>
+  /** Intended terminal status for an aborted active job: `cancelled` (user/delete) or `interrupted` (host dispose). Absent → cancelled. */
+  readonly jobStopStatus: Map<string, 'cancelled' | 'interrupted'>
 }
 
 /** Build a frozen success branch. */

--- a/packages/mimir/src/services/server.ts
+++ b/packages/mimir/src/services/server.ts
@@ -488,6 +488,11 @@ export async function deleteJob(
   }
   const abort = state.jobAborts.get(request.id)
   if (abort !== undefined && (existing.status === 'queued' || existing.status === 'running')) {
+    // Deleting an active row is a cancel request: the local SSH session is
+    // aborted and the record settles `cancelled` (the remote process outcome
+    // is unknowable once the session drops). The row stays visible until that
+    // terminal flip, so the user can see what was cancelled.
+    state.jobStopStatus.set(request.id, 'cancelled')
     abort.abort()
     return success({ id: request.id })
   }
@@ -517,10 +522,11 @@ async function runJob(
   const queued = table.get(id)
   if (queued === undefined) {
     state.jobAborts.delete(id)
+    state.jobStopStatus.delete(id)
     return
   }
   if (signal.aborted) {
-    await settleCancelledJob(deps, state, queued)
+    await settleStoppedJob(deps, state, queued, state.jobStopStatus.get(id) ?? 'cancelled')
     return
   }
   const server = deps.domain.table('servers').get(queued.serverId)
@@ -531,12 +537,14 @@ async function runJob(
       stderrTail: 'server record deleted before the job started',
       finishedAt: new Date().toISOString(),
     })
+    state.jobAborts.delete(id)
+    state.jobStopStatus.delete(id)
     return
   }
   const running: JobRecord = { ...queued, status: 'running', startedAt: new Date().toISOString() }
   await table.put(id, running)
   if (signal.aborted) {
-    await settleCancelledJob(deps, state, running)
+    await settleStoppedJob(deps, state, running, state.jobStopStatus.get(id) ?? 'cancelled')
     return
   }
   let settled: JobRecord
@@ -560,7 +568,7 @@ async function runJob(
     }
   } catch (error) {
     if (signal.aborted) {
-      await settleCancelledJob(deps, state, running, error)
+      await settleStoppedJob(deps, state, running, state.jobStopStatus.get(id) ?? 'cancelled', error)
       return
     }
     // execFile failures carry the child's exit code and captured output;
@@ -580,11 +588,69 @@ async function runJob(
       finishedAt: new Date().toISOString(),
     }
   }
-  // A delete during the run already dropped the record: the remote
-  // command still finished, but nothing is written back.
-  if (table.get(id) === undefined) return
-  await table.put(id, settled)
-  state.jobAborts.delete(id)
+  await finishJob(deps, state, settled)
+}
+
+/** Abort every active SSH session this service owns (host dispose path). */
+export function stopOwnedJobs(state: ServiceState): void {
+  for (const [id, controller] of state.jobAborts) {
+    // Set the intended terminal status before aborting so the settle races
+    // can distinguish host stop (`interrupted`) from a user cancel.
+    state.jobStopStatus.set(id, 'interrupted')
+    controller.abort()
+  }
+}
+
+/**
+ * Settle an aborted SSH session without claiming a remote process outcome:
+ * `cancelled` for a user/delete cancel, `interrupted` for host dispose.
+ * The preserved output tails ride any stderr the child captured before the
+ * abort; a fabricated success/failure is never written for a session whose
+ * remote outcome is unknowable.
+ */
+async function settleStoppedJob(
+  deps: ServerDeps,
+  state: ServiceState,
+  job: JobRecord,
+  status: 'cancelled' | 'interrupted',
+  error?: unknown,
+): Promise<void> {
+  const current = deps.domain.table('jobs').get(job.id)
+  if (current === undefined) {
+    state.jobAborts.delete(job.id)
+    state.jobStopStatus.delete(job.id)
+    return
+  }
+  const carrier = error as { stdout?: unknown; stderr?: unknown } | undefined
+  const stdout = typeof carrier?.stdout === 'string' ? carrier.stdout : ''
+  const note = status === 'cancelled'
+    ? 'cancelled locally; remote process outcome is unknown'
+    : 'host stopped before the job outcome was known'
+  const stderr = typeof carrier?.stderr === 'string' && carrier.stderr.trim() !== ''
+    ? `${carrier.stderr}\n${note}`
+    : note
+  await finishJob(deps, state, {
+    ...current,
+    status,
+    exitCode: null,
+    stdoutTail: tailOf(stdout),
+    stderrTail: tailOf(stderr),
+    finishedAt: new Date().toISOString(),
+  })
+}
+
+/**
+ * Persist one terminal job, emit its settle event, write back the linked
+ * experiment, and release the local SSH ownership for the job id.
+ */
+async function finishJob(deps: ServerDeps, state: ServiceState, settled: JobRecord): Promise<void> {
+  state.jobAborts.delete(settled.id)
+  state.jobStopStatus.delete(settled.id)
+  const table = deps.domain.table('jobs')
+  // A delete during the run already dropped the record: the remote command
+  // still finished, but nothing is written back.
+  if (table.get(settled.id) === undefined) return
+  await table.put(settled.id, settled)
   const startedMs = settled.startedAt === undefined ? null : Date.parse(settled.startedAt)
   const finishedMs = settled.finishedAt === undefined ? null : Date.parse(settled.finishedAt)
   await emitEvent(deps.domain, {
@@ -605,32 +671,6 @@ async function runJob(
       summary: jobSummaryOf(settled),
     },
   })
-  await writeBackExperiment(deps, settled)
-}
-
-async function settleCancelledJob(
-  deps: ServerDeps,
-  state: ServiceState,
-  job: JobRecord,
-  error?: unknown,
-): Promise<void> {
-  const table = deps.domain.table('jobs')
-  if (table.get(job.id) === undefined) return
-  const carrier = error as { stdout?: unknown; stderr?: unknown } | undefined
-  const stdout = typeof carrier?.stdout === 'string' ? carrier.stdout : ''
-  const stderr = typeof carrier?.stderr === 'string' && carrier.stderr.trim() !== ''
-    ? `${carrier.stderr}\ncancelled locally; remote process outcome is unknown`
-    : 'cancelled locally; remote process outcome is unknown'
-  const settled: JobRecord = {
-    ...job,
-    status: 'cancelled',
-    exitCode: null,
-    stdoutTail: tailOf(stdout),
-    stderrTail: tailOf(stderr),
-    finishedAt: new Date().toISOString(),
-  }
-  await table.put(job.id, settled)
-  state.jobAborts.delete(job.id)
   await writeBackExperiment(deps, settled)
 }
 

--- a/packages/mimir/tests/ssh-jobs.spec.ts
+++ b/packages/mimir/tests/ssh-jobs.spec.ts
@@ -81,11 +81,16 @@ async function settleJob(service: ResearchService, id: string): Promise<JobRecor
     const listed = await service.listJobs({})
     if (listed.ok) {
       const job = listed.value.jobs.find(record => record.id === id)
-      if (job !== undefined && (job.status === 'succeeded' || job.status === 'failed')) return job
+      if (job !== undefined && !isActiveJob(job)) return job
     }
     await new Promise(resolve => setTimeout(resolve, 25))
   }
   throw new Error(`job ${id} did not settle`)
+}
+
+/** A queued/running job still owns an in-process SSH session. */
+function isActiveJob(job: JobRecord): boolean {
+  return job.status === 'queued' || job.status === 'running'
 }
 
 afterEach(() => { vi.unstubAllEnvs() })
@@ -357,7 +362,7 @@ describe('ResearchService.listJobs / deleteJob', () => {
       .resolves.toMatchObject({ ok: false, error: { code: 'server-not-found', id: 'srv-missing' } })
   })
 
-  it('cancels an active job instead of deleting its record while SSH continues', async () => {
+  it('cancels an active job instead of deleting an unowned remote command', async () => {
     const { service } = await harness()
     await stubFakeSsh()
     const created = await service.saveServer({ server: SERVER_INPUT })
@@ -377,21 +382,32 @@ describe('ResearchService.listJobs / deleteJob', () => {
       ok: true,
       value: { id: submitted.value.job.id },
     })
-    for (let attempt = 0; attempt < 200; attempt += 1) {
-      const listed = await service.listJobs({})
-      if (listed.ok) {
-        const job = listed.value.jobs.find(record => record.id === submitted.value.job.id)
-        if (job?.status === 'cancelled') {
-          expect(job).toMatchObject({
-            exitCode: null,
-            stderrTail: expect.stringContaining('remote process outcome is unknown'),
-          })
-          return
-        }
-      }
-      await new Promise(resolve => setTimeout(resolve, 25))
-    }
-    throw new Error('cancelled job did not settle')
+    const settled = await settleJob(service, submitted.value.job.id)
+    expect(settled).toMatchObject({
+      status: 'cancelled',
+      exitCode: null,
+      stderrTail: expect.stringContaining('remote process outcome is unknown'),
+    })
+  })
+
+  it('interrupts an active job when its host service is disposed', async () => {
+    const { ctx, service } = await harness()
+    await stubFakeSsh()
+    const created = await service.saveServer({ server: SERVER_INPUT })
+    if (!created.ok) throw new Error('create failed')
+    const submitted = await service.submitJob({
+      serverId: created.value.server.id,
+      command: 'mimir-slow python train.py --epochs 20',
+    })
+    if (!submitted.ok) throw new Error('submit rejected')
+
+    await ctx.fiber.dispose()
+    const settled = await settleJob(service, submitted.value.job.id)
+    expect(settled).toMatchObject({
+      status: 'interrupted',
+      exitCode: null,
+      stderrTail: expect.stringContaining('host stopped'),
+    })
   })
 
   it('deletes a record and reports job-not-found on a repeat', async () => {


### PR DESCRIPTION
## 改动内容

宿主服务 dispose 时未中止它 spawn 的 SSH 子进程。当前 `submitJob` 会把 in-flight session 的 abort handle 记入 `jobAborts`（JOB-02），但没有任何路径在服务销毁时统一触发清理：宿主重启 / 插件 unload / fiber dispose 后，陈旧 ssh 子进程会继续在远端跑它的命令，job 记录也一直停在 queued/running——本地已无法观测或干预（audit JOB-03）。

本 PR 在 `ResearchService` 构造时经 `ctx.fiber.effect` 注册一个 dispose 清理器：销毁时对所有 `jobAborts` 里的 session abort，每个 settle 把记录写成 `interrupted`（`host stopped before the job outcome was known`），绝不伪造断开 session 的远端成功/失败。

**没有这个 PR 会坏什么**：进程失控（孤儿 SSH 长跑）、job 记录重启后悬挂、实验写回悬空——正是 audit 5.3/JOB-03 描述的场景。

## 检查清单

- [x] **范围聚焦**：只改 `services/common.ts`（+2 行状态字段）、`service.ts`（+9）、`services/server.ts`（host-dispose 中止 + 统一 settle/清理路径）、`ssh-jobs.spec.ts`（回归测试）；无顺手重构。改动文件全程 LF，`git diff --check` 与 `no-crlf` 干净
- [x] **纯逻辑分离**：取消/中断 settle、所有权清理都是 DOM-free 的 domain 函数（`services/server.ts`），Remote 薄壳只在 `service.ts` 接 `ctx.fiber.effect`；无 ctx 进入纯逻辑
- [x] **测试**：新增「interrupts an active job when its host service is disposed」回归（无本修复必失败：dispose 前记录停在 running/无 interrupted settle）；cancel 用例复用统一 settle helper，改为断言完整终端态而非轮询短路
- [x] **安全红线自查**：无新用户/模型可控输入路径；状态从既有枚举取值（`cancelled`/`interrupted`），不新增字符串拼接边界
- [x] **涉及 UI**：否——纯宿主生命周期与持久化语义
- [x] **门禁全绿**：`pnpm run build`、`pnpm run typecheck`、`pnpm test`（1125 passed / 1 skipped）、`pnpm run check-style`（style gate: clean）本地全过
- [x] **文档随代码走**：host dispose 语义与 §14.2 既有描述一致，无 README/ROADMAP 队列条目变更
- [x] **合并方式知悉**：merge commit 合并
- [ ] 涉及 `@Remote` 新增：否（无新 Remote）

## 测试证据

```
$ pnpm run typecheck
Done in 17.9s    (exit 0)

$ pnpm test
Test Files  101 passed (101)
     Tests  1125 passed | 1 skipped (1126)
(exit 0)

$ pnpm run build
[dsh-mimir/client] Build complete in 653ms   (exit 0)

$ pnpm run check-style
style gate: clean
```

## 截图

不涉及 UI，无截图。