### PR TITLE
fix(wiki-admin): recover interrupted snapshot replacement

### DIFF
--- a/packages/mimir/src/index.ts
+++ b/packages/mimir/src/index.ts
@@ -38,6 +38,7 @@ import { TEMPLATE_DIR_NAME } from './services/venue.ts'
 import { meetingDeckPath } from './services/meeting.ts'
 import { ResearchService } from './service.ts'
 import { recoverInterruptedJobs } from './services/server.ts'
+import { recoverPendingWikiImport } from './services/wiki-admin.ts'
 import { registerResearchSkills } from './skills.ts'
 import { registerSxngSkill } from './sxng-skill.ts'
 import { startWikiBackupLoop } from './backup.ts'
@@ -1137,15 +1138,17 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   const resolved = resolveConfig(config)
   const domain = await ctx.storageDomain.open(researchWikiDomainSpec)
   ctx.effect(() => () => domain.close(), 'mimir.domainClose')
+  const workspaceDir = resolve(process.cwd(), resolved.workspaceDir)
+  await recoverPendingWikiImport({ workspaceDir, domain })
   // Stored paper records with path-unsafe ids predate the whitelist (or were
   // hand-edited); quarantine them before any surface can join them into a
   // filesystem path. The schema stays permissive so their presence can never
   // abort the open itself.
   await quarantineUnsafePaperIds(domain, message => ctx.logger.warn(message))
