### PR TITLE
fix(ui-mimir): keep typing done during SVG conversion when inserting a figure

### DIFF
--- a/packages/ui-mimir/src/client/controller.ts
+++ b/packages/ui-mimir/src/client/controller.ts
@@ -2688,13 +2688,22 @@ export class ResearchController implements HostObservable<ResearchView> {
         this.notify('error', 'toast.figureSvgConvertFailed', transportFailure(error).message)
         return null
       }
-      // The conversion round-trip is long: a project switch in between means
-      // the editor below would write this project's block into ANOTHER
-      // project's draft.
-      if (this.disposed || this.view.source?.projectId !== projectId) return null
+    }
+    // The conversion round-trip is long relative to the draft. Re-anchor on the
+    // CURRENT view rather than the pre-conversion `source` snapshot: a user who
+    // kept typing while the host converted must keep that text — splicing the
+    // block into the stale snapshot would overwrite their continued draft. A
+    // project switch or dispose mid-flight still writes nothing, and a draft
+    // that went into conflict (the agent landed a version mid-conversion) is
+    // reported instead of silently skipping the insert.
+    const live = this.view.source
+    if (this.disposed || live === null || live.projectId !== projectId || live.status !== 'ready') return null
+    if (live.saveState === 'conflict') {
+      this.notify('error', 'toast.figureInsertConflict')
+      return null
     }
     const block = figureBlockOf(relPath, entry.caption ?? '')
-    const inserted = insertFigureBlock(source.content, block)
+    const inserted = insertFigureBlock(live.content, block)
     this.edit(inserted.content)
     this.jumpPaper(projectId, inserted.line)
     this.notify('success', convertedName === null ? 'toast.figureInserted' : 'toast.figureConvertedSvg', convertedName ?? entry.name)

--- a/packages/ui-mimir/tests/controller.client.spec.ts
+++ b/packages/ui-mimir/tests/controller.client.spec.ts
@@ -1735,6 +1735,30 @@ describe('ResearchController figure insert', () => {
     expect(view.source?.content).toBe('p2 tex')
   })
 
+  it('keeps typing done during the SVG conversion by splicing into the live draft', async () => {
+    const conversion = deferred<RemoteResult<ResearchConvertFigureResult>>()
+    const controller = new ResearchController(stubRemote({
+      ...selectReads,
+      getPaperSource: () => Promise.resolve(carried(sourceOk(TEX, 1000))),
+      convertFigure: () => conversion.promise,
+    }))
+    controller.select('p1')
+    await vi.advanceTimersByTimeAsync(0)
+    const pending = controller.insertFigureIntoPaper('p1', { ...FIGURE, name: 'plot.svg', relPath: 'figures/plot.svg' })
+    // The user keeps typing while the host converts to PDF.
+    controller.edit('text\\nnew paragraph typed during conversion')
+    conversion.resolve(carried({ ok: true, value: { relPath: 'figures/plot.pdf', converter: 'rsvg-convert' } }))
+    const line = await pending
+    expect(line).not.toBeNull()
+    await vi.advanceTimersByTimeAsync(0)
+    const view = controller.getSnapshot()
+    // Both survive: the continued paragraph AND the inserted figure block.
+    expect(view.source?.content).toContain('new paragraph typed during conversion')
+    expect(view.source?.content).toContain('\\includegraphics[width=\\linewidth]{figures/plot.pdf}')
+    expect(view.source?.saveState).toBe('dirty')
+    expect(view.toasts.at(-1)).toMatchObject({ kind: 'success', copy: 'toast.figureConvertedSvg' })
+  })
+
   it('does not re-read the paper when the project switched during a figure rename', async () => {
     const rename = deferred<RemoteResult<ResearchRenameFigureResult>>()
     const sourceReads: string[] = []


### PR DESCRIPTION
## 改动内容

插图入正文的流程在 SVG 转换前先拍了 `source` 快照，转换结束后把 figure block 拼进这张**过期快照**再 `edit()`。用户在宿主转换（SVG→PDF，长往返）期间继续打字会丢草稿：插入的 `edit()` 用「只有新 figure、没有新段落」的旧内容覆盖了转换期间敲下的每个字（audit R35：异步插图覆盖草稿）。

**没有这个 PR 会坏什么**：SVG 图转换期间输入的整段正文被静默覆盖——对面板用户是一次「文件里的字不见了」的数据丢失。

## 改动

转换完成后再**对当前 source view 重新锚定**，拼进用户此刻正在编辑的真实草稿：继续输入的段落与插入的 block 一并保留。中途切项目/dispose 依旧不写（保留旧守卫）；转换期间草稿进入 conflict（agent 落了新版本）则显式报错而非静默跳过——conflict 路径本就拒绝一切编辑。

## 检查清单

- [x] **范围聚焦**：只改 `ui-mimir/src/client/controller.ts`（insertFigureIntoPaper 重锚定）与 `controller.client.spec.ts`（回归）。无顺手重构；全程 LF，`git diff --check` 干净
- [x] **纯逻辑分离**：改动在 controller 的 UI 编排层；不引入 DOM，纯逻辑函数（figure-insert.ts）未动
- [x] **测试**：新增「keeps typing done during the SVG conversion by splicing into the live draft」回归——断言继续输入的段落与插入的 block 都存活。旧实现（过期快照拼接）会覆盖该段落，此用例必失败
- [x] **安全红线自查**：无新用户/模型可控输入进入文件路径或 shell；无 CSS 改动
- [x] **涉及 UI**：是。行为级改动（保存结果断言在单测覆盖），非视觉布局；截图 QA 不适用无 DOM 差异的 controller 状态流
- [x] **门禁全绿**：`pnpm run build`、`pnpm run typecheck`、`pnpm test`（1127 passed / 1 skipped）、`pnpm run check-style`（style gate: clean）本地全过
- [x] **文档随代码走**：无 README/ROADMAP 队列条目变更
- [x] **合并方式知悉**：merge commit 合并
- [ ] 涉及 `@Remote` 新增：否

## 测试证据

```
$ pnpm run typecheck
exit 0

$ pnpm test
Test Files  101 passed (101)
     Tests  1127 passed | 1 skipped (1128)
(exit 0)

$ pnpm run build
Build complete  (exit 0)

$ pnpm run check-style
style gate: clean
```

## 截图

controller 状态流改动（非视觉布局），以单测断言保存结果为准，无独立截图。