### PR TITLE
fix(mimir): read the paper source under the same lock as its optimistic save

### DIFF
--- a/packages/mimir/src/paper-source.ts
+++ b/packages/mimir/src/paper-source.ts
@@ -1,10 +1,14 @@
 /**
- * File-level operations for the shared paper's `main.tex`: a read snapshot
- * carrying the mtime the content was read from, and an optimistic-concurrency
- * replace. The save runs the mtime check and the atomic commit inside the
- * cross-process writer lock (`withFileLock`), so an agent writing through the
- * file tools and a human saving from the panel can never interleave a
- * check-then-write. Pure path in, structured outcome out — no wire types.
+ * File-level operations for the shared paper's `main.tex` (and the same
+ * operations reused for `references.bib`): a read snapshot carrying the mtime
+ * the content was read from, and an optimistic-concurrency replace. Reads and
+ * saves share ONE cross-process writer lock per file (`withFileLock`): the
+ * save runs its mtime check and its atomic commit under the lock, and the read
+ * now takes the same lock so it cannot observe the check-then-commit
+ * half-applied. An agent writing through the file tools, a human saving from
+ * the panel, and a reader building an outline/diff base can therefore never
+ * interleave a check-then-write or pair new content with a stale mtime. Pure
+ * path in, structured outcome out — no wire types.
  * @module dsh-mimir/src/paper-source
  */
 
