### PR TITLE
fix(mimir): run figure-reference rewrite under the per-file body lock

### DIFF
--- a/packages/mimir/src/services/experiment.ts
+++ b/packages/mimir/src/services/experiment.ts
@@ -6,11 +6,11 @@
  * @module dsh-mimir/src/services/experiment
  */
 
-import { mkdir, readdir, readFile, rename, stat, unlink } from 'node:fs/promises'
+import { mkdir, readdir, rename, stat, unlink } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
-import { writeFileAtomic } from '@deepseek-ai/dsh-atomic-write'
+import { withFileLock, writeFileAtomic } from '@deepseek-ai/dsh-atomic-write'
 import { isArtifactName, isFigureFile, listPaperFigures, readWorkspaceArtifact } from '../artifacts.ts'
-import { isNotFound, resolvePaperDir } from '../paper-source.ts'
+import { isNotFound, readPaperSourceUnlocked, resolvePaperDir } from '../paper-source.ts'
 import { emitEvent, PANEL_ACTOR } from '../ledger.ts'
 import { convertSvgFigure, svgConverterNames } from '../svg-convert.ts'
 import type { SvgConversionDeps } from '../svg-convert.ts'
@@ -533,8 +533,12 @@ async function texFilesOf(dir: string): Promise<string[]> {
 /**
  * Rewrite one figure's references in every `.tex` file of the paper
  * directory: exact `figures/foo.png` occurrences plus the extensionless
- * `\includegraphics{figures/foo}` form. Only changed files are rewritten
- * (atomically).
+ * `\includegraphics{figures/foo}` form. Each file's read-rewrite-write runs
+ * inside the file's cross-process writer lock — the same lock a panel
+ * `savePaperSource`/`saveBibliography` commit holds — with the content re-read
+ * under the lock, so a rename never overwrites a concurrent save's text it
+ * never saw (the draft survives) and the rewrite always lands on the live
+ * body. Only changed files are rewritten (atomically).
  * @param dir - absolute paper directory.
  * @param oldRelPath - the figure's previous paper-directory-relative path.
  * @param newRelPath - the figure's new paper-directory-relative path.
@@ -545,12 +549,19 @@ async function rewriteFigureReferences(dir: string, oldRelPath: string, newRelPa
   const newStem = newRelPath.replace(/\.[^.]+$/, '')
   let rewritten = 0
   for (const file of await texFilesOf(dir)) {
-    const content = await readFile(file, 'utf8')
-    let next = content.split(oldRelPath).join(newRelPath)
-    if (oldStem !== oldRelPath) next = next.split(`{${oldStem}}`).join(`{${newStem}}`)
-    if (next === content) continue
-    await writeFileAtomic(file, next, { mode: 0o666 })
-    rewritten += 1
+    // The callback already holds the file's writer lock; nest the unlocked
+    // read so the rewrite cannot self-deadlock (the locking reader is not
+    // re-entrant), as `appendBibEntries` does for `references.bib`.
+    const changed = await withFileLock(file, async (): Promise<boolean> => {
+      const snapshot = await readPaperSourceUnlocked(file)
+      if (snapshot === undefined) return false
+      let next = snapshot.content.split(oldRelPath).join(newRelPath)
+      if (oldStem !== oldRelPath) next = next.split(`{${oldStem}}`).join(`{${newStem}}`)
+      if (next === snapshot.content) return false
+      await writeFileAtomic(file, next, { mode: 0o666 })
+      return true
+    })
+    if (changed) rewritten += 1
   }
   return rewritten
 }

--- a/packages/mimir/tests/service.spec.ts
+++ b/packages/mimir/tests/service.spec.ts
@@ -16,6 +16,7 @@ import { createServer } from 'node:net'
 import type { AddressInfo } from 'node:net'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
+import { writeFileAtomic, withFileLock } from '@deepseek-ai/dsh-atomic-write'
 import Storage, { storageBackendServiceKey } from '@deepseek-ai/dsh-storage'
 import { DomainFacility } from '@deepseek-ai/dsh-storage-domain'
 import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.ts'
@@ -1600,6 +1601,40 @@ describe('ResearchService.renameFigure', () => {
     await scaffoldPaper(workspaceDir)
     await expect(service.renameFigure({ projectId: 'p1', relPath: 'figures/plot.png', newName: 'plot.png' }))
       .resolves.toEqual({ ok: true, value: { relPath: 'figures/plot.png', references: 0 } })
+  })
+
+  it('runs the reference rewrite under the body lock: a draft landed mid-rename survives (R23)', async () => {
+    const { domain, workspaceDir, service } = await harness()
+    await domain.table('projects').put(PROJECT.id, PROJECT)
+    await scaffoldWithReference(workspaceDir)
+    const texPath = join(workspaceDir, 'paper', 'main.tex')
+    // A body edit lands (the agent's file tools, or a panel save) while the
+    // rename is in flight: it keeps the figure block and adds a paragraph. The
+    // edit is a raw write that does NOT take the body lock — exactly the writer
+    // a lock-free rename rewrite would clobber by rewriting a body it read
+    // before the edit landed.
+    const draft = '\\documentclass{article}\n\\begin{document}\n\\section{Draft paragraph kept}\n\\includegraphics[width=\\linewidth]{figures/plot.png}\n\\end{document}\n'
+    // Hold main.tex's writer lock (the same lock a rename rewrite now waits
+    // on), THEN fire the rename: it moves the figure file and must block on
+    // this lock before rewriting the body.
+    let releaseRename = (): void => {}
+    const renameMayRun = new Promise<void>(resolve => { releaseRename = resolve })
+    const renaming = (async () => {
+      await renameMayRun
+      return service.renameFigure({ projectId: 'p1', relPath: 'figures/plot.png', newName: 'loss-curve.png' })
+    })()
+    await withFileLock(texPath, async () => {
+      releaseRename()
+      await writeFileAtomic(texPath, draft, { mode: 0o666 })
+      // Returning releases the lock; the rename's rewrite then re-reads the
+      // NEW body and rewrites only the figure reference onto it.
+    })
+    const outcome = await renaming
+    expect(outcome).toEqual({ ok: true, value: { relPath: 'figures/loss-curve.png', references: 2 } })
+    // Both edits survive: the draft's paragraph and the renamed reference.
+    const body = await readFile(texPath, 'utf8')
+    expect(body).toContain('\\section{Draft paragraph kept}')
+    expect(body).toContain('\\includegraphics[width=\\linewidth]{figures/loss-curve.png}')
   })
 })
 


### PR DESCRIPTION
## 改动内容

修复 R23「重命名引用并发控制」残留（本批 P0 · 丢新正文）。`renameFigure` 的 `rewriteFigureReferences` 此前对每个 `.tex` 文件 **不加锁裸读裸写**：重命名移动 figure 文件后、改写正文前，若期间有正文保存落地（面板乐观保存或 agent 文件工具写），改写在旧内容上发生，会**静默覆盖这份草稿**。

本 PR：每个 `.tex` 文件的 read-rewrite-write 移入 `withFileLock`（与 `savePaperSource`/`saveBibliography` 乐观提交**同一把**跨进程写锁），并在锁内 re-read 当前盘上内容再改写。重命名与正文保存互斥，草稿必存，改写落在最新正文上——关掉正文最后一个无锁写入口。

无此 PR 会坏什么：重命名 figure 与并发保存交错时丢失新正文（正是 R01/R23 组验收条文）。此前 70791e3 已把**读取**入口并入同锁；本 PR 收掉**重命名改写**这个写入口。

## 检查清单

- [x] **范围聚焦**：只处理 figure 引用重写的锁协同，无顺手重构
- [x] **纯逻辑分离**：锁定 I/O 留在 experiment.ts 服务层，正文改写仍是纯路径字符串运算
- [x] **测试**：新增回归测试「rename 期间落地草稿，两条正文都保留」——若无本修复必失败（锁外裸写覆盖草稿）；无 `it.skip`/`.only`
- [x] **安全红线自查**：无新增用户可控字符串进路径/shell；改动为既有路径替换的并发语义
- [x] **涉及 UI**：否——host 服务层并发语义改动，以服务级单测断言保存结果为准，无 UI 截图
- [x] **门禁全绿**：`pnpm run build` ✅、`pnpm run typecheck` ✅、`pnpm test` ✅、`pnpm run check-style` ✅（见下）
- [x] **文档随代码走**：不涉及 README/ROADMAP 队列条目（内部并发语义修复）
- [x] **合并方式知悉**：merge commit 合并，提交历史干净
- [ ] 涉及 `@Remote` 新增：否

## 测试证据

- `npx vitest run packages/mimir/tests/service.spec.ts` — 81 passed（含新增 R23 回归，该用例在锁外裸写的旧代码上必超时/覆盖失败）
- `pnpm run typecheck` — exit 0
- `pnpm test` — 101 files / **1128 passed | 1 skipped**
- `pnpm run build` — Build complete（dsh-mimir + client preset）
- `pnpm run check-style` — style gate: clean

## 截图

N/A（非 UI 改动）