-  await recoverInterruptedJobs({ workspaceDir: resolve(process.cwd(), resolved.workspaceDir), domain })
+  await recoverInterruptedJobs({ workspaceDir, domain })
 
   const deps: ResearchCommandDeps = {
-    workspaceDir: resolve(process.cwd(), resolved.workspaceDir),
+    workspaceDir,
     domain,
     reviewer: resolved.reviewer,
     latex: resolved.latex,

--- a/packages/mimir/src/services/wiki-admin.ts
+++ b/packages/mimir/src/services/wiki-admin.ts
@@ -6,7 +6,9 @@
  * @module dsh-mimir/src/services/wiki-admin
  */
 
-import { readdir } from 'node:fs/promises'
+import { access, mkdir, readFile, readdir, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { withFileLock, writeFileAtomic } from '@deepseek-ai/dsh-atomic-write'
 import { isValidArxivId } from '../arxiv-id.ts'
 import { isValidProjectId } from '../project-id.ts'
 import { isBackupFileName } from '../backup.ts'
@@ -39,12 +41,87 @@ import { rejected, success } from './common.ts'
  */
 export interface WikiAdminDeps {
   readonly domain: ResearchWikiDomain
+  readonly workspaceDir: string
   readonly backup?: {
     readonly enabled: boolean
     readonly intervalMinutes: number
     readonly keep: number
     readonly dir: string
   }
+}
+
+/** Durable undo record for an interrupted destructive wiki import. */
+export const WIKI_IMPORT_RECOVERY_FILE = '.wiki-import-recovery.json'
+
+type WikiTable = {
+  get: (key: string) => unknown
+  put: (key: string, value: unknown) => Promise<void>
+  delete: (key: string) => Promise<boolean>
+  entries: () => IterableIterator<[string, unknown]>
+}
+
+/** Replace exactly the tables carried by one already-validated snapshot. */
+async function replaceWiki(
+  domain: ResearchWikiDomain,
+  snapshot: ResearchWikiSnapshot,
+  skipUnsafeIds: boolean,
+): Promise<Record<ResearchWikiTableName, number>> {
+  const imported: Record<ResearchWikiTableName, number> = {
+    papers: 0, ideas: 0, claims: 0, projects: 0, experiments: 0, servers: 0, figures: 0, events: 0,
+  }
+  // Queue the whole replacement synchronously: a write already queued wins
+  // before replace; one queued after this batch wins after replace.
+  const writes: Promise<unknown>[] = []
+  for (const name of snapshotTables(snapshot)) {
+    const table = domain.table(name) as WikiTable
+    for (const [key] of [...table.entries()]) writes.push(table.delete(key))
+    const keyField = WIKI_TABLE_KEY[name]
+    for (const row of snapshot.tables[name]) {
+      const key = (row as unknown as Record<string, unknown>)[keyField] as string
+      if (skipUnsafeIds && name === 'papers' && !isValidArxivId(key)) continue
+      if (skipUnsafeIds && name === 'projects' && !isValidProjectId(key)) continue
+      writes.push(table.put(key, row))
+      imported[name] += 1
+    }
+  }
+  const settled = await Promise.allSettled(writes)
+  const failed = settled.find(result => result.status === 'rejected')
+  if (failed?.status === 'rejected') throw failed.reason
+  return imported
+}
+
+/** Validate a recovery snapshot read from disk before it can touch the domain. */
+function validateSnapshot(snapshot: ResearchWikiSnapshot): void {
+  const envelopeError = snapshotEnvelopeError(snapshot)
+  if (envelopeError !== null) throw new Error(`invalid wiki import recovery: ${envelopeError}`)
+  for (const name of snapshotTables(snapshot)) {
+    const rowError = tableRowsError(name, snapshot.tables[name])
+    if (rowError !== null) throw new Error(`invalid wiki import recovery: ${rowError}`)
+  }
+}
+
+/** Restore and remove a pending destructive-import undo record, when present. */
+export async function recoverPendingWikiImport(deps: WikiAdminDeps): Promise<void> {
+  const path = join(deps.workspaceDir, WIKI_IMPORT_RECOVERY_FILE)
+  try {
+    await access(path)
+  } catch (error) {
+    if ((error as { code?: unknown }).code === 'ENOENT') return
+    throw error
+  }
+  await withFileLock(path, async () => {
+    let text: string
+    try {
+      text = await readFile(path, 'utf8')
+    } catch (error) {
+      if ((error as { code?: unknown }).code === 'ENOENT') return
+      throw error
+    }
+    const snapshot = JSON.parse(text) as ResearchWikiSnapshot
+    validateSnapshot(snapshot)
+    await replaceWiki(deps.domain, snapshot, false)
+    await unlink(path)
+  })
 }
 
 /** Project one wiki record into the panel's row shape. */
@@ -112,7 +189,9 @@ export async function exportWiki(deps: WikiAdminDeps): Promise<ResearchExportWik
  * upserts only absent primary keys — existing records are never
  * overwritten, just counted as skipped (conservative first). `replace`
  * wipes the tables the snapshot carries first, so it additionally requires
- * `confirmReplace: true` (`invalid-input` otherwise).
+ * `confirmReplace: true` (`invalid-input` otherwise). Replace is an exclusive
+ * maintenance operation: writes issued while it is running may be superseded
+ * by the replacement or a failure rollback.
  * @param deps - open wiki domain.
  * @param request - the parsed snapshot JSON, the mode, and the replace
  * confirmation flag. A legacy v2 snapshot (seven tables, no `events`) is
@@ -150,16 +229,33 @@ export async function importWiki(
   })
   const imported = zeroCounts()
   const skipped = zeroCounts()
+  if (request.mode === 'replace') {
+    const path = join(deps.workspaceDir, WIKI_IMPORT_RECOVERY_FILE)
+    await mkdir(deps.workspaceDir, { recursive: true })
+    await withFileLock(path, async () => {
+      await writeFileAtomic(path, JSON.stringify(buildWikiSnapshot(deps.domain)), { mode: 0o600 })
+      try {
+        Object.assign(imported, await replaceWiki(deps.domain, snapshot, true))
+        await unlink(path)
+      } catch (error) {
+        try {
+          const recovery = JSON.parse(await readFile(path, 'utf8')) as ResearchWikiSnapshot
+          validateSnapshot(recovery)
+          await replaceWiki(deps.domain, recovery, false)
+          await unlink(path)
+        } catch (recoveryError) {
+          throw new AggregateError([error, recoveryError], 'wiki import failed and recovery is pending')
+        }
+        throw error
+      }
+    })
+  }
   for (const name of names) {
-    const table = deps.domain.table(name) as {
-      get: (key: string) => unknown
-      put: (key: string, value: unknown) => Promise<void>
-      delete: (key: string) => Promise<boolean>
-      entries: () => IterableIterator<[string, unknown]>
-    }
+    const table = deps.domain.table(name) as WikiTable
     const keyField = WIKI_TABLE_KEY[name]
     if (request.mode === 'replace') {
-      for (const [key] of [...table.entries()]) await table.delete(key)
+      skipped[name] = snapshot.tables[name].length - imported[name]
+      continue
     }
     for (const row of snapshot.tables[name]) {
       const key = (row as unknown as Record<string, unknown>)[keyField] as string

--- a/packages/mimir/tests/helpers/memory-backend.ts
+++ b/packages/mimir/tests/helpers/memory-backend.ts
@@ -43,9 +43,22 @@ export class MemoryMediaPool {
    * untouched after a durability failure.
    */
   failNextWrites = 0
+  /** One-based write ordinal to reject once; zero disables ordinal injection. */
+  failWriteAt = 0
+  private writeCount = 0
+
+  /** Reject once after the requested number of subsequent writes succeed. */
+  failAfterSuccessfulWrites(count: number): void {
+    this.failWriteAt = this.writeCount + count + 1
+  }
 
   /** Consume one injected failure, throwing in a rejected write's place. */
   consumeInjectedFailure(): void {
+    this.writeCount += 1
+    if (this.writeCount === this.failWriteAt) {
+      this.failWriteAt = 0
+      throw new Error('injected write failure')
+    }
     if (this.failNextWrites > 0) {
       this.failNextWrites -= 1
       throw new Error('injected write failure')

--- a/packages/mimir/tests/wiki-transfer.spec.ts
+++ b/packages/mimir/tests/wiki-transfer.spec.ts
@@ -7,7 +7,7 @@
  * validators in wiki-snapshot.ts. Memory-backed domain, no mocks.
  */
 
-import { mkdtemp } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -18,31 +18,32 @@ import { MemoryMediaPool, MemoryStorageBackend } from './helpers/memory-backend.
 import { researchWikiDomainSpec } from '../src/store.ts'
 import { ResearchService } from '../src/service.ts'
 import {
-  snapshotEnvelopeError, snapshotTables, tableRowsError,
+  buildWikiSnapshot, snapshotEnvelopeError, snapshotTables, tableRowsError,
   WIKI_SNAPSHOT_FORMAT, WIKI_SNAPSHOT_VERSION, WIKI_SNAPSHOT_MIN_VERSION,
 } from '../src/wiki-snapshot.ts'
+import { recoverPendingWikiImport, WIKI_IMPORT_RECOVERY_FILE } from '../src/services/wiki-admin.ts'
 import { appendEvent, PANEL_ACTOR } from '../src/ledger.ts'
 import type {
   ExperimentRecord, FigureRecord, PaperRecord, ProjectRecord, ResearchWikiSnapshot, ServerRecord,
 } from '../src/types.ts'
 
 /** Boot a service over a memory-backed domain and a fresh temp workspace. */
-async function harness() {
+async function harness(pool = new MemoryMediaPool(), workspaceDir?: string) {
   const ctx = new Context()
   await ctx.plugin(Storage)
-  const backend = new MemoryStorageBackend(new MemoryMediaPool())
+  const backend = new MemoryStorageBackend(pool)
   ctx.storage.backend.register('memory', backend)
   ctx.provide(storageBackendServiceKey('memory'), backend)
   const facility = new DomainFacility(ctx, { backend: 'memory', routes: {} })
   ctx.storage.mount('domain', facility)
   const domain = await facility.open(researchWikiDomainSpec)
-  const workspaceDir = await mkdtemp(join(tmpdir(), 'mimir-wiki-'))
+  workspaceDir ??= await mkdtemp(join(tmpdir(), 'mimir-wiki-'))
   const service = new ResearchService(ctx, {
     workspaceDir,
     domain,
     latex: { engine: 'auto', timeoutMs: 1000 },
   })
-  return { ctx, domain, service }
+  return { ctx, domain, pool, service, workspaceDir }
 }
 
 const PAPER: PaperRecord = {
@@ -96,13 +97,27 @@ const FIGURE: FigureRecord = {
   createdAt: '2026-08-20T00:00:00.000Z',
 }
 
-/** Seed one record into five of the seven tables. */
+const IDEA = {
+  id: 'i1', title: 'Idea', hypothesis: 'It works.', status: 'active', createdAt: '2026-08-01T00:00:00.000Z',
+} as const
+
+const CLAIM = { id: 'c1', text: 'Claim', status: 'supported', evidence: 'Evidence' } as const
+
+/** Seed one record into five snapshot tables. */
 async function seed(domain: Awaited<ReturnType<typeof harness>>['domain']): Promise<void> {
   await domain.table('papers').put(PAPER.arxivId, PAPER)
   await domain.table('projects').put(PROJECT.id, PROJECT)
   await domain.table('experiments').put(EXPERIMENT.id, EXPERIMENT)
   await domain.table('servers').put(SERVER.id, SERVER)
   await domain.table('figures').put(FIGURE.id, FIGURE)
+}
+
+/** Fill the three remaining snapshot tables for all-table recovery checks. */
+async function seedAll(domain: Awaited<ReturnType<typeof harness>>['domain']): Promise<void> {
+  await seed(domain)
+  await domain.table('ideas').put(IDEA.id, IDEA)
+  await domain.table('claims').put(CLAIM.id, CLAIM)
+  await appendEvent(domain, { actor: PANEL_ACTOR, action: 'knowledge.claim.set', refs: { claimId: CLAIM.id }, payload: {} })
 }
 
 /** Export through the service and assert the envelope; returns the snapshot. */
@@ -181,6 +196,12 @@ describe('importWiki merge', () => {
 })
 
 describe('importWiki replace', () => {
+  it('treats an absent recovery journal in a missing workspace as a no-op', async () => {
+    const { domain } = await harness()
+    await expect(recoverPendingWikiImport({ domain, workspaceDir: join(tmpdir(), 'mimir-missing-workspace') }))
+      .resolves.toBeUndefined()
+  })
+
   it('requires confirmReplace: true', async () => {
     const { domain, service } = await harness()
     await seed(domain)
@@ -213,6 +234,59 @@ describe('importWiki replace', () => {
     expect(domain.table('experiments').get(EXPERIMENT.id)).toBeUndefined()
     expect(domain.table('projects').get(PROJECT.id)).toEqual(PROJECT)
     expect(domain.table('figures').get(FIGURE.id)).toEqual(FIGURE)
+  })
+
+  it('round-trips every snapshot table into an empty domain', async () => {
+    const source = await harness()
+    await seedAll(source.domain)
+    const snapshot = await exportOk(source.service)
+    const target = await harness()
+    await target.service.importWiki({ snapshot, mode: 'replace', confirmReplace: true })
+    for (const name of snapshotTables(snapshot)) {
+      for (const row of snapshot.tables[name]) {
+        const key = name === 'papers' ? row.arxivId : row.id
+        expect(target.domain.table(name).get(key)).toEqual(row)
+      }
+    }
+  })
+
+  it.each([0, 4, 8])('restores the complete old state when replace fails after %i writes', async (writes) => {
+    const target = await harness()
+    await seedAll(target.domain)
+    const before = buildWikiSnapshot(target.domain)
+    const incoming = await harness()
+    const snapshot = await exportOk(incoming.service)
+    target.pool.failAfterSuccessfulWrites(writes)
+    await expect(target.service.importWiki({ snapshot, mode: 'replace', confirmReplace: true }))
+      .rejects.toThrow('injected write failure')
+    for (const name of snapshotTables(before)) {
+      expect([...target.domain.table(name).entries()].map(([, row]) => row)).toEqual(before.tables[name])
+    }
+  })
+
+  it('restores a pending replace journal after restart', async () => {
+    const pool = new MemoryMediaPool()
+    const first = await harness(pool)
+    await seed(first.domain)
+    const before = await exportOk(first.service)
+    await writeFile(join(first.workspaceDir, WIKI_IMPORT_RECOVERY_FILE), JSON.stringify(before))
+    await first.domain.table('papers').delete(PAPER.arxivId)
+    await first.domain.close()
+    const restarted = await harness(pool, first.workspaceDir)
+    await recoverPendingWikiImport({ domain: restarted.domain, workspaceDir: restarted.workspaceDir })
+    for (const name of snapshotTables(before)) {
+      expect([...restarted.domain.table(name).entries()].map(([, row]) => row)).toEqual(before.tables[name])
+    }
+  })
+
+  it('still skips path-unsafe paper ids during replacement', async () => {
+    const target = await harness()
+    const snapshot = await exportOk(target.service)
+    const unsafe = { ...PAPER, arxivId: '../escape' }
+    const incoming = { ...snapshot, tables: { ...snapshot.tables, papers: [unsafe] } }
+    const outcome = await target.service.importWiki({ snapshot: incoming, mode: 'replace', confirmReplace: true })
+    expect(outcome.ok).toBe(true)
+    expect(target.domain.table('papers').get(unsafe.arxivId)).toBeUndefined()
   })
 })
 

--- a/packages/mimir/tests/wiki-transfer.spec.ts
+++ b/packages/mimir/tests/wiki-transfer.spec.ts
@@ -255,6 +255,7 @@ describe('importWiki replace', () => {
     await seedAll(target.domain)
     const before = buildWikiSnapshot(target.domain)
     const incoming = await harness()
+    await seed(incoming.domain)
     const snapshot = await exportOk(incoming.service)
     target.pool.failAfterSuccessfulWrites(writes)
     await expect(target.service.importWiki({ snapshot, mode: 'replace', confirmReplace: true }))


### PR DESCRIPTION
## 改动内容

`replace` import previously cleared and rewrote the live wiki tables without a durable rollback point. A storage failure or process exit during that sequence could leave a mix of old and imported records.

This change writes the complete pre-import snapshot to a locked recovery journal before replacement, restores it immediately when a write fails, and replays any pending journal during service startup after a restart. Replacement writes are queued as one maintenance batch, with concurrent writes explicitly documented as subject to replacement or rollback.

Tests cover all-table JSON round trips, failures at early/middle/late replacement writes, and restart recovery from a pending journal.

Closes #254

## 检查清单

- [x] **范围聚焦**：只做 Issue 要求的事，无顺手重构、无整文件行尾翻转（CODE_STYLE §1「Match the file you're in」；EOL 翻转会被 `no-crlf` 门禁拦下）
- [x] **纯逻辑分离**：恢复和替换逻辑位于 `wiki-admin` 服务模块，启动接线保持最小
- [x] **测试**：新增 vitest round-trip、故障注入和重启恢复用例；无 `it.skip`/`.only`
- [x] **安全红线自查**：恢复文件名为内部常量，导入行继续经过既有 ID 和快照校验
- [x] **涉及 UI**：不涉及 UI
- [x] **门禁全绿**：`pnpm run build && pnpm run typecheck && pnpm test && pnpm run check-style` 本地全过
- [x] **文档随代码走**：不改变用户文档或 ROADMAP 条目
- [x] **合并方式知悉**：提交历史保持为两个聚焦提交
- [x] 涉及 `@Remote` 新增：未新增 `@Remote`；`pnpm run build` 已通过

## 测试证据

- `pnpm exec vitest run packages/mimir/tests/wiki-transfer.spec.ts`：23 tests passed
- `pnpm run build`：passed
- `pnpm run typecheck`：passed
- `pnpm test`：passed
- `pnpm run check-style`：passed
- `git diff --check upstream/dev...HEAD`：passed

## 截图

不涉及 UI。