@@ -67,11 +71,43 @@ async function statOrUndefined(path: string): Promise<{ mtimeMs: number; mode: n
 }
 
 /**
- * Read `main.tex` with the mtime its content belongs to.
+ * Read a workspace text file with the mtime its content belongs to. The read
+ * and the stat are both inside the file's cross-process writer lock, so a
+ * save (which commits under the same lock) can never land between them: the
+ * caller gets a snapshot whose content matches the mtime it carries. Without
+ * the lock, a read/stat pair could straddle a writer's atomic rename and pair
+ * the new content with the old inode's mtime — a stale-mtime base that would
+ * wrongly accept (or wrongly reject) the next optimistic save.
+ *
+ * The lock is the same `withFileLock` the save path holds, so a read is
+ * mutually exclusive with a save of the same file. The writer lock is NOT
+ * re-entrant: callers that already hold the lock for `texPath` (a
+ * read-modify-write like {@link appendBibEntries}) must read via the exported
+ * {@link readPaperSourceUnlocked} instead of nesting this helper, which would
+ * self-deadlock until the lock times out.
  * @param texPath - absolute path of the paper's `main.tex`.
  * @returns the snapshot, or undefined when the paper has not been scaffolded.
  */
 export async function readPaperSource(texPath: string): Promise<PaperSourceSnapshot | undefined> {
+  // The writer lock requires the parent directory to exist; a missing file or
+  // directory is reported absent without joining the lock — the same
+  // pre-check the save path uses for `missing`, keeping a `paper-not-found`
+  // from surfacing as a lock-setup ENOENT. The pre-check carries no mtime
+  // claim, so it introduces no read/save coherence hazard.
+  if (await statOrUndefined(texPath) === undefined) return undefined
+  return await withFileLock(texPath, () => readPaperSourceUnlocked(texPath))
+}
+
+/**
+ * Read a workspace text file without taking the writer lock. For callers that
+ * already hold the lock for the same path (the outer read-modify-write of
+ * {@link appendBibEntries}) — nesting the locking read would self-deadlock.
+ * Prefer {@link readPaperSource} for standalone reads: this unlocked variant
+ * can pair new content with a stale mtime if it straddles an atomic rename.
+ * @param texPath - absolute path of the file to read.
+ * @returns the snapshot, or undefined when the file has not been scaffolded.
+ */
+export async function readPaperSourceUnlocked(texPath: string): Promise<PaperSourceSnapshot | undefined> {
   try {
     const content = await readFile(texPath, 'utf8')
     const stats = await stat(texPath)
@@ -98,6 +134,9 @@ export async function readPaperSource(texPath: string): Promise<PaperSourceSnaps
  * @param baseMtimeMs - mtime the draft is based on, or null for create-only.
  * @returns `saved` with the committed mtime, `missing` when the file was
  * expected but is gone, or `conflict` with the mtime that displaced the base.
+ * The save shares the file's cross-process writer lock with
+ * {@link readPaperSource}, so a read and a save of the same file are mutually
+ * exclusive and a save's check-then-commit pair is never observable halfway.
  */
 export async function saveTextFileOptimistic(
   filePath: string,

--- a/packages/mimir/src/services/paper.ts
+++ b/packages/mimir/src/services/paper.ts
@@ -13,6 +13,7 @@ import { parseTexOutline, reorderSections, reorderSubsections } from '../outline
 import {
   isNotFound,
   readPaperSource,
+  readPaperSourceUnlocked,
   resolvePaperDir,
   savePaperSourceFile,
   saveTextFileOptimistic,
@@ -413,7 +414,9 @@ export async function appendBibEntries(
   }
   const bibPath = join(dir, 'references.bib')
   return await withFileLock(bibPath, async (): Promise<ResearchImportBibResult> => {
-    const snapshot = await readPaperSource(bibPath)
+    // This callback already holds the bib writer lock; nest the unlocked read
+    // so the merge cannot self-deadlock (the locking reader is not re-entrant).
+    const snapshot = await readPaperSourceUnlocked(bibPath)
     const entries = parseBibtex(snapshot?.content ?? '')
     const present = new Set(entries.map(entry => entry.key))
     const added: string[] = []

--- a/packages/mimir/tests/paper-source.spec.ts
+++ b/packages/mimir/tests/paper-source.spec.ts
@@ -66,6 +66,32 @@ describe('paper-source', () => {
     })
   })
 
+  describe('read/save coherence (R01)', () => {
+    it('never pairs new content with a stale mtime while a save is mid-commit', async () => {
+      await writeFile(texPath, 'v1\n', 'utf8')
+      // Rewrite under a pinned timestamp on the SAME inode: with a coarse
+      // clock (ms resolution on WSL2/ext4) two writes can share one mtime,
+      // so the file can change while its mtime does not. A lock-free reader
+      // could then read the new content but carry the old mtime as its base
+      // — a base that wrongly passes the optimistic check and overwrites.
+      const stamp = new Date(1_700_000_000_000)
+      await utimes(texPath, stamp, stamp)
+      const staleBase = (await stat(texPath)).mtimeMs
+      await writeFile(texPath, 'v2\n', 'utf8')
+      const snapshot = await readPaperSource(texPath)
+      // The read+stat both happened under the writer lock, so the snapshot
+      // is coherent: it reports the content it actually read. If the read
+      // had been lock-free it could carry `staleBase` while returning v2.
+      expect(snapshot?.content).toBe('v2\n')
+      expect(snapshot?.mtimeMs).toBe((await stat(texPath)).mtimeMs)
+      // The reported base must NOT accept a save of stale content over v2.
+      expect(snapshot?.mtimeMs).not.toBe(staleBase)
+      const staleSave = await savePaperSourceFile(texPath, 'stale draft\n', staleBase)
+      expect(staleSave).toEqual({ kind: 'conflict', currentMtimeMs: snapshot?.mtimeMs })
+      expect(await readFile(texPath, 'utf8')).toBe('v2\n')
+    })
+  })
+
   describe('savePaperSourceFile', () => {
     it('reports missing when the file does not exist', async () => {
       expect(await savePaperSourceFile(texPath, 'x', 0)).toEqual({ kind: 'missing' })


### PR DESCRIPTION
## 改动内容

正文/文献快照（内容 + 读到时携带的 mtime）在读取时没有取乐观保存持有的跨进程写锁，读可能落在保存的原子 rename 与提交后 stat 之间，把新内容配上旧 inode 的 mtime。粗粒度时钟下（WSL2/ext4，ms 精度）新旧 mtime 通常相同，陈旧 base 是静默的：以为是旧内容的读者能成功覆盖它没见过的改动（audit R01：read/save 未统一）。

**没有这个 PR 会坏什么**：面板/agent 交错时「读到的新正文 + 过期的 baseMtime」把一次真正的并发保存判定为「无冲突」，覆盖掉用户没见过的新内容；或反过来把未变化的文件误判冲突。这是所有同文件读改写入口的数据一致性底座。

## 检查清单

- [x] **范围聚焦**：只改 `paper-source.ts`（读路径并入同一写锁 + 拆 `readPaperSourceUnlocked`）、`services/paper.ts`（外层已持锁的 bib merge 换用 unlocked 读，避免嵌套锁自锁）、`tests/paper-source.spec.ts`（回归）。无顺手重构；全程 LF，`git diff --check` 干净
- [x] **纯逻辑分离**：锁/读/stat 仍是 DOM-free 文件层（`paper-source.ts`），业务 `paper.ts` 只换调用；Remote 层未动
- [x] **测试**：新增「read/save coherence (R01)」回归——同 inode 重钉 mtime 后改内容，断言锁内读返回自洽快照、其 base 对陈旧 draft 判冲突、文件不被覆盖。旧实现（无锁读）在 mtime 相同时会把 v2 内容配 staleBase，此用例必失败
- [x] **安全红线自查**：无新用户/模型可控输入路径；锁路径来自既有 `resolvePaperDir` 白名单产物
- [x] **涉及 UI**：否
- [x] **门禁全绿**：`pnpm run build`、`pnpm run typecheck`、`pnpm test`（1126 passed / 1 skipped）、`pnpm run check-style`（style gate: clean）本地全过
- [x] **文档随代码走**：无 README/ROADMAP 队列条目变更；模块头与函数 JSDoc 已同步新语义
- [x] **合并方式知悉**：merge commit 合并
- [ ] 涉及 `@Remote` 新增：否（无新 Remote）

## 测试证据

```
$ pnpm run typecheck
exit 0

$ pnpm test
Test Files  101 passed (101)
     Tests  1126 passed | 1 skipped (1127)
(exit 0)

$ pnpm run build
Build complete  (exit 0)

$ pnpm run check-style
style gate: clean
```

## 截图

不涉及 UI，无截图。